### PR TITLE
fix(terminal): suppress exit 0, blockquote agent text

### DIFF
--- a/.agents/SESSIONS/2026-04-12.md
+++ b/.agents/SESSIONS/2026-04-12.md
@@ -1,6 +1,11 @@
 # Sessions: 2026-04-12
 
 ## Summary
+Session 31: Pipeline progress indicators — deterministic progress bar on Kanban cards, PipelineStatus stepper wired into IssueDetail.
+Session 30: Terminal project scoping + per-project agent count badges. Terminal clears on project switch, output leak fixed, sidebar badges added.
+
+Session 29: Centralized electron-log into logger.service.ts + routed process stdout/stderr to app log (debug in dev, info-only in prod).
+
 Session 28: Repo context system (Phase 1) — context loader utility, PipelineContext.repoContext field, {{CONTEXT_FILES}} wired into all 4 pipeline phases (plan, review, execute, verify).
 
 Session 27: Two runtime bug fixes — idle-thread restart block and Inbox "View" not opening IssueDetail. Committed all pending session 24–26 work.
@@ -1877,3 +1882,194 @@ flowchart LR
 - [ ] Manual QA: run pipeline without testCommand to confirm no-op behavior (execute -> verify unchanged)
 - [ ] Manual QA: set testingContext and verify it appears in executor prompt
 - [ ] Consider: persist testOutput to DB so restart mid-test-retry doesn't lose failure context
