### PR TITLE
Deduplicate CLI issue number parsing

### DIFF
--- a/apps/cli/src/commands/approve.ts
+++ b/apps/cli/src/commands/approve.ts
@@ -2,6 +2,7 @@ import { createPipeline } from '@shipcode/pipeline';
 import { PIPELINE_PHASE } from '@shipcode/shared';
 import { createCliContext } from '../context';
 import { requireOnboarding } from './guard';
+import { parseIssueNumberOrExit } from './issue-number';
 
 /**
  * `shipcode approve <issue-number>`
@@ -12,12 +13,7 @@ import { requireOnboarding } from './guard';
 export async function approveCommand(issueNumber: string) {
   if (!requireOnboarding()) return;
 
-  const num = parseInt(issueNumber, 10);
-  if (Number.isNaN(num)) {
-    console.error('Invalid issue number:', issueNumber);
-    process.exit(1);
-  }
-
+  const num = parseIssueNumberOrExit(issueNumber);
   const ctx = createCliContext(process.cwd());
 
   const thread = ctx.threads.getByProjectAndGithubIssue(ctx.project.id, num);

--- a/apps/cli/src/commands/issue-number.ts
+++ b/apps/cli/src/commands/issue-number.ts
@@ -1,0 +1,8 @@
+export function parseIssueNumberOrExit(issueNumber: string): number {
+  const num = Number.parseInt(issueNumber, 10);
+  if (Number.isNaN(num)) {
+    console.error('Invalid issue number:', issueNumber);
+    process.exit(1);
+  }
+  return num;
+}

--- a/apps/cli/src/commands/logs.ts
+++ b/apps/cli/src/commands/logs.ts
@@ -1,5 +1,6 @@
 import { createCliContext } from '../context';
 import { requireOnboarding } from './guard';
+import { parseIssueNumberOrExit } from './issue-number';
 
 /**
  * `shipcode logs <issue-number>`
@@ -10,12 +11,7 @@ import { requireOnboarding } from './guard';
 export async function logsCommand(issueNumber: string) {
   if (!requireOnboarding()) return;
 
-  const num = parseInt(issueNumber, 10);
-  if (Number.isNaN(num)) {
-    console.error('Invalid issue number:', issueNumber);
-    process.exit(1);
-  }
-
+  const num = parseIssueNumberOrExit(issueNumber);
   const ctx = createCliContext(process.cwd());
 
   const thread = ctx.threads.getByProjectAndGithubIssue(ctx.project.id, num);

--- a/apps/cli/src/commands/plan.ts
+++ b/apps/cli/src/commands/plan.ts
@@ -2,6 +2,7 @@ import { routeFromLabels } from '@shipcode/agents';
 import { createPipeline } from '@shipcode/pipeline';
 import { createCliContext } from '../context';
 import { requireOnboarding } from './guard';
+import { parseIssueNumberOrExit } from './issue-number';
 
 /**
  * `shipcode plan <issue-number>`
@@ -12,12 +13,7 @@ import { requireOnboarding } from './guard';
 export async function planCommand(issueNumber: string) {
   if (!requireOnboarding()) return;
 
-  const num = parseInt(issueNumber, 10);
-  if (Number.isNaN(num)) {
-    console.error('Invalid issue number:', issueNumber);
-    process.exit(1);
-  }
-
+  const num = parseIssueNumberOrExit(issueNumber);
   const ctx = createCliContext(process.cwd());
 
   console.log(`Fetching issue #${num}...`);

--- a/apps/cli/src/commands/retry.ts
+++ b/apps/cli/src/commands/retry.ts
@@ -1,6 +1,7 @@
 import { createPipeline } from '@shipcode/pipeline';
 import { createCliContext } from '../context';
 import { requireOnboarding } from './guard';
+import { parseIssueNumberOrExit } from './issue-number';
 
 /**
  * `shipcode retry <issue-number>`
@@ -11,12 +12,7 @@ import { requireOnboarding } from './guard';
 export async function retryCommand(issueNumber: string) {
   if (!requireOnboarding()) return;
 
-  const num = parseInt(issueNumber, 10);
-  if (Number.isNaN(num)) {
-    console.error('Invalid issue number:', issueNumber);
-    process.exit(1);
-  }
-
+  const num = parseIssueNumberOrExit(issueNumber);
   const ctx = createCliContext(process.cwd());
 
   const thread = ctx.threads.getByProjectAndGithubIssue(ctx.project.id, num);

--- a/apps/cli/src/commands/review.ts
+++ b/apps/cli/src/commands/review.ts
@@ -2,6 +2,7 @@ import { routeFromLabels } from '@shipcode/agents';
 import { createPipeline } from '@shipcode/pipeline';
 import { createCliContext } from '../context';
 import { requireOnboarding } from './guard';
+import { parseIssueNumberOrExit } from './issue-number';
 
 /**
  * `shipcode review <issue-number>`
@@ -11,12 +12,7 @@ import { requireOnboarding } from './guard';
 export async function reviewCommand(issueNumber: string) {
   if (!requireOnboarding()) return;
 
-  const num = parseInt(issueNumber, 10);
-  if (Number.isNaN(num)) {
-    console.error('Invalid issue number:', issueNumber);
-    process.exit(1);
-  }
-
+  const num = parseIssueNumberOrExit(issueNumber);
   const ctx = createCliContext(process.cwd());
 
   console.log(`Fetching issue #${num}...`);

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -2,16 +2,12 @@ import { routeFromLabels } from '@shipcode/agents';
 import { createPipeline } from '@shipcode/pipeline';
 import { createCliContext } from '../context';
 import { requireOnboarding } from './guard';
+import { parseIssueNumberOrExit } from './issue-number';
 
 export async function runCommand(issueNumber: string) {
   if (!requireOnboarding()) return;
 
-  const num = parseInt(issueNumber, 10);
-  if (Number.isNaN(num)) {
-    console.error('Invalid issue number:', issueNumber);
-    process.exit(1);
-  }
-
+  const num = parseIssueNumberOrExit(issueNumber);
   const ctx = createCliContext(process.cwd());
 
   console.log(`Fetching issue #${num}...`);


### PR DESCRIPTION
## Summary
- Extract shared `parseIssueNumberOrExit` helper for CLI commands
- Remove repeated issue-number validation blocks from `run`, `plan`, `review`, `approve`, `retry`, and `logs`
- Keep CLI behavior unchanged while shrinking duplicate code

## Testing
- `bunx biome check apps/cli/src/commands/issue-number.ts apps/cli/src/commands/run.ts apps/cli/src/commands/plan.ts apps/cli/src/commands/review.ts apps/cli/src/commands/approve.ts apps/cli/src/commands/retry.ts apps/cli/src/commands/logs.ts --files-ignore-unknown=true`
- `git diff --check`

Note: Vitest was attempted earlier, but Bun could not use its default temp/cache path; with workspace-local temp/cache it needed dependency resolution for Vitest/deps in that checkout.