### PR TITLE
ci: add release and CI workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+env:
+  BUN_VERSION: "1.3.11"
+  NODE_VERSION: "22"
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: bun install
+      - run: bun run typecheck
+      - run: bun run test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,94 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+env:
+  BUN_VERSION: "1.3.11"
+  NODE_VERSION: "22"
+
+jobs:
+  build-desktop-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - name: Install native build dependencies
+        run: sudo apt-get update && sudo apt-get install -y build-essential python3
+      - run: bun install
+      - name: Build desktop app
+        run: cd apps/desktop && bun run build:code
+      - name: Package Linux installers
+        run: cd apps/desktop && npx electron-builder --linux
+      - name: Upload Linux binaries to release
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} \
+            apps/desktop/out/*.AppImage \
+            apps/desktop/out/*.deb \
+            --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-desktop-macos:
+    if: ${{ secrets.CSC_LINK != '' }}
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+      - run: bun install
+      - name: Build desktop app
+        run: cd apps/desktop && bun run build:code
+      - name: Package macOS installers
+        run: cd apps/desktop && npx electron-builder --mac
+        env:
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+      - name: Upload macOS binaries to release
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} \
+            apps/desktop/out/*.dmg \
+            apps/desktop/out/*.zip \
+            --clobber
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  publish-cli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          registry-url: "https://registry.npmjs.org"
+      - run: bun install
+      - name: Build CLI and dependencies
+        run: bun run turbo run build --filter=shipcode
+      - name: Set version from release tag
+        run: |
+          VERSION="${{ github.event.release.tag_name }}"
+          VERSION="${VERSION#v}"
+          cd apps/cli && npm version "$VERSION" --no-git-tag-version
+      - name: Publish to npm
+        run: cd apps/cli && npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -35,6 +35,9 @@
   "private": true,
   "scripts": {
     "build": "tsc && vite build && electron-builder",
+    "build:code": "tsc && vite build",
+    "build:installer:linux": "electron-builder --linux",
+    "build:installer:mac": "electron-builder --mac",
     "clean": "rm -rf dist out",
     "dev": "vite",
     "start": "electron .",


### PR DESCRIPTION
## Summary
- **Release workflow** (`release.yml`): On GitHub release publish, builds Linux desktop binaries (AppImage + deb), macOS desktop binaries (DMG + zip, skips gracefully without signing secrets), and publishes CLI to npm
- **CI workflow** (`ci.yml`): Runs typecheck + tests on PRs and master pushes
- **Split desktop build scripts**: Added `build:code`, `build:installer:mac`, `build:installer:linux` to decouple app compilation from platform-specific packaging

Also set repo description and homepage (`shipcode.shipshit.dev`) via `gh repo edit`.

## Manual setup needed
- [ ] Create Vercel project `shipcode-web` (root: `apps/web`, domain: `shipcode.shipshit.dev`)
- [ ] Create Vercel project `shipcode-docs` (root: `apps/docs`, domain: `docs.shipcode.shipshit.dev`)
- [ ] Add `NPM_TOKEN` repo secret for CLI publishing
- [ ] Add macOS code signing secrets when ready (CSC_LINK, CSC_KEY_PASSWORD, APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, APPLE_TEAM_ID)

## Test plan
- [ ] Merge to master → verify CI workflow triggers (typecheck + test)
- [ ] Create draft release `v0.0.1` → verify release workflow triggers
- [ ] Verify Linux desktop binaries upload to release assets
- [ ] Verify CLI publishes to npm (after NPM_TOKEN is set)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated continuous integration pipeline to run type-checking and tests on code changes.
  * Added automated release workflow to streamline publishing of desktop applications and CLI packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->