### PR TITLE
feat: batch sprint — UTC timestamps, Projects v2 attach, pipeline polish

### DIFF
--- a/.agents/SESSIONS/2026-04-11.md
+++ b/.agents/SESSIONS/2026-04-11.md
@@ -2,6 +2,8 @@
 
 ## Summary
 
+- Session 33: Kanban closed-issue sync + new PRDs attach to Projects v2 board — `listAllIssues` now fetches `--state all --limit 200` (silent root cause was open-only filter), new SQL-guarded `markCompletedOnClose`/`markReopenedOnOpen` flips in `GitHubIssueQueries`, `github:refresh-issues` branches on `rec.state`, new `parseGithubProjectUrl` + `GhCli.addIssueToProject`, `github:create-issue` attaches best-effort and returns `{issue, projectAttachWarning}`, CreateIssueModal consumes new shape with inline warning surface. 14/14 typecheck, 292 tests green (+18 new). Codex adversarial review wedged at 9min (session 27 pattern again) → did verification pass directly, corrected 7 defects in plan before ExitPlanMode
+- Session 32: Icon optical balance in IssueDetail + SQLite UTC timestamp sweep — fixed Kanban elapsed clocks stuck at "2h" across every card (timezone bug in `datetime('now')` writes parsed as local time). New `packages/shared/src/sqlite-time.ts` with `ISO_NOW_SQL` + `toIsoUtc`; all 12 query files + schema defaults converted. Plus per-glyph optical sizing for `icon-xs` buttons in IssueDetail (Lucide viewBox fill compensation). 14/14 typecheck, 587/587 tests pass.
 - Session 31: Docs alignment with production-ready desktop app — `apps/cli/README.md` (new), OpenRouter dedicated page, agent-label table expanded to 5 variants, reviewer-model claim softened to "onboarding-only", pipeline state diagram + awaiting_approval/shipping, 9-page `apps/docs/content/desktop/` walkthrough (kanban/mission-control/inbox/costs/skills/terminal/settings/project-settings/plan-viewer), getting-started desktop-first, `apps/web` audited no-edit. 13 new files + 5 edits. Docs build 19/19, typecheck 14/14.
 - Session 30: Kanban card icon color consistency — `>` chevron now follows card tone (danger/warning/agent/muted)
 - Session 29: Plan full-screen dialog — readable fallback text, close button, Approve & Execute footer, stream-parser regex fix for nested code fences
@@ -2470,3 +2472,219 @@ flowchart TD
 
 - [ ] Commit `packages/ui/src/KanbanBoard.tsx`
 - [ ] Manual QA: hover over failed, awaiting, active, and idle cards — verify chevron color matches card border tone
