### PR TITLE
[codex] Deduplicate agent running phases

### DIFF
--- a/.agents/SESSIONS/2026-04-30.md
+++ b/.agents/SESSIONS/2026-04-30.md
@@ -51,3 +51,69 @@ Started a new session after context reset. The session-start skill expected olde
 - `bun run typecheck` passed (`15 successful, 15 total`).
 - `bunx vitest run --reporter=dot` in `apps/desktop` passed (`62 files`, `352 tests`) and exited cleanly.
 - `bun run test` passed (`16 successful, 16 total`).
+
+## Session 3: Clean-up automation PR
+
+### Context
+
+Ran the `clean-up-code` automation task to minimize LOC by removing duplication without deleting features. The automation was required to run from a `develop` base, so the first gate was verifying branch ancestry before editing.
+
+### Flow
+
+```mermaid
+flowchart LR
+  A["Verify HEAD base"] --> B["Find duplicate phase arrays"]
+  B --> C["Extract shared constant"]
+  C --> D["Update DB + UI consumers"]
+  D --> E["Validate focused checks"]
+  E --> F["Publish PR #94"]
+  F --> G["Mark ready for review"]
+```
+
+### Affected Components
+
+- Shared constants: exported a single `AGENT_RUNNING_PHASES` list.
+- DB queries: dashboard metrics and thread active/stuck queries now reuse the shared list.
+- UI package: `ActivePipelineCard` now uses the shared list for agent-active rendering.
+- GitHub: opened PR #94 against `develop`.
+
+### What Was Done
+
+- Confirmed the work was based on `origin/develop`, not `master`.
+- Centralized duplicate agent-running phase arrays into `packages/shared/src/constants.ts`.
+- Removed local copies from `packages/db/src/queries/dashboard.ts`, `packages/db/src/queries/threads.ts`, and `packages/ui/src/ActivePipelineCard.tsx`.
+- Created branch `codex/dedupe-agent-running-phases`.
+- Rebased onto current `origin/develop` (`2b1ba3c`).
+- Committed `eab7ed2 refactor(shared): dedupe agent running phases`.
+- Pushed the branch and opened PR #94: https://github.com/shipshitdev/shipcode/pull/94
+- Marked the PR ready for review after correcting the too-conservative draft default.
+
+### Key Decisions
+
+- Used `@shipcode/shared` for the phase list because both `packages/db` and `packages/ui` already depend on shared contracts.
+- Kept the cleanup narrow: one duplicate concept, four files, net LOC reduction.
+- Did not apply labels to PR #94 because the repo does not currently have `codex` or `codex-automation` labels.
+
+### Files Changed
+
+- `packages/shared/src/constants.ts`
+- `packages/db/src/queries/dashboard.ts`
+- `packages/db/src/queries/threads.ts`
+- `packages/ui/src/ActivePipelineCard.tsx`
+- `.agents/SESSIONS/2026-04-30.md`
+
+### Validation
+
+- `bunx biome check packages/shared/src/constants.ts packages/db/src/queries/dashboard.ts packages/db/src/queries/threads.ts packages/ui/src/ActivePipelineCard.tsx --files-ignore-unknown=true`
+- `git diff --check origin/develop..HEAD`
+- `bun run typecheck --filter=@shipcode/shared --filter=@shipcode/db --filter=@shipcode/ui`
+
+### Mistakes And Fixes
+
+- The initial checkout was detached and an earlier local `develop` commit was ahead of `origin/develop`; the cleanup commit was cherry-picked and then rebased onto the live `origin/develop` base before pushing.
+- PR #94 was opened as a draft due to the publish skill default. Vincent asked why; the PR was immediately marked ready for review.
+
+### Next Steps
+
+- Review and merge PR #94.
+- Consider adding `codex` and `codex-automation` labels if automation-created PRs should be labelable by future runs.

