### PR TITLE
[codex] DRY automation IPC handlers

### DIFF
--- a/apps/desktop/src/main/ipc/register-automation-handlers.ts
+++ b/apps/desktop/src/main/ipc/register-automation-handlers.ts
@@ -4,6 +4,7 @@ import {
   type UpdateAutomationInput,
 } from '@shipcode/shared';
 import { Cron } from 'croner';
+import type { IpcMainInvokeEvent } from 'electron';
 import type { AutomationSchedulerLike } from '../automation-scheduler';
 import log from '../logger.service';
 import type { IpcHandlerDeps } from './types';
@@ -18,117 +19,86 @@ export function registerAutomationHandlers(
   { ipcMain, queries }: IpcHandlerDeps,
   automationScheduler: AutomationSchedulerLike,
 ): void {
-  ipcMain.handle('automations:list-all', async () => {
-    try {
-      return queries.automations.listAll();
-    } catch (err) {
-      log.error('[automations:list-all]', err);
-      throw new Error(clampError(err));
-    }
+  const handleAutomation = <TArgs extends unknown[], TResult>(
+    channel: string,
+    handler: (event: IpcMainInvokeEvent, ...args: TArgs) => TResult | Promise<TResult>,
+  ) => {
+    ipcMain.handle(channel, async (event, ...args) => {
+      try {
+        return await handler(event, ...(args as TArgs));
+      } catch (err) {
+        log.error(`[${channel}]`, err);
+        throw new Error(clampError(err));
+      }
+    });
+  };
+
+  handleAutomation('automations:list-all', async () => {
+    return queries.automations.listAll();
   });
 
-  ipcMain.handle('automations:list', async (_e, { projectId }: { projectId: string }) => {
-    try {
-      return queries.automations.list(projectId);
-    } catch (err) {
-      log.error('[automations:list]', err);
-      throw new Error(clampError(err));
-    }
+  handleAutomation('automations:list', async (_e, { projectId }: { projectId: string }) => {
+    return queries.automations.list(projectId);
   });
 
-  ipcMain.handle('automations:get', async (_e, { id }: { id: string }) => {
-    try {
-      return queries.automations.getById(id);
-    } catch (err) {
-      log.error('[automations:get]', err);
-      throw new Error(clampError(err));
-    }
+  handleAutomation('automations:get', async (_e, { id }: { id: string }) => {
+    return queries.automations.getById(id);
   });
 
-  ipcMain.handle('automations:create', async (_e, input: CreateAutomationInput) => {
-    try {
-      validateCron(input.cronExpr);
-      const automation = queries.automations.create(input);
-      automationScheduler.schedule(automation);
-      return automation;
-    } catch (err) {
-      log.error('[automations:create]', err);
-      throw new Error(clampError(err));
-    }
+  handleAutomation('automations:create', async (_e, input: CreateAutomationInput) => {
+    validateCron(input.cronExpr);
+    const automation = queries.automations.create(input);
+    automationScheduler.schedule(automation);
+    return automation;
   });
 
-  ipcMain.handle(
+  handleAutomation(
     'automations:update',
     async (_e, payload: { id: string } & UpdateAutomationInput) => {
-      try {
-        const { id, ...patch } = payload;
-        if (patch.cronExpr !== undefined) validateCron(patch.cronExpr);
-        const automation = queries.automations.update(id, patch);
-        automationScheduler.schedule(automation);
-        return automation;
-      } catch (err) {
-        log.error('[automations:update]', err);
-        throw new Error(clampError(err));
-      }
+      const { id, ...patch } = payload;
+      if (patch.cronExpr !== undefined) validateCron(patch.cronExpr);
+      const automation = queries.automations.update(id, patch);
+      automationScheduler.schedule(automation);
+      return automation;
     },
   );
 
-  ipcMain.handle('automations:delete', async (_e, { id }: { id: string }) => {
-    try {
-      automationScheduler.unschedule(id);
-      queries.automations.delete(id);
-      return undefined;
-    } catch (err) {
-      log.error('[automations:delete]', err);
-      throw new Error(clampError(err));
-    }
+  handleAutomation('automations:delete', async (_e, { id }: { id: string }) => {
+    automationScheduler.unschedule(id);
+    queries.automations.delete(id);
+    return undefined;
   });
 
-  ipcMain.handle(
+  handleAutomation(
     'automations:set-enabled',
     async (_e, { id, enabled }: { id: string; enabled: boolean }) => {
-      try {
-        const automation = queries.automations.setEnabled(id, enabled);
-        if (enabled) {
-          automationScheduler.schedule(automation);
-        } else {
-          automationScheduler.unschedule(id);
-          queries.automations.setNextRunAt(id, null);
-        }
-        return automation;
-      } catch (err) {
-        log.error('[automations:set-enabled]', err);
-        throw new Error(clampError(err));
+      const automation = queries.automations.setEnabled(id, enabled);
+      if (enabled) {
+        automationScheduler.schedule(automation);
+      } else {
+        automationScheduler.unschedule(id);
+        queries.automations.setNextRunAt(id, null);
       }
+      return automation;
     },
   );
 
-  ipcMain.handle('automations:run-now', async (_e, { id }: { id: string }) => {
-    try {
-      const automation = queries.automations.getById(id);
-      if (!automation) throw new Error(`Automation ${id} not found`);
-      // fireNow routes through pipelineScheduler so capacity caps still apply.
-      // We deliberately don't await the full pipeline run — only the
-      // start-or-queue decision — so the IPC call returns promptly.
-      void automationScheduler.fireNow(id).catch((err) => {
-        log.error(`[automations:run-now] fire failed for ${id}:`, err);
-      });
-      return { queued: false };
-    } catch (err) {
-      log.error('[automations:run-now]', err);
-      throw new Error(clampError(err));
-    }
+  handleAutomation('automations:run-now', async (_e, { id }: { id: string }) => {
+    const automation = queries.automations.getById(id);
+    if (!automation) throw new Error(`Automation ${id} not found`);
+    // fireNow routes through pipelineScheduler so capacity caps still apply.
+    // We deliberately don't await the full pipeline run — only the
+    // start-or-queue decision — so the IPC call returns promptly.
+    void automationScheduler.fireNow(id).catch((err) => {
+      log.error(`[automations:run-now] fire failed for ${id}:`, err);
+    });
+    return { queued: false };
   });
 
-  ipcMain.handle(
+  handleAutomation(
     'automations:run-history',
     async (_e, { automationId }: { automationId: string }) => {
-      try {
-        return queries.threads.listByAutomationId(automationId);
-      } catch (err) {
-        log.error('[automations:run-history]', err);
-        throw new Error(clampError(err));
-      }
+      return queries.threads.listByAutomationId(automationId);
     },
   );
 }


### PR DESCRIPTION
## Summary
- Replaced repeated automation IPC try/catch blocks with one local handler wrapper.
- Preserved per-channel logging, clamped renderer-safe errors, and existing scheduler behavior.
- Reduced `register-automation-handlers.ts` by 30 LOC without deleting features.

## Validation
- `git diff --check`
- `bunx biome check apps/desktop/src/main/ipc/register-automation-handlers.ts --formatter-enabled=false --assist-enabled=false --files-ignore-unknown=true`
- Pre-commit Biome hook passed

## Notes
- `bun --filter @shipcode/desktop typecheck` still fails because workspace package imports such as `@shipcode/shared` and `@shipcode/db` are unresolved in this checkout/typecheck setup, after `bun install --frozen-lockfile` succeeded.