### PR TITLE
chore: sync lint cleanup from develop

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,6 +93,13 @@ jobs:
   publish-cli:
     if: ${{ inputs.publish_cli }}
     runs-on: ubuntu-latest
+    # id-token: write is required for npm Trusted Publishers (OIDC).
+    # contents: read is required for actions/checkout. The job-level
+    # permissions block fully replaces the top-level, so we re-declare
+    # contents: read explicitly.
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
@@ -110,10 +117,13 @@ jobs:
           VERSION="${{ inputs.release_tag }}"
           VERSION="${VERSION#v}"
           cd apps/cli && npm version "$VERSION" --no-git-tag-version
-      - name: Publish to npm
-        run: cd apps/cli && npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm (OIDC / Trusted Publisher)
+        run: cd apps/cli && npm publish --access public --provenance
+        # No NODE_AUTH_TOKEN. Authentication happens via OIDC — the npm
+        # registry verifies the GitHub Actions ID token against the
+        # Trusted Publisher config on the package. One-time setup at
+        # https://www.npmjs.com/package/@shipshitdev/shipcode/access
+        # (Repository: shipshitdev/shipcode, Workflow: release.yml).
 
 # ─────────────────────────────────────────────────────────────────
 # DISABLED until Apple codesigning + notarization are wired.

