### PR TITLE
chore: defer CLI terminal live monitor implementation

### DIFF
--- a/.agents/SESSIONS/2026-04-07.md
+++ b/.agents/SESSIONS/2026-04-07.md
@@ -151,9 +151,10 @@ flowchart TD
 - [ ] Implement actual label sync in pipeline phase transitions
 - [ ] Add boot-time recovery for orphaned threads
 - [ ] Add heartbeat for long-running pipeline phases
-- [ ] Build the `shipcode watch` TUI mode (ink-based terminal dashboard)
 - [ ] Test full E2E: label GitHub issue → pipeline runs → PR created
 - [ ] Add tests (none exist currently)
 - [ ] Deploy docs site to Vercel
 - [ ] Consider: is this better as a CLI daemon + GitHub as UI, or keep the desktop app?
 - [ ] Evaluate OpenHands as potential execution engine vs building from scratch
+
+> **Deferred:** CLI terminal live-monitor (TUI/watch mode) — see shipshitdev/shipcode#7


### PR DESCRIPTION
## Summary
- defer CLI terminal live-monitor (TUI/watch mode) to future implementation

## Notes
- this is the only pushed branch that still has commits not already in `develop`
- the other pushed branches are already fully contained in `develop`, so they do not have an openable diff against `develop`