### PR TITLE
Refactor: dedupe relative time formatter

### DIFF
--- a/.agents/SESSIONS/2026-04-30.md
+++ b/.agents/SESSIONS/2026-04-30.md
@@ -51,3 +51,60 @@ Started a new session after context reset. The session-start skill expected olde
 - `bun run typecheck` passed (`15 successful, 15 total`).
 - `bunx vitest run --reporter=dot` in `apps/desktop` passed (`62 files`, `352 tests`) and exited cleanly.
 - `bun run test` passed (`16 successful, 16 total`).
+
+## Session 3: Cleanup automation branch fix and relative time dedupe
+
+### System Flow
+
+```mermaid
+flowchart TD
+  A["Clean Up Code automation"] --> B["Codex worktree"]
+  B --> C{"Base branch correct?"}
+  C -->|wrong: master| D["Stop and rebase/recreate from develop"]
+  C -->|correct: develop| E["Find duplicate formatter code"]
+  E --> F["Shared formatRelativeTime helper"]
+  F --> G["Activity, Inbox, Overview, Issue Detail imports"]
+  G --> H["Commit and PR against develop"]
+```
+
+### Affected Components
+
+- `packages/shared`: new reusable relative-time formatter.
+- Desktop renderer: Activity, Inbox, Overview, and issue-detail relative time display.
+- Automation setup: clean-up automations now require `develop` except the Veref master-only exception.
+
+### What Was Done
+
+- Diagnosed the failed commit hook as a branch-base mismatch: the run started from `master`, but the shared hook expected a script present on `develop`.
+- Audited local clean-up automations and documented the Veref exception.
+- Reset the cleanup run onto current `origin/develop`.
+- Replaced four duplicate `timeAgo` implementations with one shared `formatRelativeTime` export.
+- Opened PR #92 against `develop`.
+
+### Key Decisions
+
+- Use `origin/develop` as the PR base so the cleanup PR does not carry unrelated local `develop` commits.
+- Keep the issue-detail `timeAgo` export as a compatibility alias to avoid touching the nested issue-detail tab imports.
+- Do not run full package typechecks in this worktree because `node_modules` is not installed; use Biome, hook validation, and a focused helper smoke check instead.
+
+### Files Changed
+
+- `packages/shared/src/format-relative-time.ts`
+- `packages/shared/src/index.ts`
+- `apps/desktop/src/renderer/components/ActivityView.tsx`
+- `apps/desktop/src/renderer/components/InboxView.tsx`
+- `apps/desktop/src/renderer/components/OverviewView.tsx`
+- `apps/desktop/src/renderer/components/issue-detail/helpers.ts`
+- `.agents/SESSIONS/2026-04-30.md`
+
+### Mistakes And Fixes
+
+- Mistake: the first cleanup commit was created from a master-based Codex worktree.
+- Fix: changed the automation source/default branch behavior, reset this branch onto `origin/develop`, and recreated the cleanup patch there.
+- Mistake: the first PR view temporarily included unrelated local develop commits while `origin/develop` was behind.
+- Fix: updated the branch after `origin/develop` advanced so the PR only carries this cleanup/session work.
+
+### Next Steps
+
+- Review PR #92.
+- Discard any stale master-based cleanup worktrees instead of continuing them.

--- a/apps/desktop/src/renderer/components/ActivityView.tsx
+++ b/apps/desktop/src/renderer/components/ActivityView.tsx
@@ -1,4 +1,4 @@
-import type { ActivityEntry } from '@shipcode/shared';
+import { type ActivityEntry, formatRelativeTime } from '@shipcode/shared';
 import { PageHeader } from '@shipcode/ui';
 import {
   Button,
@@ -16,19 +16,6 @@ import { useEffect, useState } from 'react';
 import { useAppStore } from '../stores/app-store';
 
 const PAGE_SIZE = 25;
-
-function timeAgo(input: string | number): string {
-  const t = typeof input === 'number' ? input : new Date(input).getTime();
-  const diff = Math.max(0, Date.now() - t);
-  const s = Math.floor(diff / 1000);
-  if (s < 60) return `${s}s ago`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ago`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h ago`;
-  const d = Math.floor(h / 24);
-  return `${d}d ago`;
-}
 
 function dayLabel(isoStr: string): string {
   const date = new Date(isoStr);
@@ -160,7 +147,7 @@ export function ActivityView() {
                                 )}
                               </TableCell>
                               <TableCell className="w-px whitespace-nowrap text-right text-[10px] text-muted">
-                                {timeAgo(entry.createdAt)}
+                                {formatRelativeTime(entry.createdAt)}
                               </TableCell>
                             </TableRow>
                           );