--- a/apps/web/app/components/FeatureGrid.tsx
+++ b/apps/web/app/components/FeatureGrid.tsx
@@ -1,4 +1,4 @@
-import { Shield, GitBranch, CheckCircle, Shuffle } from 'lucide-react';
+import { CheckCircle, GitBranch, Shield, Shuffle } from 'lucide-react';
 
 const features = [
   {

--- a/apps/web/app/components/HowItWorks.tsx
+++ b/apps/web/app/components/HowItWorks.tsx
@@ -1,6 +1,6 @@
-import { Fragment } from 'react';
-import { ArrowRight, Tag, FileText, Search, Play, GitPullRequest } from 'lucide-react';
 import { Card } from '@shipcode/ui';
+import { ArrowRight, FileText, GitPullRequest, Play, Search, Tag } from 'lucide-react';
+import { Fragment } from 'react';
 
 const steps = [
   {

--- a/apps/web/app/components/InstallCommand.tsx
+++ b/apps/web/app/components/InstallCommand.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useState } from 'react';
 import { Button } from '@shipcode/ui';
+import { useState } from 'react';
 
 const INSTALL_COMMAND = 'npx @shipshitdev/shipcode';
 

--- a/apps/web/app/globals.css
+++ b/apps/web/app/globals.css
@@ -3,57 +3,76 @@
 @source "../../../packages/ui/src/**/*.{ts,tsx}";
 
 :root {
-	--bg-primary: #0d1117;
-	--bg-secondary: #161b22;
-	--bg-tertiary: #21262d;
-	--bg-hover: #30363d;
-	--text-primary: #e6edf3;
-	--text-secondary: #8b949e;
-	--text-muted: #484f58;
+  --bg-primary: #0d1117;
+  --bg-secondary: #161b22;
+  --bg-tertiary: #21262d;
+  --bg-hover: #30363d;
+  --text-primary: #e6edf3;
+  --text-secondary: #8b949e;
+  --text-muted: #484f58;
 }
 
 @theme {
-	--color-border: #30363d;
-	--color-accent: #58a6ff;
-	--color-accent-hover: #79c0ff;
-	--color-success: #3fb950;
-	--color-warning: #d29922;
-	--color-danger: #f85149;
-	--font-sans: 'Inter', system-ui, sans-serif;
-	--font-mono: 'JetBrains Mono', 'SF Mono', 'Fira Code', monospace;
+  --color-border: #30363d;
+  --color-accent: #58a6ff;
+  --color-accent-hover: #79c0ff;
+  --color-success: #3fb950;
+  --color-warning: #d29922;
+  --color-danger: #f85149;
+  --font-sans: "Inter", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", "SF Mono", "Fira Code", monospace;
 }
 
-@utility bg-primary { background-color: var(--bg-primary); }
-@utility bg-secondary { background-color: var(--bg-secondary); }
-@utility bg-tertiary { background-color: var(--bg-tertiary); }
-@utility bg-hover { background-color: var(--bg-hover); }
-@utility text-primary { color: var(--text-primary); }
-@utility text-secondary { color: var(--text-secondary); }
-@utility text-muted { color: var(--text-muted); }
+@utility bg-primary {
+  background-color: var(--bg-primary);
+}
+@utility bg-secondary {
+  background-color: var(--bg-secondary);
+}
+@utility bg-tertiary {
+  background-color: var(--bg-tertiary);
+}
+@utility bg-hover {
+  background-color: var(--bg-hover);
+}
+@utility text-primary {
+  color: var(--text-primary);
+}
+@utility text-secondary {
+  color: var(--text-secondary);
+}
+@utility text-muted {
+  color: var(--text-muted);
+}
 
 @keyframes blink {
-	0%, 100% { opacity: 1; }
-	50% { opacity: 0; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
 }
 
 @keyframes fadeInUp {
-	from {
-		opacity: 0;
-		transform: translateY(20px);
-	}
-	to {
-		opacity: 1;
-		transform: translateY(0);
-	}
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 @keyframes slideIn {
-	from {
-		opacity: 0;
-		transform: translateX(-10px);
-	}
-	to {
-		opacity: 1;
-		transform: translateX(0);
-	}
+  from {
+    opacity: 0;
+    transform: translateX(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
 }

--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -1,12 +1,12 @@
-import { Header } from './components/Header';
-import { Hero } from './components/Hero';
-import { InstallCommand } from './components/InstallCommand';
-import { PlanReviewLoop } from './components/PlanReviewLoop';
-import { HowItWorks } from './components/HowItWorks';
-import { FeatureGrid } from './components/FeatureGrid';
 import { CodeWindow } from './components/CodeWindow';
 import { CTASection } from './components/CTASection';
+import { FeatureGrid } from './components/FeatureGrid';
 import { Footer } from './components/Footer';
+import { Header } from './components/Header';
+import { Hero } from './components/Hero';
+import { HowItWorks } from './components/HowItWorks';
+import { InstallCommand } from './components/InstallCommand';
+import { PlanReviewLoop } from './components/PlanReviewLoop';
 
 export default function Home() {
   return (

--- a/biome.json
+++ b/biome.json
@@ -16,7 +16,8 @@
       "!**/.env.*",
       "!.agents",
       "!.worktrees",
-      "!.shipcode"
+      "!.shipcode",
+      "!apps/web/public/docs"
     ]
   },
   "formatter": {
@@ -33,6 +34,12 @@
     },
     "parser": {
       "unsafeParameterDecoratorsEnabled": true
+    }
+  },
+  "css": {
+    "parser": {
+      "cssModules": true,
+      "tailwindDirectives": true
     }
   },
   "linter": {

--- a/packages/ui/src/DiffViewer.tsx
+++ b/packages/ui/src/DiffViewer.tsx
@@ -1,7 +1,7 @@
 import type { DiffRecord } from '@shipcode/shared';
+import { cn } from './lib/utils';
 import { Badge } from './primitives/badge';
 import { Button } from './primitives/button';
-import { cn } from './lib/utils';
 
 interface DiffViewerProps {
   diffs: DiffRecord[];
@@ -83,6 +83,7 @@ export function DiffViewer({ diffs, activeFile, onFileSelect }: DiffViewerProps)
 
                   return (
                     <div
+                      // biome-ignore lint/suspicious/noArrayIndexKey: diff lines have stable order; blank lines repeat so index is the only unique key
                       key={i}
                       className={cn(
                         'px-3',

--- a/packages/ui/src/IssueCard.tsx
+++ b/packages/ui/src/IssueCard.tsx
@@ -13,8 +13,9 @@ interface IssueCardProps {
 
 export function IssueCard({ issue, onClick }: IssueCardProps) {
   return (
-    <div
-      className="rounded-md border border-border bg-primary p-3 cursor-pointer hover:border-text-muted transition-colors"
+    <button
+      type="button"
+      className="w-full text-left rounded-md border border-border bg-primary p-3 cursor-pointer hover:border-text-muted transition-colors"
       onClick={onClick}
     >
       <div className="flex items-center justify-between">
@@ -34,6 +35,6 @@ export function IssueCard({ issue, onClick }: IssueCardProps) {
             </Badge>
           ))}
       </div>
-    </div>
+    </button>
   );
 }

--- a/packages/ui/src/KanbanBoard.tsx
+++ b/packages/ui/src/KanbanBoard.tsx
@@ -1,22 +1,31 @@
 'use client';
 
-import { useEffect, useState, type ReactNode } from 'react';
-import { ChevronDown, ChevronRight, ExternalLink, LayoutGrid, LayoutList, RefreshCw, RotateCcw, User } from 'lucide-react';
 import {
+  type CollisionDetection,
   DndContext,
+  type DragEndEvent,
   DragOverlay,
+  type DragStartEvent,
   pointerWithin,
   rectIntersection,
-  type CollisionDetection,
-  type DragEndEvent,
-  type DragStartEvent,
+  useDraggable,
+  useDroppable,
 } from '@dnd-kit/core';
-import { useDroppable } from '@dnd-kit/core';
-import { useDraggable } from '@dnd-kit/core';
 import type { GitHubIssueCacheRecord, IssuePipelineStatus } from '@shipcode/shared';
-import { cn } from './lib/utils';
-import { getStatusBadgeVariant } from './lib/status-variant';
+import {
+  ChevronDown,
+  ChevronRight,
+  ExternalLink,
+  LayoutGrid,
+  LayoutList,
+  RefreshCw,
+  RotateCcw,
+  User,
+} from 'lucide-react';
+import { type ReactNode, useEffect, useState } from 'react';
 import { MODEL_DISPLAY } from './lib/model-display';
+import { getStatusBadgeVariant } from './lib/status-variant';
+import { cn } from './lib/utils';
 import { Badge } from './primitives/badge';
 import { Button, buttonVariants } from './primitives/button';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './primitives/select';
@@ -191,9 +200,7 @@ function PhaseElapsed({ since }: { since: number }) {
     const id = setInterval(() => setLabel(formatPhaseElapsed(since)), 1000);
     return () => clearInterval(id);
   }, [since]);
-  return (
-    <span className="font-mono tabular-nums text-[10px] text-muted">{label}</span>
-  );
+  return <span className="font-mono tabular-nums text-[10px] text-muted">{label}</span>;
 }
 
 function DraggableCard({
@@ -219,9 +226,12 @@ function DraggableCard({
   const isActive = ACTIVE_STATUSES.includes(issue.pipelineStatus);
   const showPhaseElapsed =
     PHASE_ELAPSED_STATUSES.includes(issue.pipelineStatus) && !!issue.lastPhaseUpdate;
-  const phaseSince = showPhaseElapsed ? new Date(issue.lastPhaseUpdate!).getTime() : 0;
+  const phaseSince =
+    showPhaseElapsed && issue.lastPhaseUpdate ? new Date(issue.lastPhaseUpdate).getTime() : 0;
 
   return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: dnd-kit's useDraggable provides keyboard accessibility via listeners/attributes spread below
+    // biome-ignore lint/a11y/useKeyWithClickEvents: dnd-kit KeyboardSensor handles activation; the onClick only forwards selection on pointer click
     <div
       ref={setNodeRef}
       className={cn(
@@ -232,8 +242,14 @@ function DraggableCard({
           : !isSelected && !isActive
             ? 'border-border/50 hover:border-border-strong'
             : '',
-        isFailed && (isSelected ? 'border-danger bg-danger/[0.07]' : 'border-danger/40 bg-danger/[0.04] hover:border-danger/60'),
-        isAwaiting && (isSelected ? 'border-warning bg-warning/[0.07]' : 'border-warning/30 bg-warning/[0.03] hover:border-warning/50'),
+        isFailed &&
+          (isSelected
+            ? 'border-danger bg-danger/[0.07]'
+            : 'border-danger/40 bg-danger/[0.04] hover:border-danger/60'),
+        isAwaiting &&
+          (isSelected
+            ? 'border-warning bg-warning/[0.07]'
+            : 'border-warning/30 bg-warning/[0.03] hover:border-warning/50'),
         // Agent-active cards use the dedicated `--agent` violet so they are
         // visually distinct from failed (red), awaiting (amber), and selected
         // (white). Lower opacity than failed/awaiting because agent work is
@@ -549,8 +565,8 @@ const LIST_COLUMN_LABEL: Record<ColumnKey, string> = {
 // ids `handleDragEnd` recognizes lets the existing transitions still fire from
 // the list view without touching pipeline code.
 const LIST_COLUMN_DROP_ID: Partial<Record<ColumnKey, string>> = {
-  todo: 'todo',                // failed → todo (retry)
-  agent: 'agent:planning',     // todo|failed → agent:planning (start/rerun)
+  todo: 'todo', // failed → todo (retry)
+  agent: 'agent:planning', // todo|failed → agent:planning (start/rerun)
 };
 
 type RowTone = 'default' | 'agent' | 'danger' | 'warning';
@@ -563,7 +579,11 @@ function rowToneFor(status: IssuePipelineStatus): RowTone {
 }
 
 function formatDate(iso: string): string {
-  return new Date(iso).toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  return new Date(iso).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
 }
 
 interface DraggableListRowProps {
@@ -573,7 +593,12 @@ interface DraggableListRowProps {
   onIssueClick: (issue: GitHubIssueCacheRecord) => void;
 }
 
-function DraggableListRow({ issue, selectedIssueNumber, activeId, onIssueClick }: DraggableListRowProps) {
+function DraggableListRow({
+  issue,
+  selectedIssueNumber,
+  activeId,
+  onIssueClick,
+}: DraggableListRowProps) {
   const isDraggable = DRAGGABLE_STATUSES.includes(issue.pipelineStatus);
   const { attributes, listeners, setNodeRef, isDragging } = useDraggable({
     id: issue.id,
@@ -585,6 +610,8 @@ function DraggableListRow({ issue, selectedIssueNumber, activeId, onIssueClick }
   const isActive = tone === 'agent';
 
   return (
+    // biome-ignore lint/a11y/noStaticElementInteractions: dnd-kit's useDraggable provides keyboard accessibility via listeners/attributes spread below
+    // biome-ignore lint/a11y/useKeyWithClickEvents: dnd-kit KeyboardSensor handles activation; the onClick only forwards selection on pointer click
     <div
       ref={setNodeRef}
       className={cn(
@@ -666,8 +693,8 @@ function ListSectionBlock({
   const agentLabel =
     section.agent === 'executor'
       ? (issues[0]?.executorModel ??
-         allIssues.find((i) => i.pipelineStatus === 'executing')?.executorModel ??
-         'claude')
+        allIssues.find((i) => i.pipelineStatus === 'executing')?.executorModel ??
+        'claude')
       : section.agent;
 
   const tone: 'danger' | 'warning' | null =
@@ -750,7 +777,12 @@ interface IssueListViewProps {
   onIssueClick: (issue: GitHubIssueCacheRecord) => void;
 }
 
-function IssueListView({ issues, selectedIssueNumber, activeId, onIssueClick }: IssueListViewProps) {
+function IssueListView({
+  issues,
+  selectedIssueNumber,
+  activeId,
+  onIssueClick,
+}: IssueListViewProps) {
   const [collapsed, setCollapsed] = useState<Record<string, boolean>>({});
   const toggle = (key: string) => setCollapsed((c) => ({ ...c, [key]: !c[key] }));
 
@@ -878,7 +910,7 @@ export function KanbanBoard({
       issue.pipelineStatus === 'failed' &&
       (onRerun ?? onStartPipeline)
     ) {
-      (onRerun ?? onStartPipeline)!(issue);
+      (onRerun ?? onStartPipeline)?.(issue);
       return;
     }
     // 3. human → todo (retry failed → reset to queued)
@@ -935,7 +967,9 @@ export function KanbanBoard({
           {baseBranch && branches && branches.length > 0 && onBaseBranchChange && (
             <div className="flex items-center min-w-0 max-w-[200px] shrink-0">
               <Select value={baseBranch} onValueChange={onBaseBranchChange}>
-                <SelectTrigger className={cn(buttonVariants({ variant: 'pill', size: 'xs' }), 'font-mono')}>
+                <SelectTrigger
+                  className={cn(buttonVariants({ variant: 'pill', size: 'xs' }), 'font-mono')}
+                >
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
@@ -952,10 +986,7 @@ export function KanbanBoard({
             <Button
               variant="ghost"
               size="icon-sm"
-              className={cn(
-                'rounded-none',
-                view === 'list' && 'bg-secondary text-primary',
-              )}
+              className={cn('rounded-none', view === 'list' && 'bg-secondary text-primary')}
               onClick={() => setView('list')}
               title="List view"
             >
@@ -974,12 +1005,7 @@ export function KanbanBoard({
               <LayoutGrid size={14} />
             </Button>
           </div>
-          <Button
-            variant="outline"
-            size="icon-sm"
-            onClick={onRefresh}
-            title="Refresh"
-          >
+          <Button variant="outline" size="icon-sm" onClick={onRefresh} title="Refresh">
             <RefreshCw size={14} />
           </Button>
           {onNewIssue && (

--- a/packages/ui/src/PipelineStatus.tsx
+++ b/packages/ui/src/PipelineStatus.tsx
@@ -1,7 +1,7 @@
-import { type PipelinePhase } from '@shipcode/shared';
+import type { PipelinePhase } from '@shipcode/shared';
 import { Check, X } from 'lucide-react';
-import { Button } from './primitives/button';
 import { cn } from './lib/utils';
+import { Button } from './primitives/button';
 
 const PHASES: { key: PipelinePhase; label: string }[] = [
   { key: 'planning', label: 'Plan' },

--- a/packages/ui/src/PlanViewer.tsx
+++ b/packages/ui/src/PlanViewer.tsx
@@ -1,12 +1,9 @@
 import type { ShipCodePlan } from '@shipcode/shared';
 import { Square } from 'lucide-react';
 import { Badge } from './primitives/badge';
-import { cn } from './lib/utils';
 
 interface PlanViewerProps {
   plan: ShipCodePlan | null;
-  isEditable?: boolean;
-  onPlanEdit?: (plan: ShipCodePlan) => void;
 }
 
 const fileActionVariant = (action: string) => {
@@ -24,7 +21,7 @@ const fileActionVariant = (action: string) => {
   }
 };
 
-export function PlanViewer({ plan, isEditable = false, onPlanEdit }: PlanViewerProps) {
+export function PlanViewer({ plan }: PlanViewerProps) {
   if (!plan) {
     return (
       <div className="flex items-center justify-center h-full p-4 text-muted">
@@ -113,8 +110,8 @@ export function PlanViewer({ plan, isEditable = false, onPlanEdit }: PlanViewerP
             Acceptance Criteria
           </h3>
           <ul className="list-none p-0">
-            {plan.acceptanceCriteria.map((criteria, i) => (
-              <li key={i} className="flex items-start gap-2 py-1 text-[13px]">
+            {plan.acceptanceCriteria.map((criteria) => (
+              <li key={criteria} className="flex items-start gap-2 py-1 text-[13px]">
                 <Square size={12} className="mt-1 shrink-0 text-muted" />
                 <span>{criteria}</span>
               </li>
@@ -129,9 +126,9 @@ export function PlanViewer({ plan, isEditable = false, onPlanEdit }: PlanViewerP
             Out of Scope
           </h3>
           <ul className="list-none p-0">
-            {plan.outOfScope.map((item, i) => (
+            {plan.outOfScope.map((item) => (
               <li
-                key={i}
+                key={item}
                 className="py-1 pl-4 text-[13px] relative before:content-['—'] before:absolute before:left-0 before:text-muted"
               >
                 {item}

--- a/packages/ui/src/ReviewViewer.tsx
+++ b/packages/ui/src/ReviewViewer.tsx
@@ -1,6 +1,6 @@
 import type { PlanReview, ReviewFinding } from '@shipcode/shared';
-import { Badge } from './primitives/badge';
 import { cn } from './lib/utils';
+import { Badge } from './primitives/badge';
 
 interface ReviewViewerProps {
   review: PlanReview | null;
@@ -108,8 +108,8 @@ export function ReviewViewer({ review }: ReviewViewerProps) {
             Suggested Changes
           </h3>
           <ul className="list-disc pl-5">
-            {review.suggestedChanges.map((change, i) => (
-              <li key={i} className="py-0.5 text-[13px]">
+            {review.suggestedChanges.map((change) => (
+              <li key={change} className="py-0.5 text-[13px]">
                 {change}
               </li>
             ))}

--- a/packages/ui/src/VerificationViewer.tsx
+++ b/packages/ui/src/VerificationViewer.tsx
@@ -21,9 +21,9 @@ export function VerificationViewer({ verification }: VerificationViewerProps) {
         <div className="space-y-2">
           <h4 className="text-sm font-semibold text-primary">Acceptance Criteria</h4>
           <ul className="space-y-2">
-            {verification.criteriaResults.map((cr, i) => (
+            {verification.criteriaResults.map((cr) => (
               <li
-                key={i}
+                key={cr.criterion}
                 className={cn(
                   'flex gap-2 rounded-md border p-2 text-sm',
                   cr.passed ? 'border-success/30 bg-success/5' : 'border-danger/30 bg-danger/5',
@@ -53,8 +53,11 @@ export function VerificationViewer({ verification }: VerificationViewerProps) {
             Issues ({verification.issues.length})
           </h4>
           <ul className="space-y-1.5">
-            {verification.issues.map((issue, i) => (
-              <li key={i} className="flex items-start gap-2 text-sm text-primary">
+            {verification.issues.map((issue) => (
+              <li
+                key={`${issue.severity}:${issue.description}`}
+                className="flex items-start gap-2 text-sm text-primary"
+              >
                 <Badge
                   variant={
                     issue.severity === 'blocker'

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -1,21 +1,16 @@
-export { cn } from './lib/utils';
-export { getStatusBadgeVariant } from './lib/status-variant';
-export type { StatusBadgeVariant } from './lib/status-variant';
-export { MODEL_DISPLAY, modelDisplay } from './lib/model-display';
-
 // Icons — re-exported from lucide-react so apps import via @shipcode/ui
 export {
   Activity,
   Archive,
   ArrowRight,
-  Bell,
-  Copy,
   ArrowUpDown,
+  Bell,
   Check,
   ChevronDown,
   ChevronLeft,
   ChevronRight,
   ChevronUp,
+  Copy,
   DollarSign,
   ExternalLink,
   Folder,
@@ -24,8 +19,8 @@ export {
   Keyboard,
   Layers,
   LayoutGrid,
-  Lock,
   Loader2,
+  Lock,
   Maximize2,
   Minimize2,
   MoreHorizontal,
@@ -44,11 +39,20 @@ export {
   Wrench,
   X,
 } from 'lucide-react';
-
+export { DiffViewer } from './DiffViewer';
+export { IssueCard } from './IssueCard';
+export { KanbanBoard } from './KanbanBoard';
+export { MODEL_DISPLAY, modelDisplay } from './lib/model-display';
+export type { StatusBadgeVariant } from './lib/status-variant';
+export { getStatusBadgeVariant } from './lib/status-variant';
+export { cn } from './lib/utils';
+// Domain components
+export { PipelineStatus } from './PipelineStatus';
+export { PlanViewer } from './PlanViewer';
+export { Alert, AlertDescription, AlertTitle, alertVariants } from './primitives/alert';
+export { Badge, badgeVariants } from './primitives/badge';
 // Primitives (more added incrementally as tasks need them)
 export { Button, buttonVariants } from './primitives/button';
-export { Input } from './primitives/input';
-export { Badge, badgeVariants } from './primitives/badge';
 export {
   Card,
   CardContent,
@@ -57,30 +61,7 @@ export {
   CardHeader,
   CardTitle,
 } from './primitives/card';
-export { Alert, AlertTitle, AlertDescription, alertVariants } from './primitives/alert';
-export { Label } from './primitives/label';
-export { Textarea } from './primitives/textarea';
-export { Switch } from './primitives/switch';
 export { Checkbox } from './primitives/checkbox';
-export {
-  Table,
-  TableBody,
-  TableCaption,
-  TableCell,
-  TableFooter,
-  TableHead,
-  TableHeader,
-  TableRow,
-} from './primitives/table';
-export {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from './primitives/dialog';
 export {
   Command,
   CommandDialog,
@@ -92,24 +73,40 @@ export {
   CommandSeparator,
   CommandShortcut,
 } from './primitives/command';
-export { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './primitives/select';
+export {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from './primitives/dialog';
 export {
   DropdownMenu,
-  DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuTrigger,
 } from './primitives/dropdown-menu';
-export { Pagination } from './primitives/pagination';
+export { Input } from './primitives/input';
+export { Label } from './primitives/label';
 export type { PaginationProps } from './primitives/pagination';
+export { Pagination } from './primitives/pagination';
+export { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './primitives/select';
 export { SettingsRow } from './primitives/settings-row';
-
-// Domain components
-export { PipelineStatus } from './PipelineStatus';
-export { PlanViewer } from './PlanViewer';
+export { Switch } from './primitives/switch';
+export {
+  Table,
+  TableBody,
+  TableCaption,
+  TableCell,
+  TableFooter,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from './primitives/table';
+export { Textarea } from './primitives/textarea';
 export { ReviewViewer } from './ReviewViewer';
-export { VerificationViewer } from './VerificationViewer';
-export { KanbanBoard } from './KanbanBoard';
-export { IssueCard } from './IssueCard';
-export { DiffViewer } from './DiffViewer';
 export { StatusMappingEditor } from './StatusMappingEditor';
+export { VerificationViewer } from './VerificationViewer';

--- a/packages/ui/src/lib/utils.ts
+++ b/packages/ui/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { clsx, type ClassValue } from 'clsx';
+import { type ClassValue, clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 
 export function cn(...inputs: ClassValue[]) {

--- a/packages/ui/src/primitives/alert.tsx
+++ b/packages/ui/src/primitives/alert.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
+import type * as React from 'react';
 import { cn } from '../lib/utils';
 
 const alertVariants = cva(
@@ -36,4 +36,4 @@ function AlertDescription({ className, ...props }: React.ComponentProps<'div'>) 
   return <div className={cn('text-sm [&_p]:leading-relaxed', className)} {...props} />;
 }
 
-export { Alert, AlertTitle, AlertDescription, alertVariants };
+export { Alert, AlertDescription, AlertTitle, alertVariants };

--- a/packages/ui/src/primitives/badge.tsx
+++ b/packages/ui/src/primitives/badge.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { cva, type VariantProps } from 'class-variance-authority';
+import type * as React from 'react';
 import { cn } from '../lib/utils';
 
 const badgeVariants = cva(

--- a/packages/ui/src/primitives/button.tsx
+++ b/packages/ui/src/primitives/button.tsx
@@ -1,6 +1,6 @@
-import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
+import type * as React from 'react';
 import { cn } from '../lib/utils';
 
 const buttonVariants = cva(
@@ -10,9 +10,12 @@ const buttonVariants = cva(
       variant: {
         default:
           'justify-center rounded-md bg-accent text-accent-foreground hover:bg-accent-hover shadow-[inset_0_0_0_1px_rgba(0,0,0,0.08)]',
-        secondary: 'justify-center rounded-md bg-tertiary text-primary border border-border hover:bg-hover',
-        outline: 'justify-center rounded-md bg-transparent border border-border text-primary hover:bg-hover',
-        ghost: 'justify-start rounded-md bg-transparent text-secondary hover:bg-hover hover:text-primary',
+        secondary:
+          'justify-center rounded-md bg-tertiary text-primary border border-border hover:bg-hover',
+        outline:
+          'justify-center rounded-md bg-transparent border border-border text-primary hover:bg-hover',
+        ghost:
+          'justify-start rounded-md bg-transparent text-secondary hover:bg-hover hover:text-primary',
         pill: 'justify-center rounded-md bg-transparent text-secondary hover:text-primary border border-border hover:border-text-secondary',
         destructive:
           'justify-center rounded-md bg-danger/15 text-danger border border-danger/30 hover:bg-danger/25',

--- a/packages/ui/src/primitives/card.tsx
+++ b/packages/ui/src/primitives/card.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type * as React from 'react';
 import { cn } from '../lib/utils';
 
 function Card({ className, ...props }: React.ComponentProps<'div'>) {
@@ -29,4 +29,4 @@ function CardFooter({ className, ...props }: React.ComponentProps<'div'>) {
   return <div className={cn('flex items-center p-5 pt-0', className)} {...props} />;
 }
 
-export { Card, CardHeader, CardFooter, CardTitle, CardDescription, CardContent };
+export { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle };

--- a/packages/ui/src/primitives/checkbox.tsx
+++ b/packages/ui/src/primitives/checkbox.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type * as React from 'react';
 import { cn } from '../lib/utils';
 
 /**
@@ -19,4 +19,5 @@ function Checkbox({ className, ...props }: React.ComponentProps<'input'>) {
     />
   );
 }
+
 export { Checkbox };

--- a/packages/ui/src/primitives/command.tsx
+++ b/packages/ui/src/primitives/command.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import { Command as CommandPrimitive } from 'cmdk';
+import type * as React from 'react';
 import { cn } from '../lib/utils';
 import { Dialog, DialogContent } from './dialog';
 
@@ -90,6 +90,7 @@ function CommandShortcut({ className, ...props }: React.ComponentProps<'span'>) 
     <span className={cn('ml-auto text-xs tracking-widest text-muted', className)} {...props} />
   );
 }
+
 export {
   Command,
   CommandDialog,

--- a/packages/ui/src/primitives/dialog.tsx
+++ b/packages/ui/src/primitives/dialog.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import * as DialogPrimitive from '@radix-ui/react-dialog';
+import type * as React from 'react';
 import { cn } from '../lib/utils';
 
 function Dialog(props: React.ComponentProps<typeof DialogPrimitive.Root>) {
@@ -62,14 +62,15 @@ function DialogDescription({
     <DialogPrimitive.Description className={cn('text-sm text-secondary', className)} {...props} />
   );
 }
+
 export {
   Dialog,
-  DialogTrigger,
-  DialogPortal,
-  DialogOverlay,
   DialogContent,
-  DialogHeader,
-  DialogFooter,
-  DialogTitle,
   DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
 };

--- a/packages/ui/src/primitives/dropdown-menu.tsx
+++ b/packages/ui/src/primitives/dropdown-menu.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import type * as React from 'react';
 import { cn } from '../lib/utils';
 
 function DropdownMenu(props: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
@@ -65,8 +65,8 @@ function DropdownMenuSeparator({
 
 export {
   DropdownMenu,
-  DropdownMenuTrigger,
   DropdownMenuContent,
   DropdownMenuItem,
   DropdownMenuSeparator,
+  DropdownMenuTrigger,
 };

--- a/packages/ui/src/primitives/input.tsx
+++ b/packages/ui/src/primitives/input.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type * as React from 'react';
 import { cn } from '../lib/utils';
 
 function Input({ className, type, ...props }: React.ComponentProps<'input'>) {

--- a/packages/ui/src/primitives/label.tsx
+++ b/packages/ui/src/primitives/label.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import * as LabelPrimitive from '@radix-ui/react-label';
+import type * as React from 'react';
 import { cn } from '../lib/utils';
 
 function Label({ className, ...props }: React.ComponentProps<typeof LabelPrimitive.Root>) {

--- a/packages/ui/src/primitives/pagination.tsx
+++ b/packages/ui/src/primitives/pagination.tsx
@@ -44,6 +44,7 @@ function Pagination({ page, totalPages, onPageChange, className }: PaginationPro
       {getPages().map((p, i) =>
         p === '…' ? (
           <span
+            // biome-ignore lint/suspicious/noArrayIndexKey: ellipsis can appear twice (leading/trailing) so position is the only unique key
             key={`ellipsis-${i}`}
             className="flex h-6 w-6 items-center justify-center text-[11px] text-muted"
           >
@@ -79,5 +80,5 @@ function Pagination({ page, totalPages, onPageChange, className }: PaginationPro
   );
 }
 
-export { Pagination };
 export type { PaginationProps };
+export { Pagination };

--- a/packages/ui/src/primitives/select.tsx
+++ b/packages/ui/src/primitives/select.tsx
@@ -1,5 +1,6 @@
-import * as React from 'react';
 import * as SelectPrimitive from '@radix-ui/react-select';
+import { Check, ChevronDown } from 'lucide-react';
+import type * as React from 'react';
 import { cn } from '../lib/utils';
 
 function Select(props: React.ComponentProps<typeof SelectPrimitive.Root>) {
@@ -20,16 +21,7 @@ function SelectTrigger({
     >
       {children}
       <SelectPrimitive.Icon asChild>
-        <svg
-          className="h-4 w-4 opacity-50"
-          xmlns="http://www.w3.org/2000/svg"
-          viewBox="0 0 24 24"
-          fill="none"
-          stroke="currentColor"
-          strokeWidth="2"
-        >
-          <path d="m6 9 6 6 6-6" />
-        </svg>
+        <ChevronDown className="h-4 w-4 opacity-50" aria-hidden="true" />
       </SelectPrimitive.Icon>
     </SelectPrimitive.Trigger>
   );
@@ -81,16 +73,7 @@ function SelectItem({
     >
       <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
         <SelectPrimitive.ItemIndicator>
-          <svg
-            className="h-4 w-4"
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            strokeWidth="2"
-          >
-            <path d="M20 6 9 17l-5-5" />
-          </svg>
+          <Check className="h-4 w-4" aria-hidden="true" />
         </SelectPrimitive.ItemIndicator>
       </span>
       <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
@@ -100,4 +83,5 @@ function SelectItem({
 function SelectValue(props: React.ComponentProps<typeof SelectPrimitive.Value>) {
   return <SelectPrimitive.Value {...props} />;
 }
+
 export { Select, SelectContent, SelectItem, SelectTrigger, SelectValue };

--- a/packages/ui/src/primitives/settings-row.tsx
+++ b/packages/ui/src/primitives/settings-row.tsx
@@ -9,9 +9,20 @@ interface SettingsRowProps {
   className?: string;
 }
 
-export function SettingsRow({ label, htmlFor, description, children, className }: SettingsRowProps) {
+export function SettingsRow({
+  label,
+  htmlFor,
+  description,
+  children,
+  className,
+}: SettingsRowProps) {
   return (
-    <div className={cn('flex items-center justify-between border-b border-border py-2.5 gap-4', className)}>
+    <div
+      className={cn(
+        'flex items-center justify-between border-b border-border py-2.5 gap-4',
+        className,
+      )}
+    >
       <div className="min-w-0">
         {htmlFor ? (
           <label htmlFor={htmlFor} className="text-sm text-primary cursor-pointer select-none">

--- a/packages/ui/src/primitives/switch.tsx
+++ b/packages/ui/src/primitives/switch.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
 import * as SwitchPrimitives from '@radix-ui/react-switch';
+import type * as React from 'react';
 import { cn } from '../lib/utils';
 
 function Switch({ className, ...props }: React.ComponentProps<typeof SwitchPrimitives.Root>) {
@@ -15,4 +15,5 @@ function Switch({ className, ...props }: React.ComponentProps<typeof SwitchPrimi
     </SwitchPrimitives.Root>
   );
 }
+
 export { Switch };

--- a/packages/ui/src/primitives/table.tsx
+++ b/packages/ui/src/primitives/table.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type * as React from 'react';
 import { cn } from '../lib/utils';
 
 function Table({ className, ...props }: React.ComponentProps<'table'>) {
@@ -63,4 +63,4 @@ function TableCaption({ className, ...props }: React.ComponentProps<'caption'>) 
   return <caption className={cn('mt-4 text-[11px] text-muted', className)} {...props} />;
 }
 
-export { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell, TableCaption };
+export { Table, TableBody, TableCaption, TableCell, TableFooter, TableHead, TableHeader, TableRow };

--- a/packages/ui/src/primitives/textarea.tsx
+++ b/packages/ui/src/primitives/textarea.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type * as React from 'react';
 import { cn } from '../lib/utils';
 
 function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
@@ -12,4 +12,5 @@ function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
     />
   );
 }
+
 export { Textarea };


### PR DESCRIPTION
Brings the lint cleanup in 16c1dd3 from \`develop\` back into \`master\` so the release line stays green.

## What's in here

Single commit: \`chore: clean up lint errors across the repo\` (31 files, +255/-200).

See 16c1dd3 for the full per-file rationale. Highlights:

- \`biome.json\` — enable \`css.parser.tailwindDirectives\` (needed for Tailwind v4 \`@utility\`/\`@theme\`) and exclude \`apps/web/public/docs\` (Next.js static-export build artifacts, not source).
- \`packages/ui\` — widespread \`biome check --write [--unsafe]\` cleanup: \`import type\` for React namespace imports, organized imports, a handful of long class strings wrapped. No behavior changes.
- \`IssueCard\` — \`<div onClick>\` → \`<button type=\"button\">\` for keyboard accessibility.
- \`KanbanBoard\` — drop the \`lastPhaseUpdate!\` non-null assertion in favor of a narrower conditional; suppress a11y rules on the two draggable card wrappers with a rationale comment (dnd-kit's \`KeyboardSensor\` handles keyboard activation).
- \`PlanViewer\` — drop the never-implemented \`isEditable\` / \`onPlanEdit\` props (no callers).
- \`{Plan,Review,Verification}Viewer\` — use the rendered string as React key instead of array index.
- \`DiffViewer\` + \`pagination\` — \`biome-ignore\` on \`noArrayIndexKey\` with rationale.
- \`select.tsx\` — replace hand-rolled chevron / check SVGs with lucide-react \`ChevronDown\` / \`Check\`.
- \`apps/web\` — format \`globals.css\` / \`next-env.d.ts\`, organize imports in a few component files.

## Test plan

- [x] \`bun run lint\` — green
- [x] \`bun run typecheck\` — 14/14 packages
- [x] \`bun run test\` — 24/24 desktop, 256/256 agents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced security for package publishing with GitHub OIDC authentication.
  * Enabled CSS Modules and Tailwind directive parsing in build configuration.

* **Bug Fixes**
  * Improved semantic HTML and accessibility by converting card elements to proper button elements.
  * Fixed nullable handler invocations to prevent runtime errors.
  * Replaced inline SVG markup with consistent icon library components.
  * Improved React list rendering with stable keys.

* **Chores**
  * Refactored import statements and export ordering for consistency.
  * Updated React imports to type-only where applicable to optimize bundle size.
  * Standardized CSS formatting and quote styles in stylesheets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->