--- a/packages/db/src/queries/dashboard.ts
+++ b/packages/db/src/queries/dashboard.ts
@@ -1,5 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite';
 import {
+  AGENT_RUNNING_PHASES,
   type DashboardStats,
   PIPELINE_PHASE,
   type PipelinePhase,
@@ -15,17 +16,6 @@ const ACTIVE_PHASES: PipelinePhase[] = [
   PIPELINE_PHASE.reviewing,
   PIPELINE_PHASE.revising,
   PIPELINE_PHASE.awaitingApproval,
-  PIPELINE_PHASE.executing,
-  PIPELINE_PHASE.testing,
-  PIPELINE_PHASE.verifying,
-  PIPELINE_PHASE.shipping,
-];
-
-// Phases where an agent CLI process is actively running (vs waiting for user).
-const AGENT_RUNNING_PHASES: PipelinePhase[] = [
-  PIPELINE_PHASE.planning,
-  PIPELINE_PHASE.reviewing,
-  PIPELINE_PHASE.revising,
   PIPELINE_PHASE.executing,
   PIPELINE_PHASE.testing,
   PIPELINE_PHASE.verifying,

--- a/packages/db/src/queries/threads.ts
+++ b/packages/db/src/queries/threads.ts
@@ -1,5 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite';
 import {
+  AGENT_RUNNING_PHASES,
   type AnsweredClarification,
   answeredClarificationSchema,
   type ClarificationAnswer,
@@ -15,16 +16,6 @@ import {
 } from '@shipcode/shared';
 import { nanoid } from 'nanoid';
 import { asRow, asRows } from '../utils';
-
-const STUCK_THREAD_PHASES: ThreadStatus[] = [
-  PIPELINE_PHASE.planning,
-  PIPELINE_PHASE.reviewing,
-  PIPELINE_PHASE.revising,
-  PIPELINE_PHASE.executing,
-  PIPELINE_PHASE.testing,
-  PIPELINE_PHASE.verifying,
-  PIPELINE_PHASE.shipping,
-];
 
 interface ThreadRow {
   id: string;
@@ -416,9 +407,9 @@ export class ThreadQueries {
   hasActivePipeline(projectId: string): boolean {
     const row = this.db
       .prepare(
-        `SELECT 1 FROM threads WHERE project_id = ? AND status IN (${Array(STUCK_THREAD_PHASES.length).fill('?').join(',')}) LIMIT 1`,
+        `SELECT 1 FROM threads WHERE project_id = ? AND status IN (${Array(AGENT_RUNNING_PHASES.length).fill('?').join(',')}) LIMIT 1`,
       )
-      .get(projectId, ...STUCK_THREAD_PHASES);
+      .get(projectId, ...AGENT_RUNNING_PHASES);
     return !!row;
   }
 
@@ -426,9 +417,9 @@ export class ThreadQueries {
     return asRows<ThreadRow>(
       this.db
         .prepare(
-          `SELECT * FROM threads WHERE status IN (${Array(STUCK_THREAD_PHASES.length).fill('?').join(',')})`,
+          `SELECT * FROM threads WHERE status IN (${Array(AGENT_RUNNING_PHASES.length).fill('?').join(',')})`,
         )
-        .all(...STUCK_THREAD_PHASES),
+        .all(...AGENT_RUNNING_PHASES),
     ).map(mapThread);
   }
 
@@ -458,10 +449,10 @@ export class ThreadQueries {
     const rows = this.db
       .prepare(
         `SELECT * FROM threads
-         WHERE status IN (${Array(STUCK_THREAD_PHASES.length).fill('?').join(',')})
+         WHERE status IN (${Array(AGENT_RUNNING_PHASES.length).fill('?').join(',')})
            AND updated_at <= datetime('now', '-' || ? || ' seconds')`,
       )
-      .all(...STUCK_THREAD_PHASES, thresholdSec);
+      .all(...AGENT_RUNNING_PHASES, thresholdSec);
     return asRows<ThreadRow>(rows).map(mapThread);
   }
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -1,5 +1,5 @@
 import { PINNED_MODEL_DEFAULTS } from './model-catalog';
-import { type AppSettings, PIPELINE_PHASE } from './types';
+import { type AppSettings, PIPELINE_PHASE, type PipelinePhase } from './types';
 
 export const DEFAULT_STATUS_LABEL_MAPPINGS: Record<string, string> = {
   todo: '',
@@ -101,6 +101,16 @@ export const DEFAULT_SETTINGS: AppSettings = {
 };
 
 export const CURRENT_ONBOARDING_VERSION = 1;
+
+export const AGENT_RUNNING_PHASES: readonly PipelinePhase[] = [
+  PIPELINE_PHASE.planning,
+  PIPELINE_PHASE.reviewing,
+  PIPELINE_PHASE.revising,
+  PIPELINE_PHASE.executing,
+  PIPELINE_PHASE.testing,
+  PIPELINE_PHASE.verifying,
+  PIPELINE_PHASE.shipping,
+] as const;
 
 export const EXECUTION_PHASES = [
   PIPELINE_PHASE.executing,

--- a/packages/ui/src/ActivePipelineCard.tsx
+++ b/packages/ui/src/ActivePipelineCard.tsx
@@ -4,6 +4,7 @@ import type { KeyboardEvent } from 'react';
 import { modelDisplay } from './lib/model-display';
 import { useSharedSecondNow } from './lib/second-ticker';
 import {
+  AGENT_RUNNING_PHASES,
   type ExecutorModel,
   PIPELINE_PHASE,
   type PipelinePhase,
@@ -13,16 +14,6 @@ import { cn } from './lib/utils';
 import { PhaseChip } from './PhaseChip';
 import { Badge } from './primitives/badge';
 import { Button } from './primitives/button';
-
-const AGENT_ACTIVE_PHASES = new Set<PipelinePhase>([
-  PIPELINE_PHASE.planning,
-  PIPELINE_PHASE.reviewing,
-  PIPELINE_PHASE.revising,
-  PIPELINE_PHASE.executing,
-  PIPELINE_PHASE.testing,
-  PIPELINE_PHASE.verifying,
-  PIPELINE_PHASE.shipping,
-]);
 
 function formatElapsed(since: number, now: number): string {
   const seconds = Math.max(0, Math.floor((now - since) / 1000));
@@ -71,7 +62,7 @@ export function ActivePipelineCard({
   const isHumanBlocked =
     phase === PIPELINE_PHASE.clarifying ||
     (phase === PIPELINE_PHASE.awaitingApproval && !approvedAwaitingExecution);
-  const isAgentActive = AGENT_ACTIVE_PHASES.has(phase);
+  const isAgentActive = AGENT_RUNNING_PHASES.includes(phase);
   const progress = phaseToProgress(phase);
 
   const handleKeyDown = (event: KeyboardEvent<HTMLDivElement>) => {


### PR DESCRIPTION
## Summary

Centralizes the repeated list of agent-running pipeline phases into `AGENT_RUNNING_PHASES` in `@shipcode/shared`.

Consumers now reuse the shared constant in:

- DB dashboard stats
- thread active/stuck queries
- `ActivePipelineCard` rendering

## Impact

This removes duplicate phase arrays while preserving behavior. Future pipeline phase changes now have one fewer set of copies to update.

## Validation

- `bunx biome check packages/shared/src/constants.ts packages/db/src/queries/dashboard.ts packages/db/src/queries/threads.ts packages/ui/src/ActivePipelineCard.tsx --files-ignore-unknown=true`
- `git diff --check origin/develop..HEAD`
- `bun run typecheck --filter=@shipcode/shared --filter=@shipcode/db --filter=@shipcode/ui`