--- a/apps/desktop/src/renderer/components/InboxView.tsx
+++ b/apps/desktop/src/renderer/components/InboxView.tsx
@@ -1,5 +1,6 @@
 import {
   filterAttentionRequiredNotifications,
+  formatRelativeTime,
   type GitHubIssueCacheRecord,
   type NotificationKind,
   type NotificationRecord,
@@ -25,19 +26,6 @@ import { NOTIFICATIONS_STALE_TIME } from '../query-stale-times';
 import { useAppStore } from '../stores/app-store';
 
 type BadgeVariant = 'default' | 'success' | 'warning' | 'danger' | 'info' | 'accent';
-
-function timeAgo(input: string | number): string {
-  const t = typeof input === 'number' ? input : new Date(input).getTime();
-  const diff = Math.max(0, Date.now() - t);
-  const s = Math.floor(diff / 1000);
-  if (s < 60) return `${s}s ago`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ago`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h ago`;
-  const d = Math.floor(h / 24);
-  return `${d}d ago`;
-}
 
 const KIND_BADGE_VARIANT: Record<NotificationKind, BadgeVariant> = {
   awaiting_approval: 'warning',
@@ -192,7 +180,7 @@ export function InboxView() {
         </div>
       </TableCell>
       <TableCell className="w-[1%] whitespace-nowrap align-top text-[11px] text-muted">
-        {timeAgo(n.createdAt)}
+        {formatRelativeTime(n.createdAt)}
       </TableCell>
       <TableCell className="align-top">
         <div className="text-[13px] font-medium text-primary">{n.title}</div>

--- a/apps/desktop/src/renderer/components/OverviewView.tsx
+++ b/apps/desktop/src/renderer/components/OverviewView.tsx
@@ -1,10 +1,11 @@
-import type {
-  ActivePipelineSummary,
-  ActivityEntry,
-  DashboardOverview,
-  DashboardStats,
-  GitHubIssueCacheRecord,
-  RecentTask,
+import {
+  type ActivePipelineSummary,
+  type ActivityEntry,
+  type DashboardOverview,
+  type DashboardStats,
+  formatRelativeTime,
+  type GitHubIssueCacheRecord,
+  type RecentTask,
 } from '@shipcode/shared';
 import { ActivePipelineCard, PageHeader, PhaseChip } from '@shipcode/ui';
 import {
@@ -26,19 +27,6 @@ import {
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { type ReactNode, useState } from 'react';
 import { useAppStore } from '../stores/app-store';
-
-function timeAgo(input: string | number): string {
-  const t = typeof input === 'number' ? input : new Date(input).getTime();
-  const diff = Math.max(0, Date.now() - t);
-  const s = Math.floor(diff / 1000);
-  if (s < 60) return `${s}s ago`;
-  const m = Math.floor(s / 60);
-  if (m < 60) return `${m}m ago`;
-  const h = Math.floor(m / 60);
-  if (h < 24) return `${h}h ago`;
-  const d = Math.floor(h / 24);
-  return `${d}d ago`;
-}
 
 interface StatCardProps {
   label: string;
@@ -305,7 +293,7 @@ export function OverviewView() {
                                 </div>
                               </TableCell>
                               <TableCell className="w-px whitespace-nowrap text-right text-[10px] text-muted">
-                                {timeAgo(entry.createdAt)}
+                                {formatRelativeTime(entry.createdAt)}
                               </TableCell>
                             </TableRow>
                           );
@@ -374,7 +362,7 @@ export function OverviewView() {
                               </div>
                             </TableCell>
                             <TableCell className="w-px whitespace-nowrap text-right text-[10px] text-muted align-top pt-2.5">
-                              {timeAgo(task.updatedAt)}
+                              {formatRelativeTime(task.updatedAt)}
                             </TableCell>
                           </TableRow>
                         ))}

--- a/apps/desktop/src/renderer/components/issue-detail/helpers.ts
+++ b/apps/desktop/src/renderer/components/issue-detail/helpers.ts
@@ -7,6 +7,8 @@ import type {
 } from '@shipcode/shared';
 import { PIPELINE_PHASE, shipCodePlanSchema } from '@shipcode/shared';
 
+export { formatRelativeTime as timeAgo } from '@shipcode/shared';
+
 // biome-ignore lint/suspicious/noControlCharactersInRegex: strips ANSI formatting from persisted terminal lines
 const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]|\x1b\].*?(?:\x07|\x1b\\)/g;
 
@@ -108,19 +110,6 @@ export function getPlanStatusPresentation(
         style: 'phase-chip',
       };
   }
-}
-
-export function timeAgo(input: string | number): string {
-  const timestamp = typeof input === 'number' ? input : new Date(input).getTime();
-  const diff = Math.max(0, Date.now() - timestamp);
-  const seconds = Math.floor(diff / 1000);
-  if (seconds < 60) return `${seconds}s ago`;
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  return `${days}d ago`;
 }
 
 export function encodePhaseOption(provider: ExecutorModel, modelId: string | null) {

--- a/packages/shared/src/format-relative-time.ts
+++ b/packages/shared/src/format-relative-time.ts
@@ -1,0 +1,11 @@
+export function formatRelativeTime(input: string | number): string {
+  const timestamp = typeof input === 'number' ? input : new Date(input).getTime();
+  const diff = Math.max(0, Date.now() - timestamp);
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  return `${Math.floor(hours / 24)}d ago`;
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ export * from './branches';
 export * from './cli-model-capabilities';
 export * from './constants';
 export * from './errors';
+export * from './format-relative-time';
 export * from './format-token-count';
 export * from './github-issue-utils';
 export * from './github-labels';


### PR DESCRIPTION
## Summary
- Extract shared `formatRelativeTime` helper in `@shipcode/shared`
- Replace duplicate relative-time formatters in Activity, Inbox, Overview, and issue-detail helpers
- Document the cleanup automation branch-base fix in the 2026-04-30 session log

## Validation
- Biome pre-commit hook passed
- `bunx biome check --write` on touched TS files passed
- Focused `formatRelativeTime` smoke check passed
- `git diff --check` passed

Full package typecheck was not run because this Codex worktree has no `node_modules` installed.