+
+---
+
+## Session 29: Centralized Logger Service + Process Output to App Log
+
+**Status:** Complete
+
+### Affected Components
+
+| Layer | Components |
+|-------|------------|
+| Main process | `logger.service.ts` (new), `index.ts`, `ipc.ts`, `pipeline-bridge.ts` |
+
+### What was done
+
+- [x] Created `apps/desktop/src/main/logger.service.ts` — single initialization point for electron-log, exports `log` default + `logProcessOutput(type, data)` helper
+- [x] Updated `index.ts` to import from `./logger.service` instead of inline-initializing electron-log
+- [x] Updated `ipc.ts` to use `logProcessOutput` in the `processManager.on('output')` handler so raw process chunks are mirrored to the app log
+- [x] Updated `pipeline-bridge.ts` to import from `./logger.service`
+- [x] Dev mode: `file.level = 'debug'` (process output captured); prod mode: `file.level = 'info'` (lifecycle events only) — switched via `app.isPackaged`
+- [x] Typecheck: 6/6 packages passing, 0 new errors
+- [x] Committed on `feat/rich-terminal-thinking`
+
+### Files changed
+
+- `apps/desktop/src/main/logger.service.ts` — **created**: init electron-log, export log + logProcessOutput
+- `apps/desktop/src/main/index.ts` — replaced 3-line inline init with single import
+- `apps/desktop/src/main/ipc.ts` — swapped import; added logProcessOutput tap in output event handler
+- `apps/desktop/src/main/pipeline-bridge.ts` — swapped import only
+
+### Key decisions
+
+- **Decision:** Dev = debug level (process output logged), prod = info level (lifecycle only)
+  - **Context:** User wanted process output (e.g. codex ERROR stale rollout lines) visible in app log
+  - **Rationale:** Production logs would be noisy with every byte of process output; debug is sufficient for dev where you're actively watching. `app.isPackaged` is the canonical Electron check.
+
+- **Decision:** `logProcessOutput` is a named export on `logger.service`, not an inline `log.debug` call in ipc.ts
+  - **Context:** Keeps the output-formatting concern inside the service
+  - **Rationale:** Future callers (e.g. other IPC handlers) can route output consistently without duplicating the format string
+
+### Next steps
+
+- [ ] Verify in `bun run dev`: open `~/Library/Logs/ShipCode/main.log` and confirm `[output:codex]` / `[output:claude]` debug lines appear during a pipeline run
+- [ ] PR `feat/rich-terminal-thinking` into develop when that branch's other work (IssueDetail, KanbanBoard, pipeline-utils changes) is ready
+
+## Session 31: Pipeline Progress Indicators
+
+**Status:** Complete
+
+### System Flow
+
+```mermaid
+flowchart LR
+    phase[PipelinePhase] -->|phaseToProgress()| pct[0–100%]
+    pct --> bar[KanbanBoard progress bar]
+    pct --> label[% label on card]
+    phase --> stepper[PipelineStatus stepper]
+    stepper --> IssueDetail[IssueDetail panel + expanded]
+```
+
+### Affected Components
+
+| Layer | Components |
+|-------|------------|
+| Frontend | `IssueDetail.tsx` (stepper wired in), `KanbanBoard.tsx` (real progress bar + % label) |
+| Shared | `pipeline-utils.ts` (new — `phaseToProgress()`), `index.ts` (export) |
+
+### What was done
+
+- [x] Created `packages/shared/src/pipeline-utils.ts` with `phaseToProgress()` — maps each PipelinePhase/IssuePipelineStatus to a deterministic weight (0–100), exported from `@shipcode/shared`
+- [x] Replaced cosmetic CSS loop animation on Kanban cards with a real deterministic fill bar; color varies by state (agent=cyan, awaiting=amber, completed=green, failed=red)
+- [x] Added `%` label alongside elapsed time on active/awaiting cards
+- [x] Wired the existing (but unused) `PipelineStatus` 8-step stepper into `IssueDetail.tsx` in both panel and expanded layouts — shown once a pipeline has started (`activeThreadId` set and `threadPhase !== 'idle'`)
+- [x] Typecheck passes clean (8/8 tasks green)
+- [x] Committed as `7894228`
+
+### Files changed
+
+- `packages/shared/src/pipeline-utils.ts` — new file; `phaseToProgress()` utility
+- `packages/shared/src/index.ts` — added `export * from './pipeline-utils'`
+- `packages/ui/src/KanbanBoard.tsx` — import `phaseToProgress`; replace loop animation; add % label in card header row
+- `apps/desktop/src/renderer/components/IssueDetail.tsx` — import `PipelineStatus`; render stepper in panel layout (above CTAs) and expanded layout (after header, before approvalSection)
+
+### Key decisions
+
+- **Decision:** Step-based progress (option 1) over historical timing estimation (option 2)
+  - **Context:** Vincent asked if we could estimate from CLI output; CLIs are black boxes with no internal progress signal
+  - **Rationale:** Historical timing requires multiple prior runs to calibrate and is more complex; step-based is honest, zero-risk, and immediately useful
+
+- **Decision:** `phaseToProgress()` weights are not equal — executing gets the largest share (72–82%)
+  - **Context:** Phases don't consume equal time; execute typically dominates
+  - **Rationale:** Weighted mapping better reflects user's perceived progress and avoids the bar jumping 12% at a time uniformly
+
+- **Decision:** Progress bar shown for all non-todo/queued cards (not just active ones)
+  - **Context:** Completed cards should show 100% green; failed cards 0% danger; awaiting amber at 48%
+  - **Rationale:** Gives persistent visual context even on terminal-state cards
+
+### Mistakes and fixes
+
+- **Mistake:** First `Edit` tried to add `PipelineStatus` using a bad old_string match (`PipelineStatus } from '@shipcode/ui'`) -> **Fix:** Re-read the import block and matched on `PlanViewer` which was adjacent
+
+### Next steps
+
+- [ ] Manual QA: launch pipeline, watch card progress bar fill deterministically through each phase
+- [ ] Manual QA: verify PipelineStatus stepper shows correct active phase in both panel and expanded IssueDetail views
+- [ ] Future: option 2 (historical timing estimation) can be layered on top once users have enough run history
+
+---
+
+## Session 30: Terminal Project Scoping + Per-Project Agent Count Badges
+
+**Status:** Complete
+
+### System Flow
+
+```mermaid
+flowchart TD
+    User -->|clicks different project| ProjectSidebar
+    ProjectSidebar -->|selectProject| AppStore
+    AppStore -->|clears githubIssues + terminalThreadId| TerminalDrawer
+    TerminalDrawer -->|null-guard: no output when no thread| xterm
+    TerminalDrawer -->|empty githubIssues: no stale header/tabs| UI
+
+    DashboardQueries -->|agentsRunningByProject GROUP BY| SQLite
+    DashboardQueries -->|included in getStats response| IPC
+    ProjectSidebar -->|reads stats.agentsRunningByProject| Badge
+```
+
+### Affected Components
+
+| Layer | Components |
+|-------|------------|
+| Frontend | `ProjectSidebar.tsx` (badge), `TerminalDrawer.tsx` (null-guard + phase sync) |
+| State | `app-store.ts` (`selectProject` clears `githubIssues`) |
+| Data | `dashboard.ts` (`agentsRunningByProject` GROUP BY query) |
+| Types | `packages/shared/src/types.ts` (`DashboardStats.agentsRunningByProject`) |
+| Tests | `dashboard.test.ts` (2 new tests), `app-store.test.ts` (1 new test) |
+
+### What was done
+
+- [x] Planned: 2 issues identified (terminal cross-project leak, missing per-project badge)
+- [x] Adversarial Codex review surfaced real corrections: root cause is stale `githubIssues` not cleared in store; new IPC channel would bypass invalidation; badge placement conflict with overflow menu
+- [x] Plan revised with all Codex corrections incorporated
+- [x] Created git worktree `.worktrees/feat/terminal-scope` from `develop`
+- [x] `selectProject` in app-store clears `githubIssues: []` — fixes both stale header AND stale running tabs at the store layer
+- [x] Terminal output loop null-guards `terminalThreadId` — prevents cross-project output leak
+- [x] Added `'testing'` to `AGENT_ACTIVE_STATUSES` in TerminalDrawer (was missing vs. `AGENT_RUNNING_PHASES` in dashboard — badge and tab counts now match)
+- [x] Extended `DashboardStats` with `agentsRunningByProject: Record<string, number>` — reuses `dashboard:get-stats` + its existing invalidation, no new IPC channel
+- [x] Per-project GROUP BY query added inside `DashboardQueries.getStats()`
+- [x] Sidebar project rows show compact agent-colored badge; `pr-8` prevents overflow with menu button
+- [x] 3 new tests: `agentsRunningByProject` query (x2), `selectProject` clears `githubIssues`
+- [x] 14/14 typecheck clean, 184 tests passing (155 db + 29 desktop)
+- [x] Commit `1850a23` landed directly on `develop` (fast-forwarded while working)
+
+### Files changed
+
+- `apps/desktop/src/renderer/stores/app-store.ts` — `selectProject` adds `githubIssues: []` to reset
+- `apps/desktop/src/renderer/components/TerminalDrawer.tsx` — null-guard in output loop; `'testing'` added to `AGENT_ACTIVE_STATUSES`
+- `apps/desktop/src/renderer/components/ProjectSidebar.tsx` — per-project badge using `stats.agentsRunningByProject`; `pr-8` on button
+- `packages/shared/src/types.ts` — `agentsRunningByProject: Record<string, number>` added to `DashboardStats`
+- `packages/db/src/queries/dashboard.ts` — per-project GROUP BY query inside `getStats()`
+- `packages/db/src/queries/dashboard.test.ts` — 2 new tests for `agentsRunningByProject`
+- `apps/desktop/src/renderer/stores/app-store.test.ts` — 1 new test: `selectProject` clears `githubIssues`
+
+### Key decisions
+
+- **Decision:** Fix at store layer (`selectProject` clears `githubIssues`) rather than patching `pinnedIssue` in `TerminalDrawer`
+  - **Context:** Codex adversarial review identified that `githubIssues` was not cleared on project switch, making both stale header AND stale running tabs a store-layer bug
+  - **Rationale:** Fixing the source (store) is cleaner than patching derived state in the component
+
+- **Decision:** Extend `DashboardStats` rather than add a new IPC channel
+  - **Context:** A standalone `dashboard:get-project-running` channel would bypass the existing `dashboard:invalidate` contract in `pipeline-bridge.ts` and `useIpc.ts`
+  - **Rationale:** Reusing `dashboard:get-stats` means updates are properly invalidated on pipeline events; no extra polling loop
+
+- **Decision:** `pr-8` always instead of conditional padding for the badge
+  - **Context:** Badge inside the button would overlap the absolutely-positioned overflow menu at `right-1.5` with `pr-5`
+  - **Rationale:** 3px wider padding is imperceptible; conditional logic adds complexity for no visual benefit
+
+### Mistakes and fixes
+
+- **Mistake:** `feat/terminal-scope` worktree was created under `.worktrees/feat/terminal-scope` but the worktree list showed it as missing after rebase — git pruned the dangling worktree reference when we switched contexts
+  - **Fix:** Recreated the branch from commit SHA `1850a23` and pushed directly; commit was already fast-forwarded into `develop` by the time PR was attempted
+
+- **Mistake:** `stash pop` after rebase caused a conflict because `logger.service.ts` was deleted in develop but present in the stash (from `feat/rich-terminal-thinking` in-progress work)
+  - **Fix:** `git rm` the conflicted file, unstaged the stash'd changes, switched back to `feat/rich-terminal-thinking` — working changes preserved
+
+### Next steps
+
+- [ ] Manual QA: switch projects while agents are running — verify terminal clears, badge appears on correct project
+- [ ] Manual QA: Overview "2 live" still shows global count unchanged
+- [ ] `feat/rich-terminal-thinking` branch has in-progress work (IssueDetail.tsx, KanbanBoard.tsx, pipeline-utils.ts) — needs completion before merging to develop