+
+---
+
+## Session 32: Icon optical balance + SQLite UTC timestamp sweep
+
+**Status:** Complete
+
+### Affected Components
+
+| Layer | Components |
+|-------|------------|
+| Frontend | `apps/desktop/src/renderer/components/IssueDetail.tsx` |
+| Data | `packages/shared/src/sqlite-time.ts` (new), `packages/shared/src/index.ts`, `packages/db/src/schema.ts`, all 12 query files in `packages/db/src/queries/` |
+
+### What was done
+
+- [x] **Icon optical-balance pass** — fixed inconsistent icon sizes inside `icon-xs` buttons in `IssueDetail.tsx`. Root cause: Lucide icons have wildly different viewBox fill rates (Maximize2 ~75%, RefreshCw ~72%, Pencil ~66%, X ~50%, ChevronRight ~30%), so `size={14}` rendered visually different weights. Optically compensated: shrunk wide-fill icons to `12`, medium to `13`, grew narrow icons to `15–16` with `strokeWidth={2.25}`.
+- [x] **SQLite UTC timestamp bug — systemic fix.** Kanban "AGENT LOOP" elapsed clocks were stuck showing exactly 2h on every card. Root cause: SQLite `datetime('now')` returns a naive wall-clock UTC string (`"2026-04-11 23:29:00"`) without any timezone marker. Chrome/V8 in the Electron renderer parses that string as *local* time, not UTC, so the elapsed reading ends up equal to the local timezone offset (hence "2h" in UTC+2).
+- [x] Built `packages/shared/src/sqlite-time.ts` with `ISO_NOW_SQL` (SQL fragment `strftime('%Y-%m-%dT%H:%M:%fZ', 'now')`) and `toIsoUtc(value)` (read-side normalizer that appends `Z` to legacy naive strings).
+- [x] Swept all `datetime('now')` call sites out of `packages/db/src/` (source only, not tests): 12 schema defaults, 4 writes in `github-issues.ts`, 4 in `projects.ts`, 10 in `threads.ts`, 3 in `notifications.ts`, 2 in `skills.ts`. All switched to `${ISO_NOW_SQL}` via template literals.
+- [x] Piped all timestamp reads through `toIsoUtc` in every query file's `toRecord`/mapper: `github-issues.ts` (claimedAt/lastPhaseUpdate/fetchedAt), `threads.ts`, `projects.ts`, `notifications.ts`, `skills.ts`, `activity.ts`, `plans.ts`, `reviews.ts`, `diffs.ts`, `verifications.ts`, `dashboard.ts` (recent tasks), `costs.ts` (recentByTask). Retrofits `Z` onto rows already sitting in dev DBs with the legacy format — zero migration required.
+- [x] **Fixed comparison queries too** — `getStale` and `getOrphanedClaims` in `github-issues.ts` were comparing `last_phase_update`/`claimed_at` against `datetime('now', '-N ...')`. Because SQLite compares timestamps lexicographically and `'T'` (0x54) > `' '` (0x20), mixing the new ISO-Z write format with the old compare-side format would silently break stale-row detection. Both now use `strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-N ...')` so both sides are in the same format.
+- [x] **Verification:** `turbo run typecheck` → 14/14 packages clean. `turbo run test` → 587/587 pass (shared 114, agents 256, db 136, pipeline 57, desktop 24).
+
+### Files changed
+
+- `apps/desktop/src/renderer/components/IssueDetail.tsx` — optical icon sizing for 7 `icon-xs` button groups (headerButtons, PRD header × 2, plan row Maximize, error block Copy + Chevron × 2, full-screen plan X)
+- `packages/shared/src/sqlite-time.ts` — **new**, `ISO_NOW_SQL` + `toIsoUtc` helper
+- `packages/shared/src/index.ts` — re-export `sqlite-time`
+- `packages/db/src/schema.ts` — all 12 `DEFAULT (datetime('now'))` → ISO-Z form
+- `packages/db/src/queries/github-issues.ts` — writes + mapper + stale/orphan comparisons
+- `packages/db/src/queries/threads.ts` — 10 UPDATE statements + mapThread
+- `packages/db/src/queries/projects.ts` — 4 UPDATE statements + mapProject
+- `packages/db/src/queries/notifications.ts` — 3 UPDATE statements + mapRow
+- `packages/db/src/queries/skills.ts` — 2 UPDATE statements + mapRow
+- `packages/db/src/queries/activity.ts` — mapRow only (inserts use schema default)
+- `packages/db/src/queries/plans.ts` — mapPlan
+- `packages/db/src/queries/reviews.ts` — mapReview
+- `packages/db/src/queries/diffs.ts` — mapDiff
+- `packages/db/src/queries/verifications.ts` — toRecord
+- `packages/db/src/queries/dashboard.ts` — RecentTask updatedAt
+- `packages/db/src/queries/costs.ts` — recentByTask updatedAt
+
+### Key decisions
+
+- **Decision:** Two-pronged fix — write side (`ISO_NOW_SQL`) + read side (`toIsoUtc`)
+  - **Context:** Fixing only writes leaves existing dev-DB rows showing wrong. Fixing only reads leaves new writes in the broken format forever.
+  - **Rationale:** Combined approach means existing rows start rendering correctly on next mapper fetch (no migration), and new writes land directly in the correct format. `toIsoUtc` is a no-op for already-tagged strings, so it's safe to leave in place permanently as a defensive shim at the db boundary.
+
+- **Decision:** Optical-compensate icon sizes per glyph instead of a single global size constraint
+  - **Context:** Lucide icons at the same numeric `size={}` render at visually different widths because their strokes fill the 24×24 viewBox differently. A CSS `[&_svg]:size-*` constraint on the button primitive would force container uniformity but not fix perceived weight (Maximize2 would still look ~2× bigger than X).
+  - **Rationale:** Per-glyph optical sizing (shrink wide-fills, grow narrow-fills with heavier strokeWidth) is the only way to make them *look* uniform. Scoped to `IssueDetail.tsx` for now; the same pattern can be lifted into a helper component if this pain shows up elsewhere.
+
+- **Decision:** Fix `getStale`/`getOrphanedClaims` comparison side as part of the same change
+  - **Context:** Could have been overlooked since those queries weren't visibly broken in the screenshot. But changing the write format without changing the compare format would have silently broken stale-row detection because `'T' > ' '` in ASCII and SQLite compares strings lexicographically.
+  - **Rationale:** Writes and compares must share the same format or the whole invariant collapses. Both now use `strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-N ...')`.
+
+### Mistakes and fixes
+
+- **Mistake:** First pass of the sweep used `replace_all` with `"datetime('now')"` → `"${ISO_NOW_SQL}"` in `github-issues.ts`, but several of the target strings were in double-quoted strings (not template literals), so `${ISO_NOW_SQL}` became a literal substring. -> **Fix:** Manually converted each affected statement to a backtick template literal.
+- **Mistake:** Nearly shipped the write-side fix without touching `getStale`/`getOrphanedClaims`. -> **Fix:** Caught during review before moving on — updated both comparison queries to use `strftime` too.
+- **Mistake:** Responded to the "2h stuck" screenshot with scoped fix for just `github-issues.ts`, user pushed back ("why leaving out bugs?"). -> **Fix:** Swept all 12 query files in one systematic pass.
+
+### Next steps
+
+- [ ] Reload the Electron renderer (`Cmd+R`) and verify Kanban elapsed clocks on #24/#25/#7 now show seconds/minutes instead of 2h
+- [ ] Commit in two logical chunks: (1) `fix(ui): optically balance icon-xs button glyphs in IssueDetail`, (2) `fix(db): normalize SQLite timestamps to ISO-Z UTC`
+- [ ] Decide what to do with the pre-existing uncommitted changes from session start (`stream-parser.ts`, `KanbanBoard.tsx`, `dialog.tsx`, `ipc.ts`, `notification-service.ts`, `pipeline-bridge.ts`, `gh-cli.ts`, `IssueDetail.test.tsx`) — bundle or separate commits
+- [ ] Consider lifting icon optical-sizing into a reusable helper if this pattern repeats elsewhere in the app
+
+---
+
+## Session 33: Kanban closed-issue sync + new PRDs attach to Projects v2 board
+
+**Status:** Complete (code + tests + typecheck green; manual QA pending)
+
+### Problem
+
+Two related GH-Kanban coupling bugs, both flagged by Vincent with screenshots:
+
+1. **Closed issues stuck on the local Kanban.** Issues like #8 / #11 were closed on GitHub and parked in the "Done" column of the real Projects v2 board at `https://github.com/orgs/shipshitdev/projects/1`, but on the ShipCode Kanban they still appeared under FAILED / AGENT LOOP / HUMAN. The local DONE column showed 0 even though 11 issues were upstream-done. Refresh button did nothing.
+2. **New PRDs create GH issues but never attach to the Projects v2 board.** Clicking `+ New PRD` → `Create & Plan` successfully ran `gh issue create` (issues #24 "this is a test feature" / #25 "test" showed up in the repo issues list), but they never appeared on the user's configured Projects v2 board. The `project.githubProjectUrl` override (shipped in Session 27 earlier today) was read-only — only wired to the Kanban `board` quick-link button.
+
+Both share the same root: ShipCode had no concept of "a GH issue's lifecycle in Projects v2 is authoritative." This session closes the loop in both directions.
+
+### System Flow
+
+```mermaid
+flowchart LR
+  subgraph Bug1[Bug 1 — inbound close sync]
+    GH1[User closes issue\non GitHub]
+    Refresh[Kanban refresh]
+    List[listAllIssues\n--state all --limit 200]
+    Upsert[githubIssues.upsert]
+    Flip[markCompletedOnClose\nSQL-guarded on source status]
+    Done[Kanban DONE column]
+    GH1 --> Refresh --> List --> Upsert --> Flip --> Done
+  end
+  subgraph Bug2[Bug 2 — outbound attach]
+    Modal[CreateIssueModal\nClick Create & Plan]
+    Create[gh issue create\n--title --body-file -]
+    Parse[parseGithubProjectUrl\nproject.githubProjectUrl]
+    Attach[gh project item-add\nnumber --owner --url]
+    Board[Projects v2 board]
+    Warn[projectAttachWarning\nsetError in modal]
+    Modal --> Create --> Parse -->|orgs/users| Attach --> Board
+    Parse -->|repo-scoped/null| Skip((skip))
+    Attach -->|fail| Warn
+  end
+```
+
+### Affected Components
+
+| Layer | Components |
+|-------|------------|
+| Frontend | `apps/desktop/src/renderer/components/CreateIssueModal.tsx` |
+| Backend | `apps/desktop/src/main/ipc.ts` (`github:refresh-issues`, `github:create-issue`) |
+| Shared | `packages/shared/src/github-url.ts` (+ `parseGithubProjectUrl`) |
+| Data | `packages/db/src/queries/github-issues.ts` (+ `markCompletedOnClose`, `markReopenedOnOpen`) |
+| Agents | `packages/agents/src/github/gh-cli.ts` (`listAllIssues` state filter + new `addIssueToProject`) |
+
+### What was done
+
+- [x] Initial exploration — launched two Explore agents in parallel to trace (a) Kanban status → GH state sync and (b) PRD creation → board attach flow. Findings contradicted at first by a Plan agent that caught two critical errors in my exploration (KanbanBoard is cache-driven not thread-driven; `listAllIssues` is open-only)
+- [x] Verified every file:line reference directly against repo files (Read tool), not trusting the Explore+Plan agents blindly
+- [x] Wrote plan to `~/.claude-genfeedai/plans/synthetic-dancing-coral.md` with context, approach, file changes, test cases, and a dedicated adversarial-review findings section
+- [x] Dispatched `codex:rescue` for repo-against-plan review → wedged at ~9 minutes (matches session 27's memorized failure pattern for broad-scope Codex reviews) → cancelled and did the verification pass directly, corrected 7 concrete defects in the plan before `ExitPlanMode`
+- [x] **Bug 1 — `listAllIssues`:** flipped `--state open --limit 100` → `--state all --limit 200` (`gh-cli.ts:40-66`). This was the *silent* root cause — once an issue flipped to closed, the open-only filter meant the refresh never re-observed it and the cache's `state` column stayed stale forever
+- [x] **Bug 1 — query helpers:** added `markCompletedOnClose(id)` and `markReopenedOnOpen(id)` to `GitHubIssueQueries`. Both use single UPDATE statements with status guards in the WHERE clause so they're race-safe against the pipeline writer. `markCompletedOnClose` only flips from `todo | queued | awaiting_approval | failed` (NOT in-flight statuses or `completed`). `markReopenedOnOpen` only flips from `completed → todo`
+- [x] **Bug 1 — refresh handler:** in `github:refresh-issues`, after each `upsert`, branch on `rec.state` to call the appropriate flip method. Zero changes to `KanbanBoard.tsx` — the `COLUMNS` constant already routes `completed` to DONE
+- [x] **Bug 1 — tests:** new `describe('close/reopen sync')` block in `github-issues.test.ts` — 9 cases covering queued/todo/awaiting_approval/failed flips, in-flight guards (executing/planning stay put), idempotency on completed, reopen happy path, and reopen no-ops on non-completed states. Reused existing `makeIssue` helper
+- [x] **Bug 2 — parser:** added `parseGithubProjectUrl` + `ParsedGithubProject` interface to `github-url.ts`. Returns `{ownerType, owner, number}` or null. Deliberately rejects the legacy repo-scoped form (`<owner>/<repo>/projects/<n>`) even though `validateGithubProjectUrl` accepts it — that form can't be used with `gh project item-add` (repo "linked Projects" tab, not a v2 board). Case preserved, trailing slash tolerated
+- [x] **Bug 2 — gh-cli method:** new `GhCli.addIssueToProject({projectNumber, owner, issueUrl})` shelling `gh project item-add <number> --owner <owner> --url <issueUrl>`. `--owner` takes a bare login and handles both org and user projects, so `ownerType` is parsed for future use but not passed through
+- [x] **Bug 2 — create handler:** in `github:create-issue`, after upsert + broadcast, call `parseGithubProjectUrl(project.githubProjectUrl)` and attempt the attach best-effort. Guarded on `issue.url` being non-empty (because `GhCli.getIssue` at `gh-cli.ts:100` falls back to `url: ''` on JSON parse failure — would otherwise shell `--url ''`). Failures → clamped via `clampError`, logged via `log.warn`, returned as `projectAttachWarning`. **Return shape changed** from `GitHubIssueCacheRecord | null` to `{ issue: GitHubIssueCacheRecord; projectAttachWarning: string | null }` — non-null `issue` since `getByNumber` can't fail right after upsert (defensive throw if it does)
+- [x] **Bug 2 — CreateIssueModal:** consumed new return shape at both usage sites (line 135: `created.issue.issueNumber`, line 147: `selectIssue(created.issue)`). When `projectAttachWarning` is non-null, set `error` to `"Issue #N created, but couldn't add to project board: <warning>"` and skip `closeCreateIssueModal` so the user sees it. Happy path still closes the modal
+- [x] **Bug 2 — tests:** 9 new cases in `github-url.test.ts` covering orgs/users/trailing-slash/uppercase-owner/repo-scoped-rejection/non-numeric/missing-number/http/null+undefined+empty+whitespace
+- [x] `bun run typecheck` — 14/14 packages green
+- [x] `bun run test --filter @shipcode/shared --filter @shipcode/db --filter @shipcode/desktop` — shared 123✓ (4 files), db 145✓ (15 files), desktop 24✓ (3 files). Total 292 tests green
+
+### Files changed
+
+**Shared:**
+- `packages/shared/src/github-url.ts` — new `ParsedGithubProject` interface + `parseGithubProjectUrl` function
+- `packages/shared/src/github-url.test.ts` — +9 tests in new `describe('parseGithubProjectUrl')` block
+
+**DB:**
+- `packages/db/src/queries/github-issues.ts` — new `markCompletedOnClose` + `markReopenedOnOpen` methods with SQL-guarded source-status checks
+- `packages/db/src/queries/github-issues.test.ts` — +9 tests in new `describe('close/reopen sync')` block
+
+**Agents:**
+- `packages/agents/src/github/gh-cli.ts`:
+  - `listAllIssues` now fetches `--state all --limit 200` (was `--state open --limit 100`)
+  - new `addIssueToProject` method shelling `gh project item-add`
+
+**Desktop main:**
+- `apps/desktop/src/main/ipc.ts`:
+  - import extended to include `parseGithubProjectUrl`
+  - `github:refresh-issues` branches on `rec.state` to call `markCompletedOnClose` / `markReopenedOnOpen`
+  - `github:create-issue` — best-effort attach after create, new return shape `{issue, projectAttachWarning}`, `issue.url` guard
+
+**Desktop renderer:**
+- `apps/desktop/src/renderer/components/CreateIssueModal.tsx:120-156` — new `invoke` generic, both `created` usage sites updated, inline warning surface when attach fails (keeps modal open)
+
+### Key decisions
+
+- **Decision:** Non-destructive-with-a-guard flip in SQL, not a bucket override in `KanbanBoard.tsx`
+  - **Context:** Two options debated in the plan: (A) derived `githubIssueState` in the query + override in `bucketFor`, (B) SQL flip guarded by status. Kanban code reads `GitHubIssueCacheRecord[]` already, so the cache's `pipeline_status` column is the surface both options touch
+  - **Rationale:** Option B reuses the Kanban's existing `COLUMNS` routing (`completed → DONE`), zero presentation-layer changes, race-safe via `WHERE pipeline_status IN (…)`, and automatically reverses on reopen via the symmetric helper. Option A would touch four+ Kanban call sites (draggable logic, section filters, active indicators) for the same end result
+
+- **Decision:** `gh project item-add` over `gh issue create --project` or direct `gh api graphql`
+  - **Context:** `gh issue create --project <title>` exists on modern gh but takes a title (not URL/number), is version-gated, and gives opaque errors. `gh api graphql` would require a two-query dance to resolve project + issue node IDs before the `addProjectV2ItemById` mutation
+  - **Rationale:** `gh project item-add <number> --owner <owner> --url <issueUrl>` is the dedicated CLI for this exact operation, gives structured stderr errors, and works for both org and user projects with a single flag
+
+- **Decision:** Best-effort attach with a surfaced warning, not a hard-fail or silent skip
+  - **Context:** The issue already exists on GH regardless of whether the board attach worked. Silent failure violates repo memory "UI consolidation — don't delete quietly"; hard-fail would be surprising since the primary outcome already succeeded
+  - **Rationale:** Keep modal open + `setError` with a prefixed "Issue #N created, but couldn't add to project board: …" message. User sees the warning in-place, dismisses, moves on. Happy path is unchanged
+
+- **Decision:** Breaking IPC return shape change for `github:create-issue`, not a side-channel notification event
+  - **Context:** `CreateIssueModal.tsx` is the sole renderer caller. Could have added a new `github:project-attach-failed` event emitted to `mainWindow.webContents` and subscribed in the notification fan-out
+  - **Rationale:** Return shape change is a one-line update in the single caller. Event side-channel would add a new IPC surface and a new subscription point for one warning that's inherently tied to the same request/response lifecycle. Pre-release code → no migration concern
+
+- **Decision:** Parser rejects the repo-scoped form even though the validator accepts it
+  - **Context:** `validateGithubProjectUrl` has accepted the legacy `<owner>/<repo>/projects/<n>` form since Session 27 (users might still paste it). But `gh project item-add` can't target a repo's "linked Projects" tab
+  - **Rationale:** Parser is the read-time counterpart — returning null makes the attach a silent no-op for repo-scoped overrides, so the Kanban quick-link button still works for them while PRD creation skips the attach cleanly
+
+### Mistakes and fixes
+
+- **Mistake:** Initial exploration pass (two parallel Explore agents) was WRONG on two load-bearing facts: claimed Kanban is driven by `threads.pipelineStatus` (it's actually `GitHubIssueCacheRecord.pipelineStatus`) and didn't notice that `listAllIssues` is `--state open` only -> **Fix:** The Plan agent caught both. I re-verified each claim directly with Read against `KanbanBoard.tsx:203` and `gh-cli.ts:40-66` before writing the final plan
+- **Mistake:** Codex rescue adversarial review wedged at ~9 minutes on a broad scope, same pattern as Session 27's memorized failure mode -> **Fix:** Cancelled the Codex job, did the verification pass directly against the repo, documented 7 concrete defects in the plan's new "Adversarial review findings" section before `ExitPlanMode`. Saved the context of the failure for memory extraction
+- **Mistake:** Plan initially said "add block to possibly-new test file" for `github-issues.test.ts` -> **Fix:** Direct verification showed the file already exists with a reusable `makeIssue` helper. Plan updated to "add block to existing file, reuse `makeIssue`"
+- **Mistake:** Plan initially missed that `github_issue_cache.pipeline_status` has `DEFAULT 'queued'` (not `'todo'`) in `schema.ts:129`. Test block as originally written would have created rows at `'queued'` and the `todo → completed` test would've been a no-op -> **Fix:** Added an explicit `Gotcha` note in the plan; test block now calls `updatePipelineStatus` to set non-queued source statuses before invoking the flip
+- **Mistake:** Plan initially missed that `CreateIssueModal.tsx` uses `created` at TWO sites (line 135 AND line 147), not one -> **Fix:** Plan and implementation both updated to replace both
+- **Mistake:** LSP diagnostics fired spurious "no exported member" / "property does not exist" errors for every new method I added in-session (`markCompletedOnClose`, `markReopenedOnOpen`, `parseGithubProjectUrl`, `addIssueToProject`) -> **Fix:** Recognized the session-15/21/26/27 stale-IDE-cache pattern, trusted `bun run typecheck` (14/14 green) as ground truth. Ran `bun run build --filter @shipcode/shared` once mid-edit to help LSP settle but otherwise ignored
+
+### Root causes worth remembering
+
+- **Silent state filters bite hard.** `listAllIssues` has been `--state open` forever, so the entire refresh mechanism has never had a way to observe a state transition back to closed. Feature-flag-style filters like this need a comment explaining "if you bump this to 'all', also handle the closed branch"
+- **Kanban data source:** `KanbanBoard.tsx:203` takes `GitHubIssueCacheRecord`, NOT `Thread`. The `threads` table is only consulted for lastError/pipeline metadata *inside* `IssueDetail`; the board itself reads directly from `github_issue_cache`. Any bug starting with "why is this card in X column" must grep the cache, not threads
+- **`gh` CLI scope for Projects v2:** `gh project item-add` needs `project` scope on the user's gh token. If the user's `gh auth` is missing it, the error goes through `clampError` and surfaces inline in the CreateIssueModal — not silent
+- **Codex adversarial reviews wedge on broad scopes.** Same pattern as Session 27 — a numbered-question prompt completed in 1m05s there; a "verify the plan against the repo" prompt this session wedged at 9min+. Lesson holds: any Codex review dispatch needs a strict question list AND a word cap, not a free-form "review this"
+- **`.claim_at`-style claim tracking and `pipeline_status` are independent.** The SQL guard on `markCompletedOnClose` is `WHERE pipeline_status IN (…)` — it does NOT check `claimed_at`. That's intentional: claimed_at is a runtime claim-tracking field used by `tryClaim` / `releaseClaim` / `getStale`, while pipeline_status is the user-visible state machine. The in-flight guard is on pipeline_status
+
+### Next steps
+
+- [ ] **Manual QA #1 — close sync:** pick an issue currently in FAILED or AWAITING_APPROVAL (e.g. #8 `Integrate OpenRouter…`, #11 `Expose live agent terminal…`). Close it via `gh issue close <n>` or the GH web UI. Click Kanban refresh button. Card should move to DONE
+- [ ] **Manual QA #2 — reopen sync:** `gh issue reopen <n>` on a DONE card. Refresh. Card should return to TODO
+- [ ] **Manual QA #3 — in-flight guard:** drag a TODO onto Agent Loop to start a pipeline. While it's in `planning`, close the issue on GH and refresh. Card should stay in AGENT LOOP → PLANNING (not flip to DONE). When the pipeline eventually finishes/fails, the next refresh will see `state=closed` + non-in-flight status and move to DONE
+- [ ] **Manual QA #4 — happy-path attach:** ensure Project Settings has `https://github.com/orgs/shipshitdev/projects/1` set. Click `+ New PRD`, fill body, `Generate with AI`, `Create & Plan`. Open the board in a browser — new issue should appear within a couple seconds
+- [ ] **Manual QA #5 — no-override:** clear the board override. Create another PRD. Issue is still created, no attach attempt, no inline warning, modal closes normally
+- [ ] **Manual QA #6 — repo-scoped override:** paste `https://github.com/shipshitdev/shipcode/projects/1` as the override (legacy form). Create a PRD. Issue is created; parser returns null; no attach attempt; no warning. Kanban `board` quick-link still routes to the repo Projects tab via the existing fallback
+- [ ] **Manual QA #7 — attach failure:** temporarily point the override at `projects/9999` or a project you don't have write access to. Create a PRD. Issue appears on GH, modal stays open with inline `"Issue #N created, but couldn't add to project board: …"` warning, no crash
+- [ ] **Commit:** single commit covering shared + db + agents + desktop changes + plan file. No co-authored-by trailer per global rules
+- [ ] **Follow-up (out of scope):** retroactively backfill existing open issues into the new board. Not asked for; do if/when Vincent surfaces it
+- [ ] **Follow-up (out of scope):** paginate `listAllIssues` properly if `--limit 200` ceiling is ever hit on a large repo
+- [ ] **Memory extraction candidates:** (1) codex adversarial-review wedge pattern now has two documented incidents (session 27 + 33) — promote to a real memory entry; (2) Kanban-is-cache-driven-not-thread-driven worth a one-liner in repo memory since I initially got it wrong this session
+

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -21,7 +21,11 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { ProcessManager } from '@shipcode/agents';
 import type { PhaseSkillKey } from '@shipcode/shared';
-import { validateGithubProjectUrl, clampError } from '@shipcode/shared';
+import {
+  validateGithubProjectUrl,
+  clampError,
+  parseGithubProjectUrl,
+} from '@shipcode/shared';
 import {
   checkSystemHealthWithAuth,
   checkGhAuth,
@@ -294,9 +298,12 @@ export function registerIpcHandlers(
     const ghCli = new GhCli(project.path);
     const issues = await ghCli.listAllIssues();
 
-    // Upsert all issues into cache
+    // Upsert all issues into cache. After each upsert, sync external GH
+    // state into the local pipeline_status: closed → completed (guarded),
+    // reopened → todo (guarded). See `markCompletedOnClose` / `markReopenedOnOpen`
+    // for the in-flight guards that keep this race-safe with the pipeline writer.
     for (const issue of issues) {
-      queries.githubIssues.upsert({
+      const rec = queries.githubIssues.upsert({
         projectId,
         issueNumber: issue.number,
         title: issue.title,
@@ -305,6 +312,11 @@ export function registerIpcHandlers(
         assignee: issue.assignee,
         state: issue.state,
       });
+      if (rec.state === 'closed') {
+        queries.githubIssues.markCompletedOnClose(rec.id);
+      } else if (rec.state === 'open') {
+        queries.githubIssues.markReopenedOnOpen(rec.id);
+      }
     }
 
     const cached = queries.githubIssues.list(projectId);
@@ -344,7 +356,32 @@ export function registerIpcHandlers(
       const allIssues = queries.githubIssues.list(projectId);
       mainWindow.webContents.send('github:issues-updated', { projectId, issues: allIssues });
 
-      return queries.githubIssues.getByNumber(projectId, issue.number);
+      // Best-effort: if the project has a Projects v2 board override set,
+      // attach the new issue to that board. Failures never block issue
+      // creation — the issue is already on GitHub; we surface the failure
+      // via `projectAttachWarning` so the modal can show an inline note.
+      const parsed = parseGithubProjectUrl(project.githubProjectUrl);
+      let projectAttachWarning: string | null = null;
+      if (parsed && issue.url) {
+        try {
+          await ghCli.addIssueToProject({
+            projectNumber: parsed.number,
+            owner: parsed.owner,
+            issueUrl: issue.url,
+          });
+        } catch (err) {
+          projectAttachWarning = clampError(err);
+          log.warn('[github:create-issue] project attach failed:', err);
+        }
+      }
+
+      const record = queries.githubIssues.getByNumber(projectId, issue.number);
+      if (!record) {
+        throw new Error(
+          `Created issue #${issue.number} not found in cache after upsert`,
+        );
+      }
+      return { issue: record, projectAttachWarning };
     },
   );
 

--- a/apps/desktop/src/main/notification-service.ts
+++ b/apps/desktop/src/main/notification-service.ts
@@ -148,6 +148,11 @@ export class NotificationService {
     return this.notifications.listActive();
   }
 
+  dismissByThread(threadId: string) {
+    this.notifications.dismissByThread(threadId);
+    this.refreshBadge();
+  }
+
   dismiss(id: string) {
     this.notifications.dismiss(id);
     this.refreshBadge();

--- a/apps/desktop/src/main/pipeline-bridge.ts
+++ b/apps/desktop/src/main/pipeline-bridge.ts
@@ -187,6 +187,12 @@ export function createElectronEmitter(
 
       // 4. Fire phase-based notifications.
       if (event.type === 'pipeline:phase' && thread) {
+        // When a new run starts, clear any stale notifications (e.g. a previous
+        // 'failed' entry that is no longer relevant once the pipeline re-queues).
+        if (event.phase === 'planning') {
+          deps.notifications.dismissByThread(thread.id);
+        }
+
         if (event.phase === 'awaiting_approval') {
           deps.notifications.fire('awaiting_approval', thread);
         } else if (event.phase === 'failed') {

--- a/apps/desktop/src/renderer/components/CreateIssueModal.tsx
+++ b/apps/desktop/src/renderer/components/CreateIssueModal.tsx
@@ -118,21 +118,21 @@ export function CreateIssueModal() {
         });
         await queryClient.invalidateQueries({ queryKey: ['github-issues'] });
       } else {
-        const created = await window.shipcode.invoke<GitHubIssueCacheRecord>(
-          'github:create-issue',
-          {
-            projectId: activeProjectId,
-            title: derivedTitle,
-            body,
-          },
-        );
+        const created = await window.shipcode.invoke<{
+          issue: GitHubIssueCacheRecord;
+          projectAttachWarning: string | null;
+        }>('github:create-issue', {
+          projectId: activeProjectId,
+          title: derivedTitle,
+          body,
+        });
         await queryClient.invalidateQueries({ queryKey: ['github-issues'] });
         // Kick off the pipeline immediately and open the issue detail
         // so the user can watch planning start.
         try {
           await window.shipcode.invoke('github:start-issue', {
             projectId: activeProjectId,
-            issueNumber: created.issueNumber,
+            issueNumber: created.issue.issueNumber,
           });
         } catch (startErr) {
           log.error('[CreateIssueModal] start-issue failed', startErr);
@@ -144,7 +144,17 @@ export function CreateIssueModal() {
           setSubmitting(false);
           return;
         }
-        selectIssue(created);
+        selectIssue(created.issue);
+        // If best-effort board attach failed, keep the modal open with an
+        // inline warning so the user actually sees it. The issue is already
+        // on GitHub and is selected — they can dismiss and move on.
+        if (created.projectAttachWarning) {
+          setError(
+            `Issue #${created.issue.issueNumber} created, but couldn't add to project board: ${created.projectAttachWarning}`,
+          );
+          setSubmitting(false);
+          return;
+        }
       }
       closeCreateIssueModal();
     } catch (err) {

--- a/packages/agents/src/github/gh-cli.test.ts
+++ b/packages/agents/src/github/gh-cli.test.ts
@@ -139,7 +139,7 @@ describe('GhCli', () => {
   });
 
   describe('listAllIssues', () => {
-    it('returns mapped issues with --limit 100', async () => {
+    it('returns mapped issues with --limit 200', async () => {
       const raw = [
         {
           number: 10,
@@ -159,7 +159,7 @@ describe('GhCli', () => {
       expect(issues[0].labels).toEqual(['feat']);
       expect(mockExecFileAsync).toHaveBeenCalledWith(
         'gh',
-        expect.arrayContaining(['--limit', '100']),
+        expect.arrayContaining(['--limit', '200']),
         { cwd: '/test/repo' },
       );
     });

--- a/packages/agents/src/github/gh-cli.ts
+++ b/packages/agents/src/github/gh-cli.ts
@@ -44,11 +44,11 @@ export class GhCli {
         'issue',
         'list',
         '--state',
-        'open',
+        'all',
         '--json',
         'number,title,body,labels,assignees,state,url',
         '--limit',
-        '100',
+        '200',
       ],
       { cwd: this.cwd },
     );
@@ -116,6 +116,36 @@ export class GhCli {
     const match = stdout.match(/\/issues\/(\d+)/);
     if (!match) throw new Error(`Failed to parse issue number from: ${stdout}`);
     return this.getIssue(parseInt(match[1], 10));
+  }
+
+  /**
+   * Add an existing issue to a GitHub Projects v2 board, best-effort.
+   * Shells `gh project item-add <number> --owner <owner> --url <issueUrl>`.
+   *
+   * `--owner` accepts a bare login for both org and user Projects v2, so the
+   * caller does not need to distinguish `ownerType` at this layer. Throws on
+   * non-zero exit — the caller is responsible for deciding whether a failure
+   * should block issue creation (it should not: see `github:create-issue`
+   * in the desktop IPC handler).
+   */
+  async addIssueToProject(opts: {
+    projectNumber: number;
+    owner: string;
+    issueUrl: string;
+  }): Promise<void> {
+    await execFileAsync(
+      'gh',
+      [
+        'project',
+        'item-add',
+        String(opts.projectNumber),
+        '--owner',
+        opts.owner,
+        '--url',
+        opts.issueUrl,
+      ],
+      { cwd: this.cwd },
+    );
   }
 
   async editIssueBody(issueNumber: number, body: string): Promise<void> {

--- a/packages/agents/src/stream-parser.ts
+++ b/packages/agents/src/stream-parser.ts
@@ -177,8 +177,10 @@ export class StreamParser {
     const raw = this.buffer; // stored as-is (original output)
     const text = this.resolveBuffer(); // resolved LLM text for parsing
 
-    // Look for ```tag ... ``` blocks
-    const fenceRegex = new RegExp(`\`\`\`${tag}\\s*\\n([\\s\\S]*?)\`\`\``, 'm');
+    // Look for ```tag ... ``` blocks.
+    // Require \n before the closing fence so that ``` inside JSON string values
+    // (e.g. ```ts code examples in step descriptions) don't terminate the match early.
+    const fenceRegex = new RegExp(`\`\`\`${tag}[^\n]*\n([\\s\\S]*?)\n\`\`\``, 'm');
     const match = text.match(fenceRegex);
 
     if (!match) {

--- a/packages/db/src/queries/activity.ts
+++ b/packages/db/src/queries/activity.ts
@@ -1,6 +1,11 @@
 import type { DatabaseSync } from 'node:sqlite';
 import { nanoid } from 'nanoid';
-import type { ActivityEntry, ActivityKind, ActivityActor } from '@shipcode/shared';
+import {
+  toIsoUtc,
+  type ActivityEntry,
+  type ActivityKind,
+  type ActivityActor,
+} from '@shipcode/shared';
 
 function mapRow(row: any): ActivityEntry {
   return {
@@ -12,7 +17,7 @@ function mapRow(row: any): ActivityEntry {
     title: row.title,
     subtitle: row.subtitle,
     metadata: row.metadata ? (JSON.parse(row.metadata) as Record<string, unknown>) : null,
-    createdAt: row.created_at,
+    createdAt: toIsoUtc(row.created_at) ?? row.created_at,
   };
 }
 

--- a/packages/db/src/queries/costs.ts
+++ b/packages/db/src/queries/costs.ts
@@ -1,5 +1,5 @@
 import type { DatabaseSync } from 'node:sqlite';
-import type { CostSummary, PipelinePhase } from '@shipcode/shared';
+import { toIsoUtc, type CostSummary, type PipelinePhase } from '@shipcode/shared';
 
 export class CostsQueries {
   constructor(private db: DatabaseSync) {}
@@ -104,7 +104,7 @@ export class CostsQueries {
         costUsd: r.cost_usd,
         tokensPrompt: r.tokens_prompt,
         tokensCompletion: r.tokens_completion,
-        updatedAt: r.updated_at,
+        updatedAt: toIsoUtc(r.updated_at) ?? r.updated_at,
       })),
     };
   }

--- a/packages/db/src/queries/dashboard.ts
+++ b/packages/db/src/queries/dashboard.ts
@@ -1,5 +1,5 @@
 import type { DatabaseSync } from 'node:sqlite';
-import type { DashboardStats, PipelinePhase, RecentTask } from '@shipcode/shared';
+import { toIsoUtc, type DashboardStats, type PipelinePhase, type RecentTask } from '@shipcode/shared';
 
 // Phases that represent active work (agent running or waiting on action).
 const ACTIVE_PHASES: PipelinePhase[] = [
@@ -140,7 +140,7 @@ export class DashboardQueries {
       title: row.title,
       phase: row.phase as PipelinePhase,
       githubIssueNumber: row.github_issue_number,
-      updatedAt: row.updated_at,
+      updatedAt: toIsoUtc(row.updated_at) ?? row.updated_at,
     }));
   }
 

--- a/packages/db/src/queries/diffs.ts
+++ b/packages/db/src/queries/diffs.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite';
 import { nanoid } from 'nanoid';
-import type { DiffRecord } from '@shipcode/shared';
+import { toIsoUtc, type DiffRecord } from '@shipcode/shared';
 
 export class DiffQueries {
   constructor(private db: DatabaseSync) {}
@@ -50,6 +50,6 @@ function mapDiff(row: any): DiffRecord {
     diffContent: row.diff_content,
     beforeHash: row.before_hash,
     afterHash: row.after_hash,
-    createdAt: row.created_at,
+    createdAt: toIsoUtc(row.created_at) ?? row.created_at,
   };
 }

--- a/packages/db/src/queries/github-issues.test.ts
+++ b/packages/db/src/queries/github-issues.test.ts
@@ -168,4 +168,78 @@ describe('GitHubIssueQueries', () => {
     const orphaned = issues.getOrphanedClaims();
     expect(orphaned.length).toBe(0);
   });
+
+  describe('close/reopen sync', () => {
+    it('markCompletedOnClose() flips queued → completed (default source status)', () => {
+      const record = issues.upsert(makeIssue());
+      expect(record.pipelineStatus).toBe('queued');
+      const changed = issues.markCompletedOnClose(record.id);
+      expect(changed).toBe(true);
+      expect(issues.getByNumber(projectId, 1)?.pipelineStatus).toBe('completed');
+    });
+
+    it('markCompletedOnClose() flips todo → completed', () => {
+      const record = issues.upsert(makeIssue());
+      issues.updatePipelineStatus(record.id, 'todo');
+      expect(issues.markCompletedOnClose(record.id)).toBe(true);
+      expect(issues.getByNumber(projectId, 1)?.pipelineStatus).toBe('completed');
+    });
+
+    it('markCompletedOnClose() flips awaiting_approval → completed', () => {
+      const record = issues.upsert(makeIssue());
+      issues.updatePipelineStatus(record.id, 'awaiting_approval');
+      expect(issues.markCompletedOnClose(record.id)).toBe(true);
+      expect(issues.getByNumber(projectId, 1)?.pipelineStatus).toBe('completed');
+    });
+
+    it('markCompletedOnClose() flips failed → completed', () => {
+      const record = issues.upsert(makeIssue());
+      issues.updatePipelineStatus(record.id, 'failed');
+      expect(issues.markCompletedOnClose(record.id)).toBe(true);
+      expect(issues.getByNumber(projectId, 1)?.pipelineStatus).toBe('completed');
+    });
+
+    it('markCompletedOnClose() does NOT flip executing (in-flight guard)', () => {
+      const record = issues.upsert(makeIssue());
+      issues.updatePipelineStatus(record.id, 'executing');
+      expect(issues.markCompletedOnClose(record.id)).toBe(false);
+      expect(issues.getByNumber(projectId, 1)?.pipelineStatus).toBe('executing');
+    });
+
+    it('markCompletedOnClose() does NOT flip planning (in-flight guard)', () => {
+      const record = issues.upsert(makeIssue());
+      issues.updatePipelineStatus(record.id, 'planning');
+      expect(issues.markCompletedOnClose(record.id)).toBe(false);
+      expect(issues.getByNumber(projectId, 1)?.pipelineStatus).toBe('planning');
+    });
+
+    it('markCompletedOnClose() is idempotent on already-completed rows', () => {
+      const record = issues.upsert(makeIssue());
+      issues.updatePipelineStatus(record.id, 'completed');
+      expect(issues.markCompletedOnClose(record.id)).toBe(false);
+      expect(issues.getByNumber(projectId, 1)?.pipelineStatus).toBe('completed');
+    });
+
+    it('markReopenedOnOpen() flips completed → todo', () => {
+      const record = issues.upsert(makeIssue());
+      issues.updatePipelineStatus(record.id, 'completed');
+      expect(issues.markReopenedOnOpen(record.id)).toBe(true);
+      expect(issues.getByNumber(projectId, 1)?.pipelineStatus).toBe('todo');
+    });
+
+    it('markReopenedOnOpen() is a no-op on non-completed source states', () => {
+      const record = issues.upsert(makeIssue());
+      // Default is 'queued'
+      expect(issues.markReopenedOnOpen(record.id)).toBe(false);
+      expect(issues.getByNumber(projectId, 1)?.pipelineStatus).toBe('queued');
+
+      issues.updatePipelineStatus(record.id, 'executing');
+      expect(issues.markReopenedOnOpen(record.id)).toBe(false);
+      expect(issues.getByNumber(projectId, 1)?.pipelineStatus).toBe('executing');
+
+      issues.updatePipelineStatus(record.id, 'failed');
+      expect(issues.markReopenedOnOpen(record.id)).toBe(false);
+      expect(issues.getByNumber(projectId, 1)?.pipelineStatus).toBe('failed');
+    });
+  });
 });

--- a/packages/db/src/queries/github-issues.ts
+++ b/packages/db/src/queries/github-issues.ts
@@ -1,6 +1,12 @@
 import type { DatabaseSync } from 'node:sqlite';
 import { nanoid } from 'nanoid';
-import type { ExecutorModel, GitHubIssueCacheRecord, IssuePipelineStatus } from '@shipcode/shared';
+import {
+  ISO_NOW_SQL,
+  toIsoUtc,
+  type ExecutorModel,
+  type GitHubIssueCacheRecord,
+  type IssuePipelineStatus,
+} from '@shipcode/shared';
 
 export class GitHubIssueQueries {
   constructor(private db: DatabaseSync) {}
@@ -44,7 +50,7 @@ export class GitHubIssueQueries {
     if (existing) {
       this.db
         .prepare(
-          "UPDATE github_issue_cache SET title = ?, body = ?, labels = ?, assignee = ?, state = ?, fetched_at = datetime('now') WHERE id = ?",
+          `UPDATE github_issue_cache SET title = ?, body = ?, labels = ?, assignee = ?, state = ?, fetched_at = ${ISO_NOW_SQL} WHERE id = ?`,
         )
         .run(
           record.title,
@@ -77,9 +83,52 @@ export class GitHubIssueQueries {
   updatePipelineStatus(id: string, status: IssuePipelineStatus): void {
     this.db
       .prepare(
-        "UPDATE github_issue_cache SET pipeline_status = ?, last_phase_update = datetime('now') WHERE id = ?",
+        `UPDATE github_issue_cache SET pipeline_status = ?, last_phase_update = ${ISO_NOW_SQL} WHERE id = ?`,
       )
       .run(status, id);
+  }
+
+  /**
+   * When a GH issue flips to `state = 'closed'` externally (via the web UI,
+   * `gh issue close`, or a Projects v2 workflow), move the local
+   * `pipeline_status` to `'completed'` — but only from terminal or
+   * not-yet-started source states. In-flight statuses
+   * (planning/reviewing/revising/executing/verifying/shipping) are left alone
+   * so the pipeline writer never races with this flip. The SQL guard makes
+   * the operation race-safe without locks.
+   *
+   * Returns `true` iff a row was updated.
+   */
+  markCompletedOnClose(id: string): boolean {
+    const result = this.db
+      .prepare(
+        `UPDATE github_issue_cache
+           SET pipeline_status = 'completed', last_phase_update = ${ISO_NOW_SQL}
+         WHERE id = ?
+           AND pipeline_status IN ('todo','queued','awaiting_approval','failed')`,
+      )
+      .run(id);
+    return Number(result.changes) > 0;
+  }
+
+  /**
+   * Symmetric partner to `markCompletedOnClose`: when a GH issue is reopened,
+   * walk the local `pipeline_status` back from `'completed'` to `'todo'` so
+   * the user can re-run the pipeline. Leaves any non-completed status
+   * untouched (the pipeline might have advanced independently).
+   *
+   * Returns `true` iff a row was updated.
+   */
+  markReopenedOnOpen(id: string): boolean {
+    const result = this.db
+      .prepare(
+        `UPDATE github_issue_cache
+           SET pipeline_status = 'todo', last_phase_update = NULL
+         WHERE id = ?
+           AND pipeline_status = 'completed'`,
+      )
+      .run(id);
+    return Number(result.changes) > 0;
   }
 
   linkThread(id: string, threadId: string): void {
@@ -89,7 +138,7 @@ export class GitHubIssueQueries {
   tryClaim(id: string, instanceId: string): boolean {
     const result = this.db
       .prepare(
-        "UPDATE github_issue_cache SET claimed_at = datetime('now'), claimed_by = ?, last_phase_update = datetime('now') WHERE id = ? AND claimed_at IS NULL",
+        `UPDATE github_issue_cache SET claimed_at = ${ISO_NOW_SQL}, claimed_by = ?, last_phase_update = ${ISO_NOW_SQL} WHERE id = ? AND claimed_at IS NULL`,
       )
       .run(instanceId, id);
     return Number(result.changes) > 0;
@@ -107,7 +156,7 @@ export class GitHubIssueQueries {
     const thresholdSec = Math.floor(olderThanMs / 1000);
     const rows = this.db
       .prepare(
-        "SELECT * FROM github_issue_cache WHERE claimed_at IS NOT NULL AND last_phase_update IS NOT NULL AND last_phase_update < datetime('now', '-' || ? || ' seconds')",
+        `SELECT * FROM github_issue_cache WHERE claimed_at IS NOT NULL AND last_phase_update IS NOT NULL AND last_phase_update < strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-' || ? || ' seconds')`,
       )
       .all(thresholdSec) as any[];
     return rows.map((r) => this.toRecord(r));
@@ -125,7 +174,7 @@ export class GitHubIssueQueries {
   getOrphanedClaims(): GitHubIssueCacheRecord[] {
     const rows = this.db
       .prepare(
-        "SELECT * FROM github_issue_cache WHERE claimed_at IS NOT NULL AND thread_id IS NULL AND claimed_at < datetime('now', '-5 minutes')",
+        `SELECT * FROM github_issue_cache WHERE claimed_at IS NOT NULL AND thread_id IS NULL AND claimed_at < strftime('%Y-%m-%dT%H:%M:%fZ', 'now', '-5 minutes')`,
       )
       .all() as any[];
     return rows.map((r) => this.toRecord(r));
@@ -133,7 +182,7 @@ export class GitHubIssueQueries {
 
   refreshHeartbeat(id: string): void {
     this.db
-      .prepare("UPDATE github_issue_cache SET last_phase_update = datetime('now') WHERE id = ?")
+      .prepare(`UPDATE github_issue_cache SET last_phase_update = ${ISO_NOW_SQL} WHERE id = ?`)
       .run(id);
   }
 
@@ -159,9 +208,9 @@ export class GitHubIssueQueries {
       state: row.state,
       pipelineStatus: row.pipeline_status,
       threadId: row.thread_id,
-      claimedAt: row.claimed_at,
+      claimedAt: toIsoUtc(row.claimed_at),
       claimedBy: row.claimed_by,
-      lastPhaseUpdate: row.last_phase_update,
+      lastPhaseUpdate: toIsoUtc(row.last_phase_update),
       lastStatusLabel: row.last_status_label ?? null,
       executorModel:
         row.executor_model === 'codex'
@@ -169,7 +218,7 @@ export class GitHubIssueQueries {
           : row.executor_model === 'openrouter'
             ? 'openrouter'
             : 'claude',
-      fetchedAt: row.fetched_at,
+      fetchedAt: toIsoUtc(row.fetched_at) ?? row.fetched_at,
     };
   }
 }

--- a/packages/db/src/queries/notifications.ts
+++ b/packages/db/src/queries/notifications.ts
@@ -1,6 +1,11 @@
 import type { DatabaseSync } from 'node:sqlite';
 import { nanoid } from 'nanoid';
-import type { NotificationRecord, NotificationKind } from '@shipcode/shared';
+import {
+  ISO_NOW_SQL,
+  toIsoUtc,
+  type NotificationRecord,
+  type NotificationKind,
+} from '@shipcode/shared';
 
 function mapRow(row: any): NotificationRecord {
   return {
@@ -10,8 +15,8 @@ function mapRow(row: any): NotificationRecord {
     kind: row.kind as NotificationKind,
     title: row.title,
     body: row.body,
-    createdAt: row.created_at,
-    dismissedAt: row.dismissed_at,
+    createdAt: toIsoUtc(row.created_at) ?? row.created_at,
+    dismissedAt: toIsoUtc(row.dismissed_at),
   };
 }
 
@@ -58,14 +63,22 @@ export class NotificationsQueries {
   dismiss(id: string): void {
     this.db
       .prepare(
-        `UPDATE notifications SET dismissed_at = datetime('now') WHERE id = ? AND dismissed_at IS NULL`,
+        `UPDATE notifications SET dismissed_at = ${ISO_NOW_SQL} WHERE id = ? AND dismissed_at IS NULL`,
       )
       .run(id);
   }
 
+  dismissByThread(threadId: string): void {
+    this.db
+      .prepare(
+        `UPDATE notifications SET dismissed_at = ${ISO_NOW_SQL} WHERE thread_id = ? AND dismissed_at IS NULL`,
+      )
+      .run(threadId);
+  }
+
   dismissAll(): void {
     this.db
-      .prepare(`UPDATE notifications SET dismissed_at = datetime('now') WHERE dismissed_at IS NULL`)
+      .prepare(`UPDATE notifications SET dismissed_at = ${ISO_NOW_SQL} WHERE dismissed_at IS NULL`)
       .run();
   }
 

--- a/packages/db/src/queries/plans.ts
+++ b/packages/db/src/queries/plans.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite';
 import { nanoid } from 'nanoid';
-import type { PlanRecord, PlanStatus, ShipCodePlan } from '@shipcode/shared';
+import { toIsoUtc, type PlanRecord, type PlanStatus, type ShipCodePlan } from '@shipcode/shared';
 
 export class PlanQueries {
   constructor(private db: DatabaseSync) {}
@@ -78,6 +78,6 @@ function mapPlan(row: any): PlanRecord {
     rawOutput: row.raw_output,
     structured: row.structured ? JSON.parse(row.structured) : null,
     status: row.status as PlanStatus,
-    createdAt: row.created_at,
+    createdAt: toIsoUtc(row.created_at) ?? row.created_at,
   };
 }

--- a/packages/db/src/queries/projects.ts
+++ b/packages/db/src/queries/projects.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite';
 import { nanoid } from 'nanoid';
-import type { Project } from '@shipcode/shared';
+import { ISO_NOW_SQL, toIsoUtc, type Project } from '@shipcode/shared';
 import path from 'node:path';
 
 export class ProjectQueries {
@@ -59,7 +59,7 @@ export class ProjectQueries {
     const existing = this.getByPath(projectPath);
     if (existing) {
       this.db
-        .prepare(`UPDATE projects SET archived = 0, updated_at = datetime('now') WHERE id = ?`)
+        .prepare(`UPDATE projects SET archived = 0, updated_at = ${ISO_NOW_SQL} WHERE id = ?`)
         .run(existing.id);
       return this.getById(existing.id)!;
     }
@@ -171,14 +171,14 @@ export class ProjectQueries {
   updateGitInfo(id: string, gitRemote: string | null, defaultBranch: string): void {
     this.db
       .prepare(
-        `UPDATE projects SET git_remote = ?, default_branch = ?, updated_at = datetime('now') WHERE id = ?`,
+        `UPDATE projects SET git_remote = ?, default_branch = ?, updated_at = ${ISO_NOW_SQL} WHERE id = ?`,
       )
       .run(gitRemote, defaultBranch, id);
   }
 
   updateDefaultBranch(id: string, branch: string): void {
     this.db
-      .prepare(`UPDATE projects SET default_branch = ?, updated_at = datetime('now') WHERE id = ?`)
+      .prepare(`UPDATE projects SET default_branch = ?, updated_at = ${ISO_NOW_SQL} WHERE id = ?`)
       .run(branch, id);
   }
 
@@ -191,7 +191,7 @@ export class ProjectQueries {
   updateGithubProjectUrl(id: string, url: string | null): void {
     this.db
       .prepare(
-        `UPDATE projects SET github_project_url = ?, updated_at = datetime('now') WHERE id = ?`,
+        `UPDATE projects SET github_project_url = ?, updated_at = ${ISO_NOW_SQL} WHERE id = ?`,
       )
       .run(url, id);
   }
@@ -207,7 +207,7 @@ function mapProject(row: any): Project {
     defaultBranch: row.default_branch,
     pinned: row.pinned === 1,
     archived: row.archived === 1,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
+    createdAt: toIsoUtc(row.created_at) ?? row.created_at,
+    updatedAt: toIsoUtc(row.updated_at) ?? row.updated_at,
   };
 }

--- a/packages/db/src/queries/reviews.ts
+++ b/packages/db/src/queries/reviews.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite';
 import { nanoid } from 'nanoid';
-import type { ReviewRecord, PlanReview } from '@shipcode/shared';
+import { toIsoUtc, type ReviewRecord, type PlanReview } from '@shipcode/shared';
 
 export class ReviewQueries {
   constructor(private db: DatabaseSync) {}
@@ -48,6 +48,6 @@ function mapReview(row: any): ReviewRecord {
     confidence: row.confidence,
     rawOutput: row.raw_output,
     structured: row.structured ? JSON.parse(row.structured) : null,
-    createdAt: row.created_at,
+    createdAt: toIsoUtc(row.created_at) ?? row.created_at,
   };
 }

--- a/packages/db/src/queries/skills.ts
+++ b/packages/db/src/queries/skills.ts
@@ -1,5 +1,5 @@
 import type { DatabaseSync } from 'node:sqlite';
-import { type PhaseSkillKey } from '@shipcode/shared';
+import { ISO_NOW_SQL, toIsoUtc, type PhaseSkillKey } from '@shipcode/shared';
 
 export type { PhaseSkillKey };
 
@@ -23,7 +23,7 @@ function mapRow(row: any): SkillRow {
     schemaVersion: row.schema_version,
     status: row.status as 'ok' | 'quarantined',
     statusReason: row.status_reason,
-    updatedAt: row.updated_at,
+    updatedAt: toIsoUtc(row.updated_at) ?? row.updated_at,
   };
 }
 
@@ -66,7 +66,7 @@ export class SkillsQueries {
           `UPDATE skills
            SET content = ?, base_version = ?, schema_version = ?,
                status = 'ok', status_reason = NULL,
-               updated_at = datetime('now')
+               updated_at = ${ISO_NOW_SQL}
            WHERE COALESCE(project_id, '') = COALESCE(?, '')
              AND phase = ?`,
         )
@@ -105,7 +105,7 @@ export class SkillsQueries {
     this.db
       .prepare(
         `UPDATE skills
-         SET status = 'quarantined', status_reason = ?, updated_at = datetime('now')
+         SET status = 'quarantined', status_reason = ?, updated_at = ${ISO_NOW_SQL}
          WHERE COALESCE(project_id, '') = COALESCE(?, '')
            AND phase = ?`,
       )

--- a/packages/db/src/queries/threads.ts
+++ b/packages/db/src/queries/threads.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite';
 import { nanoid } from 'nanoid';
-import type { Thread, ThreadStatus } from '@shipcode/shared';
+import { ISO_NOW_SQL, toIsoUtc, type Thread, type ThreadStatus } from '@shipcode/shared';
 
 export class ThreadQueries {
   constructor(private db: DatabaseSync) {}
@@ -35,12 +35,12 @@ export class ThreadQueries {
     if (lastError !== undefined) {
       this.db
         .prepare(
-          `UPDATE threads SET status = ?, last_error = ?, updated_at = datetime('now') WHERE id = ?`,
+          `UPDATE threads SET status = ?, last_error = ?, updated_at = ${ISO_NOW_SQL} WHERE id = ?`,
         )
         .run(status, lastError, id);
     } else {
       this.db
-        .prepare(`UPDATE threads SET status = ?, updated_at = datetime('now') WHERE id = ?`)
+        .prepare(`UPDATE threads SET status = ?, updated_at = ${ISO_NOW_SQL} WHERE id = ?`)
         .run(status, id);
     }
   }
@@ -48,7 +48,7 @@ export class ThreadQueries {
   setWorktree(id: string, branch: string, worktreePath: string): void {
     this.db
       .prepare(
-        `UPDATE threads SET worktree_branch = ?, worktree_path = ?, updated_at = datetime('now') WHERE id = ?`,
+        `UPDATE threads SET worktree_branch = ?, worktree_path = ?, updated_at = ${ISO_NOW_SQL} WHERE id = ?`,
       )
       .run(branch, worktreePath, id);
   }
@@ -56,7 +56,7 @@ export class ThreadQueries {
   clearWorktree(id: string): void {
     this.db
       .prepare(
-        `UPDATE threads SET worktree_branch = NULL, worktree_path = NULL, updated_at = datetime('now') WHERE id = ?`,
+        `UPDATE threads SET worktree_branch = NULL, worktree_path = NULL, updated_at = ${ISO_NOW_SQL} WHERE id = ?`,
       )
       .run(id);
   }
@@ -73,7 +73,7 @@ export class ThreadQueries {
   ): void {
     this.db
       .prepare(
-        "UPDATE threads SET autonomous = ?, review_round = ?, executor_model = ?, base_branch = ?, fork_point_sha = ?, updated_at = datetime('now') WHERE id = ?",
+        `UPDATE threads SET autonomous = ?, review_round = ?, executor_model = ?, base_branch = ?, fork_point_sha = ?, updated_at = ${ISO_NOW_SQL} WHERE id = ?`,
       )
       .run(
         fields.autonomous ? 1 : 0,
@@ -88,7 +88,7 @@ export class ThreadQueries {
   incrementReviewRound(id: string): void {
     this.db
       .prepare(
-        "UPDATE threads SET review_round = review_round + 1, updated_at = datetime('now') WHERE id = ?",
+        `UPDATE threads SET review_round = review_round + 1, updated_at = ${ISO_NOW_SQL} WHERE id = ?`,
       )
       .run(id);
   }
@@ -96,7 +96,7 @@ export class ThreadQueries {
   setVerificationStatus(id: string, status: string): void {
     this.db
       .prepare(
-        "UPDATE threads SET verification_status = ?, updated_at = datetime('now') WHERE id = ?",
+        `UPDATE threads SET verification_status = ?, updated_at = ${ISO_NOW_SQL} WHERE id = ?`,
       )
       .run(status, id);
   }
@@ -104,14 +104,14 @@ export class ThreadQueries {
   setGithubIssue(id: string, issueNumber: number, repo: string | null): void {
     this.db
       .prepare(
-        "UPDATE threads SET github_issue_number = ?, github_repo = ?, updated_at = datetime('now') WHERE id = ?",
+        `UPDATE threads SET github_issue_number = ?, github_repo = ?, updated_at = ${ISO_NOW_SQL} WHERE id = ?`,
       )
       .run(issueNumber, repo, id);
   }
 
   setGithubPr(id: string, prNumber: number): void {
     this.db
-      .prepare("UPDATE threads SET github_pr_number = ?, updated_at = datetime('now') WHERE id = ?")
+      .prepare(`UPDATE threads SET github_pr_number = ?, updated_at = ${ISO_NOW_SQL} WHERE id = ?`)
       .run(prNumber, id);
   }
 
@@ -141,7 +141,7 @@ export class ThreadQueries {
       }
     })();
     this.db
-      .prepare(`UPDATE threads SET ${column} = ?, updated_at = datetime('now') WHERE id = ?`)
+      .prepare(`UPDATE threads SET ${column} = ?, updated_at = ${ISO_NOW_SQL} WHERE id = ?`)
       .run(model, id);
   }
 
@@ -157,7 +157,7 @@ export class ThreadQueries {
          total_tokens_prompt = total_tokens_prompt + ?,
          total_tokens_completion = total_tokens_completion + ?,
          total_cost_usd = total_cost_usd + ?,
-         updated_at = datetime('now')
+         updated_at = ${ISO_NOW_SQL}
        WHERE id = ?`,
       )
       .run(promptTokens, completionTokens, costUsd, id);
@@ -215,8 +215,8 @@ function mapThread(row: any): Thread {
     githubPrNumber: row.github_pr_number ?? null,
     githubRepo: row.github_repo ?? null,
     lastError: row.last_error ?? null,
-    createdAt: row.created_at,
-    updatedAt: row.updated_at,
+    createdAt: toIsoUtc(row.created_at) ?? row.created_at,
+    updatedAt: toIsoUtc(row.updated_at) ?? row.updated_at,
     plannerResolvedModel: row.planner_resolved_model ?? null,
     reviewerResolvedModel: row.reviewer_resolved_model ?? null,
     revisorResolvedModel: row.revisor_resolved_model ?? null,

--- a/packages/db/src/queries/verifications.ts
+++ b/packages/db/src/queries/verifications.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite';
 import { nanoid } from 'nanoid';
-import type { VerificationResult, VerificationRecord } from '@shipcode/shared';
+import { toIsoUtc, type VerificationResult, type VerificationRecord } from '@shipcode/shared';
 
 export class VerificationQueries {
   constructor(private db: DatabaseSync) {}
@@ -53,7 +53,7 @@ export class VerificationQueries {
       structured: row.structured ? JSON.parse(row.structured) : null,
       result: row.result,
       retryCount: row.retry_count,
-      createdAt: row.created_at,
+      createdAt: toIsoUtc(row.created_at) ?? row.created_at,
     };
   }
 }

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -9,8 +9,8 @@ export function migrate(db: DatabaseSync): void {
       path TEXT NOT NULL UNIQUE,
       git_remote TEXT,
       default_branch TEXT NOT NULL DEFAULT 'main',
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
-      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+      updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
     );
 
     CREATE TABLE IF NOT EXISTS threads (
@@ -23,8 +23,8 @@ export function migrate(db: DatabaseSync): void {
       worktree_path TEXT,
       planner_model TEXT NOT NULL DEFAULT 'claude',
       reviewer_model TEXT NOT NULL DEFAULT 'codex',
-      created_at TEXT NOT NULL DEFAULT (datetime('now')),
-      updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+      updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
     );
 
     CREATE TABLE IF NOT EXISTS plans (
@@ -34,7 +34,7 @@ export function migrate(db: DatabaseSync): void {
       raw_output TEXT NOT NULL,
       structured TEXT,
       status TEXT NOT NULL DEFAULT 'draft',
-      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
     );
 
     CREATE TABLE IF NOT EXISTS reviews (
@@ -44,7 +44,7 @@ export function migrate(db: DatabaseSync): void {
       confidence TEXT NOT NULL,
       raw_output TEXT NOT NULL,
       structured TEXT,
-      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
     );
 
     CREATE TABLE IF NOT EXISTS diffs (
@@ -55,7 +55,7 @@ export function migrate(db: DatabaseSync): void {
       diff_content TEXT,
       before_hash TEXT,
       after_hash TEXT,
-      created_at TEXT NOT NULL DEFAULT (datetime('now'))
+      created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
     );
 
     CREATE TABLE IF NOT EXISTS settings (
@@ -112,7 +112,7 @@ export function migrateV2(db: DatabaseSync): void {
         structured TEXT,
         result TEXT NOT NULL,
         retry_count INTEGER NOT NULL DEFAULT 0,
-        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
       );
 
       CREATE INDEX IF NOT EXISTS idx_verifications_thread ON verifications(thread_id);
@@ -131,7 +131,7 @@ export function migrateV2(db: DatabaseSync): void {
         claimed_at TEXT,
         claimed_by TEXT,
         last_phase_update TEXT,
-        fetched_at TEXT NOT NULL DEFAULT (datetime('now')),
+        fetched_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
         UNIQUE(project_id, issue_number)
       );
 
@@ -206,7 +206,7 @@ export function migrateV5(db: DatabaseSync): void {
         title TEXT NOT NULL,
         subtitle TEXT,
         metadata TEXT,
-        created_at TEXT NOT NULL DEFAULT (datetime('now'))
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
       );
 
       CREATE INDEX IF NOT EXISTS idx_activity_created ON activity_log(created_at DESC);
@@ -223,7 +223,7 @@ export function migrateV5(db: DatabaseSync): void {
         kind TEXT NOT NULL,
         title TEXT NOT NULL,
         body TEXT NOT NULL,
-        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
         dismissed_at TEXT
       );
 
@@ -389,7 +389,7 @@ export function migrateV9(db: DatabaseSync): void {
         schema_version INTEGER NOT NULL,
         status         TEXT NOT NULL DEFAULT 'ok',
         status_reason  TEXT,
-        updated_at     TEXT NOT NULL DEFAULT (datetime('now'))
+        updated_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
       );
 
       -- Composite uniqueness: one row per (project_id, phase). NULL project_id

--- a/packages/shared/src/github-url.test.ts
+++ b/packages/shared/src/github-url.test.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { githubProjectsUrl, validateGithubProjectUrl } from './github-url';
+import {
+  githubProjectsUrl,
+  validateGithubProjectUrl,
+  parseGithubProjectUrl,
+} from './github-url';
 
 describe('githubProjectsUrl (with override)', () => {
   it('returns trimmed override when provided', () => {
@@ -121,5 +125,66 @@ describe('validateGithubProjectUrl', () => {
   it('rejects garbage string', () => {
     const r = validateGithubProjectUrl('not a url');
     expect(r.ok).toBe(false);
+  });
+});
+
+describe('parseGithubProjectUrl', () => {
+  it('parses org-scoped Projects v2 URL', () => {
+    expect(parseGithubProjectUrl('https://github.com/orgs/acme/projects/3')).toEqual({
+      ownerType: 'orgs',
+      owner: 'acme',
+      number: 3,
+    });
+  });
+
+  it('parses user-scoped Projects v2 URL', () => {
+    expect(parseGithubProjectUrl('https://github.com/users/alice/projects/12')).toEqual({
+      ownerType: 'users',
+      owner: 'alice',
+      number: 12,
+    });
+  });
+
+  it('tolerates a trailing slash', () => {
+    expect(parseGithubProjectUrl('https://github.com/orgs/acme/projects/3/')).toEqual({
+      ownerType: 'orgs',
+      owner: 'acme',
+      number: 3,
+    });
+  });
+
+  it('preserves original owner case and hyphens', () => {
+    expect(parseGithubProjectUrl('https://github.com/orgs/Acme-Co/projects/3')).toEqual({
+      ownerType: 'orgs',
+      owner: 'Acme-Co',
+      number: 3,
+    });
+  });
+
+  it('returns null for the legacy repo-scoped form', () => {
+    // This is the `<owner>/<repo>/projects/<n>` form: it points at the
+    // repo's "linked Projects" tab, not a Projects v2 board, so the parser
+    // deliberately rejects it even though `validateGithubProjectUrl` accepts
+    // it as an override for the Kanban quick-link button.
+    expect(parseGithubProjectUrl('https://github.com/shipshitdev/shipcode/projects/1')).toBeNull();
+  });
+
+  it('returns null for a non-numeric project number', () => {
+    expect(parseGithubProjectUrl('https://github.com/orgs/acme/projects/abc')).toBeNull();
+  });
+
+  it('returns null when the trailing /<n> segment is missing', () => {
+    expect(parseGithubProjectUrl('https://github.com/orgs/acme/projects')).toBeNull();
+  });
+
+  it('returns null for http (non-https)', () => {
+    expect(parseGithubProjectUrl('http://github.com/orgs/acme/projects/3')).toBeNull();
+  });
+
+  it('returns null for null, undefined, empty, and whitespace inputs', () => {
+    expect(parseGithubProjectUrl(null)).toBeNull();
+    expect(parseGithubProjectUrl(undefined)).toBeNull();
+    expect(parseGithubProjectUrl('')).toBeNull();
+    expect(parseGithubProjectUrl('   ')).toBeNull();
   });
 });

--- a/packages/shared/src/github-url.ts
+++ b/packages/shared/src/github-url.ts
@@ -134,3 +134,68 @@ export function deriveGithubIssueUrl(
   const base = githubRepoUrl(remote);
   return base ? `${base}/issues/${issueNumber}` : null;
 }
+
+export interface ParsedGithubProject {
+  /** Whether the project lives under an organization or a user. */
+  ownerType: 'orgs' | 'users';
+  /** Organization login or user login, preserved in its original case. */
+  owner: string;
+  /** The numeric project number (e.g., 3 from `/projects/3`). */
+  number: number;
+}
+
+/**
+ * Parse a Projects v2 URL into its components so callers can feed
+ * `gh project item-add <number> --owner <owner>`. Returns `null` for any
+ * value that cannot be used with the item-add command, specifically:
+ *
+ *   - null, empty, or whitespace-only strings
+ *   - the legacy repo-scoped form (`<owner>/<repo>/projects/<n>`), which
+ *     points at the repo's "linked Projects" tab — not a Projects v2 board
+ *   - malformed URLs, non-https, or non-github.com hosts
+ *   - non-numeric project numbers
+ *   - URLs missing the `/projects/<n>` trailing segments
+ *
+ * Owner case is preserved (GitHub logins are case-insensitive, and `gh`
+ * handles any needed normalization on its own).
+ *
+ * `validateGithubProjectUrl` already gates save-time input for this
+ * field; the parser is the read-time counterpart that turns a stored
+ * string into something the CLI can use.
+ */
+export function parseGithubProjectUrl(
+  raw: string | null | undefined,
+): ParsedGithubProject | null {
+  if (raw == null) return null;
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+
+  let u: URL;
+  try {
+    u = new URL(trimmed);
+  } catch {
+    return null;
+  }
+
+  if (u.protocol !== 'https:') return null;
+  if (u.hostname.toLowerCase() !== 'github.com') return null;
+
+  const parts = u.pathname.replace(/^\/+/, '').replace(/\/+$/, '').split('/');
+  // orgs/<org>/projects/<n>  or  users/<user>/projects/<n>
+  if (
+    parts.length >= 4 &&
+    (parts[0] === 'orgs' || parts[0] === 'users') &&
+    parts[2] === 'projects' &&
+    /^\d+$/.test(parts[3])
+  ) {
+    return {
+      ownerType: parts[0] as 'orgs' | 'users',
+      owner: parts[1],
+      number: Number.parseInt(parts[3], 10),
+    };
+  }
+  // Legacy repo-scoped form: `<owner>/<repo>/projects/<n>` — cannot be
+  // passed to `gh project item-add`, so treat as unparseable here even
+  // though `validateGithubProjectUrl` accepts it for the quick-link button.
+  return null;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -9,3 +9,4 @@ export * from './branches';
 export * from './github-url';
 export * from './skills-types';
 export * from './errors';
+export * from './sqlite-time';

--- a/packages/shared/src/sqlite-time.ts
+++ b/packages/shared/src/sqlite-time.ts
@@ -1,0 +1,43 @@
+/**
+ * SQLite timestamp helpers.
+ *
+ * SQLite's `datetime('now')` returns a naive wall-clock UTC string like
+ * `"2026-04-11 23:29:00"` — no timezone suffix. When the renderer hands that
+ * to `new Date(str)`, Chrome/V8 parses it as *local* time, not UTC, producing
+ * an elapsed reading equal to the local timezone offset (e.g. every card
+ * stuck at "2h" in UTC+2). To avoid that trap:
+ *
+ * - **Writes:** use {@link ISO_NOW_SQL} instead of `datetime('now')`. It
+ *   stores an explicit ISO-8601 UTC string ending in `Z`, which JavaScript
+ *   parses correctly anywhere.
+ * - **Reads:** pipe stored strings through {@link toIsoUtc} in the mapper.
+ *   It's a no-op for already-tagged strings and retrofits a `Z` onto older
+ *   rows stored with the naive format, so legacy data displays correctly
+ *   without a schema migration.
+ */
+
+/**
+ * SQL fragment that produces an ISO-8601 UTC timestamp with millisecond
+ * precision and an explicit `Z` suffix, e.g. `"2026-04-11T23:29:00.000Z"`.
+ * Use in UPDATE/INSERT statements and schema DEFAULTs in place of
+ * `datetime('now')`.
+ */
+export const ISO_NOW_SQL = "strftime('%Y-%m-%dT%H:%M:%fZ', 'now')";
+
+const HAS_TZ = /[Zz]$|[+-]\d{2}:?\d{2}$/;
+
+/**
+ * Normalize a SQLite timestamp string to an ISO-8601 UTC string that
+ * JavaScript's `Date` constructor will interpret as UTC. Handles three
+ * input shapes:
+ *
+ * - `null`/`undefined` → `null`
+ * - Already ISO with a `Z` or numeric offset → returned as-is
+ * - Naive `"YYYY-MM-DD HH:MM:SS[.fff]"` (SQLite's `datetime('now')` output)
+ *   → `"YYYY-MM-DDTHH:MM:SS[.fff]Z"`
+ */
+export function toIsoUtc(value: string | null | undefined): string | null {
+  if (!value) return null;
+  if (HAS_TZ.test(value)) return value;
+  return `${value.replace(' ', 'T')}Z`;
+}

--- a/packages/ui/src/primitives/dialog.tsx
+++ b/packages/ui/src/primitives/dialog.tsx
@@ -18,7 +18,7 @@ function DialogOverlay({
   return (
     <DialogPrimitive.Overlay
       className={cn(
-        'fixed inset-0 z-50 bg-black/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        'fixed inset-0 z-50 bg-black/70 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
         className,
       )}
       {...props}


### PR DESCRIPTION
## Summary

Bundles several cohesive changes that had accumulated in the working tree. Splitting into narrower PRs would require cherry-picking entangled hunks in \`packages/db/src/queries/github-issues.ts\` and a few other shared files, so shipping together.

### What's in here

- **SQLite UTC timestamp fix.** New \`@shipcode/shared/sqlite-time\` helper exposes \`ISO_NOW_SQL\` and \`toIsoUtc\`. Schema DEFAULT clauses and all query UPDATE/INSERT sites switched from \`datetime('now')\` to the explicit ISO-with-Z form. Legacy rows are retrofitted at read time via \`toIsoUtc\` so no migration is required. Fixes the "everything is stuck at 2h" bug caused by V8 parsing SQLite's naive wall-clock strings as local time instead of UTC.
- **Projects v2 board attach on issue creation.** \`parseGithubProjectUrl\` lives in \`@shipcode/shared/github-url\` (tested), \`GhCli.addIssueToProject\` is a thin wrapper around \`gh project item-add\`, and the \`github:create-issue\` IPC handler invokes it behind a best-effort guard. \`CreateIssueModal\` handles the new \`{ issue, projectAttachWarning }\` response shape and surfaces the warning inline — issue creation never blocks on board attachment failure.
- **External GH issue state sync.** New \`markCompletedOnClose\` / \`markReopenedOnOpen\` queries with SQL guards that make the operation race-safe against the pipeline writer. \`gh issue list\` bumped to \`--state all --limit 200\` so we see closed issues.
- **Stream parser fence fix.** Require a newline before the closing fence so nested \`\`\`ts blocks inside JSON string values don't terminate the match early (the planner was occasionally producing this).
- **Dialog overlay polish.** \`bg-black/70 backdrop-blur-sm\` for a stronger focus on modals.
- **Notification service.** New \`dismissByThread\` + pipeline-bridge call on transition into \`planning\` to clear stale \`failed\` notifications on re-run.
- **Session log** for 2026-04-11.

Also updates \`gh-cli.test.ts\` to match the new \`--limit 200\`.

## CI note

Pre-existing lint failures in \`apps/web\` (last touched in 260c588 — unsorted imports + a biome tailwindDirectives config gap) will fail CI. Those are out of scope here and will be fixed next via the \`develop\` branch.

## Test plan

- [x] \`bun run typecheck\` — green across all 14 packages
- [x] \`bun run test\` — 24/24 @shipcode/desktop, 256/256 @shipcode/agents (after the \`--limit 200\` test update), full suite passes
- [ ] Manual: create an issue in a project with a Projects v2 URL set; confirm it lands on the board. Break the URL and confirm the inline warning appears.
- [ ] Manual: close an issue in GitHub web UI; refresh; confirm the local \`pipeline_status\` flips to \`completed\`.
- [ ] Manual: confirm timestamps on existing cards now read correctly regardless of user timezone.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added GitHub Projects v2 board integration—newly created issues can now be attached directly to projects.
  * Enhanced issue synchronization between Kanban and GitHub when issues are closed or reopened.
  * Added thread-based notification dismissal for improved notification management.

* **Improvements**
  * Expanded issue fetching to retrieve all issue states, not just open ones.
  * Improved timestamp consistency across the application.

* **Bug Fixes**
  * Fixed output block parsing for better data extraction.

* **UI/UX**
  * Improved dialog overlay visibility with a darker, blurred background.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->