### PR TITLE
ci: rename release → publish, run CI on develop, add lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [master, develop]
   pull_request:
-    branches: [master]
+    branches: [master, develop]
 
 env:
   BUN_VERSION: "1.3.11"
@@ -22,5 +22,6 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - run: bun install
+      - run: bun run lint
       - run: bun run typecheck
       - run: bun run test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,14 @@
-name: Release
+name: Publish
 
 # Manual-dispatch only until Apple signing / notarization is wired.
 # When CSC_LINK + APPLE_* secrets are available, re-enable the
 # `release: published` trigger below and restore the commented
 # `build-desktop-macos` + `update-homebrew-cask` jobs at the bottom.
+#
+# File renamed from `release.yml` to `publish.yml` because the previous
+# registration cached a stale state where GitHub kept recording 0-job
+# "failure" runs on every push to master even though the workflow has
+# no push trigger. Renaming forces a fresh workflow registration.
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -128,7 +128,13 @@ jobs:
         # registry verifies the GitHub Actions ID token against the
         # Trusted Publisher config on the package. One-time setup at
         # https://www.npmjs.com/package/@shipshitdev/shipcode/access
-        # (Repository: shipshitdev/shipcode, Workflow: release.yml).
+        # (Repository: shipshitdev/shipcode, Workflow: publish.yml).
+        #
+        # IMPORTANT: npm's Trusted Publisher binding pins the workflow
+        # filename exactly (case-sensitive, with .yml extension). If you
+        # rename this file you MUST update the "Workflow filename" field
+        # in the npm package's Trusted Publishing settings or
+        # `npm publish --provenance` will fail with an auth error.
 
 # ─────────────────────────────────────────────────────────────────
 # DISABLED until Apple codesigning + notarization are wired.


### PR DESCRIPTION
Two fixes bundled.

## 1. Release workflow ghost failures

The old \`.github/workflows/release.yml\` is stuck in a cached GitHub registration state. Symptoms:

- \`gh workflow list\` shows its name as the file path (\`.github/workflows/release.yml\`) instead of the \`name: Release\` field at the top.
- Every push to master records a 0-job \"failure\" run with \`event: push\`, even though the file has no push trigger. Confirmed via \`gh api\`: \`latest_check_runs_count: 0\`, \`rerequestable: false\`.
- Disable/re-enable via \`gh workflow\` did not clear the state.

Renaming the file from \`release.yml\` to \`publish.yml\` forces GitHub to drop the stale registration and create a fresh one at a new workflow ID. Also updates the \`name:\` field from \`Release\` to \`Publish\` so it reflects what the workflow actually does (deploy web, upload Linux binaries, publish CLI to npm). No job content changes.

## 2. CI on develop + lint step

- CI now runs on \`push\` / \`pull_request\` into \`develop\` as well as \`master\`, so the integration branch stays green.
- Added \`bun run lint\` to the check job. Lint is now green across all packages (see #28), and this locks it in.

## Test plan

- [x] \`bun run lint\` — green
- [x] \`bun run typecheck\` — green
- [x] \`bun run test\` — green
- [ ] After merge: confirm new \`Publish\` workflow is registered with the correct name in \`gh workflow list\`.
- [ ] After merge: confirm no more phantom failed runs in \`gh run list --workflow publish.yml\` on pushes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI pipeline now runs linting alongside type checks and tests, and is triggered for pushes and pull requests on both master and develop branches
  * Release workflow renamed and clarified as the Publish workflow to ensure consistent publishing behavior and clearer workflow registration details
<!-- end of auto-generated comment: release notes by coderabbit.ai -->