--- a/apps/desktop/src/renderer/components/TerminalDrawer.tsx
+++ b/apps/desktop/src/renderer/components/TerminalDrawer.tsx
@@ -43,11 +43,19 @@ const PHASE_LABELS: Record<string, string> = {
  */
 function renderTerminalEvent(event: import('@shipcode/agents').TerminalEvent): string | null {
   switch (event.kind) {
-    case 'text':
-      return event.content;
-    case 'thinking':
-      // Dim italic for reasoning/thinking blocks
-      return `\x1b[2;3m${event.content}\x1b[0m`;
+    case 'text': {
+      // Render agent text with a left-border blockquote style
+      // so it visually separates from tool calls and commands
+      const lines = event.content.split('\n');
+      const quoted = lines.map((line) => `\x1b[36m\u2502\x1b[0m ${line}`).join('\n');
+      return quoted;
+    }
+    case 'thinking': {
+      // Dim italic with left-border blockquote for reasoning/thinking
+      const lines = event.content.split('\n');
+      const quoted = lines.map((line) => `\x1b[2;35m\u2502\x1b[0m \x1b[2;3m${line}\x1b[0m`).join('\n');
+      return quoted;
+    }
     case 'tool_start':
       return `\x1b[2m\u2192 ${event.summary}\x1b[0m`;
     case 'tool_end':

--- a/apps/desktop/src/renderer/components/TerminalDrawer.tsx
+++ b/apps/desktop/src/renderer/components/TerminalDrawer.tsx
@@ -51,10 +51,8 @@ function renderTerminalEvent(event: import('@shipcode/agents').TerminalEvent): s
     case 'tool_start':
       return `\x1b[2m\u2192 ${event.summary}\x1b[0m`;
     case 'tool_end':
-      if (event.exitCode !== undefined) {
-        return event.exitCode === 0
-          ? '\x1b[32m[exit 0]\x1b[0m'
-          : `\x1b[31m[exit ${event.exitCode}]\x1b[0m`;
+      if (event.exitCode !== undefined && event.exitCode !== 0) {
+        return `\x1b[31m[exit ${event.exitCode}]\x1b[0m`;
       }
       if (event.durationMs !== undefined) {
         return `\x1b[2m(${(event.durationMs / 1000).toFixed(1)}s)\x1b[0m`;
@@ -94,11 +92,13 @@ function renderTerminalEvent(event: import('@shipcode/agents').TerminalEvent): s
   }
 }
 
+const EMPTY_STREAM: never[] = [];
+
 export function TerminalDrawer() {
   const { toggleTerminal } = useAppStore();
   const terminalThreadId = useAppStore((s) => s.terminalThreadId);
   const canonicalStream = useAppStore((s) =>
-    s.terminalThreadId ? (s.canonicalTerminalStream[s.terminalThreadId] ?? []) : [],
+    s.terminalThreadId ? (s.canonicalTerminalStream[s.terminalThreadId] ?? EMPTY_STREAM) : EMPTY_STREAM,
   );
   const activeIssue = useAppStore((s) => s.activeIssue);
   const pipelinePhase = useAppStore((s) => s.pipelinePhase);

--- a/packages/agents/src/providers/normalizers/codex-normalizer.ts
+++ b/packages/agents/src/providers/normalizers/codex-normalizer.ts
@@ -118,14 +118,17 @@ export class CodexNormalizer {
       return;
     }
 
-    // Command execution completed → tool_end with exit code
+    // Command execution completed → tool_end (only on failure)
     if (event.type === 'item.completed' && item?.type === 'command_execution') {
       const code = item.exit_code as number | null;
-      this.onEvent({
-        kind: 'tool_end',
-        name: 'Bash',
-        exitCode: code ?? undefined,
-      });
+      // Only emit tool_end for non-zero exits — exit 0 is noise
+      if (code !== null && code !== 0) {
+        this.onEvent({
+          kind: 'tool_end',
+          name: 'Bash',
+          exitCode: code,
+        });
+      }
       return;
     }
 


### PR DESCRIPTION
## Summary
- Suppress `[exit 0]` noise from codex tool calls -- only show failures
- Agent text rendered with cyan left-border blockquote (`|`) to separate from tool calls
- Thinking blocks rendered with magenta left-border + dim italic

## Test plan
- [ ] Run a Codex review pipeline -- verify no `[exit 0]` after successful commands
- [ ] Verify agent text has a visible cyan `|` left border
- [ ] Verify thinking blocks have magenta `|` with dim italic text
- [ ] Failed commands still show red `[exit N]`