### PR TITLE
Refactor shared clampError usage

### DIFF
--- a/apps/desktop/src/renderer/components/CreateIssueModal.tsx
+++ b/apps/desktop/src/renderer/components/CreateIssueModal.tsx
@@ -1,6 +1,7 @@
 import {
   bodyHasRequiredPrdSections,
   buildPrdMetadataLabels,
+  clampError,
   type GitHubIssueCacheRecord,
   ISSUE_PIPELINE_STATUS,
   PRD_REQUIRED_HEADINGS,
@@ -48,17 +49,6 @@ function deriveTitleFromBody(body: string): string {
   const heading = lines.find((l) => l.startsWith('# '));
   const raw = heading ? heading.replace(/^#\s+/, '').replace(/^PRD:\s*/i, '') : (lines[0] ?? '');
   return raw.slice(0, 80).trim();
-}
-
-/**
- * Clamp an error message to a single line + 280 chars so we never dump
- * multi-KB stderr (or an echoed prompt) into the renderer. The full error
- * still goes to the devtools console via `console.error` in the caller.
- */
-function clampError(err: unknown): string {
-  if (err instanceof Error) return err.message.split('\n')[0].slice(0, 280);
-  if (typeof err === 'string') return err.split('\n')[0].slice(0, 280);
-  return 'Unknown error';
 }
 
 function formatBytes(bytes: number): string {

--- a/apps/desktop/src/renderer/features/automations/create-automation-modal.tsx
+++ b/apps/desktop/src/renderer/features/automations/create-automation-modal.tsx
@@ -1,10 +1,11 @@
-import type {
-  AgentType,
-  Automation,
-  CreateAutomationInput,
-  Project,
-  ReasoningEffort,
-  UpdateAutomationInput,
+import {
+  type AgentType,
+  type Automation,
+  type CreateAutomationInput,
+  clampError,
+  type Project,
+  type ReasoningEffort,
+  type UpdateAutomationInput,
 } from '@shipcode/shared';
 import {
   Button,
@@ -52,12 +53,6 @@ const REASONING_OPTIONS: Array<{ value: 'inherit' | ReasoningEffort; label: stri
   { value: 'high', label: 'High' },
   { value: 'xhigh', label: 'Extra high' },
 ];
-
-function clampError(err: unknown): string {
-  if (err instanceof Error) return err.message.split('\n')[0].slice(0, 280);
-  if (typeof err === 'string') return err.split('\n')[0].slice(0, 280);
-  return 'Unknown error';
-}
 
 function presetForCron(cron: string): string {
   const found = PRESETS.find((p) => p.cron === cron);


### PR DESCRIPTION
## Summary
- Removed duplicate `clampError` helpers from the create issue and create automation renderer modals.
- Reused the shared `@shipcode/shared` error clamping helper to keep the renderer surface consistent and smaller.

## Testing
- Verified the focused Biome check on the touched files.
- No unit or UI tests were run for this cleanup.