### PR TITLE
Refactor CLI issue command helpers

### DIFF
--- a/apps/cli/src/commands/approve.ts
+++ b/apps/cli/src/commands/approve.ts
@@ -2,7 +2,7 @@ import { createPipeline } from '@shipcode/pipeline';
 import { PIPELINE_PHASE } from '@shipcode/shared';
 import { createCliContext } from '../context';
 import { requireOnboarding } from './guard';
-import { parseIssueNumberOrExit } from './issue-number';
+import { getThreadForIssueOrExit, parseIssueNumber } from './issue-helpers';
 
 /**
  * `shipcode approve <issue-number>`
@@ -13,14 +13,9 @@ import { parseIssueNumberOrExit } from './issue-number';
 export async function approveCommand(issueNumber: string) {
   if (!requireOnboarding()) return;
 
-  const num = parseIssueNumberOrExit(issueNumber);
+  const num = parseIssueNumber(issueNumber);
   const ctx = createCliContext(process.cwd());
-
-  const thread = ctx.threads.getByProjectAndGithubIssue(ctx.project.id, num);
-  if (!thread) {
-    console.error(`No thread found for issue #${num} in this project.`);
-    process.exit(1);
-  }
+  const thread = getThreadForIssueOrExit(ctx, num);
 
   if (thread.status !== PIPELINE_PHASE.awaitingApproval) {
     console.error(

--- a/apps/cli/src/commands/issue-helpers.ts
+++ b/apps/cli/src/commands/issue-helpers.ts
@@ -1,0 +1,16 @@
+import type { Thread } from '@shipcode/shared';
+import type { CliContext } from '../context';
+import { parseIssueNumberOrExit } from './issue-number';
+
+export function parseIssueNumber(issueNumber: string): number {
+  return parseIssueNumberOrExit(issueNumber);
+}
+
+export function getThreadForIssueOrExit(ctx: CliContext, issueNumber: number): Thread {
+  const thread = ctx.threads.getByProjectAndGithubIssue(ctx.project.id, issueNumber);
+  if (!thread) {
+    console.error(`No thread found for issue #${issueNumber} in this project.`);
+    process.exit(1);
+  }
+  return thread;
+}

--- a/apps/cli/src/commands/logs.ts
+++ b/apps/cli/src/commands/logs.ts
@@ -1,6 +1,6 @@
 import { createCliContext } from '../context';
 import { requireOnboarding } from './guard';
-import { parseIssueNumberOrExit } from './issue-number';
+import { getThreadForIssueOrExit, parseIssueNumber } from './issue-helpers';
 
 /**
  * `shipcode logs <issue-number>`
@@ -11,14 +11,9 @@ import { parseIssueNumberOrExit } from './issue-number';
 export async function logsCommand(issueNumber: string) {
   if (!requireOnboarding()) return;
 
-  const num = parseIssueNumberOrExit(issueNumber);
+  const num = parseIssueNumber(issueNumber);
   const ctx = createCliContext(process.cwd());
-
-  const thread = ctx.threads.getByProjectAndGithubIssue(ctx.project.id, num);
-  if (!thread) {
-    console.error(`No thread found for issue #${num} in this project.`);
-    process.exit(1);
-  }
+  const thread = getThreadForIssueOrExit(ctx, num);
 
   console.log(`Logs for issue #${num}: ${thread.title}`);
   console.log(`Status: ${thread.status}\n`);

--- a/apps/cli/src/commands/plan.ts
+++ b/apps/cli/src/commands/plan.ts
@@ -2,7 +2,7 @@ import { routeFromLabels } from '@shipcode/agents';
 import { createPipeline } from '@shipcode/pipeline';
 import { createCliContext } from '../context';
 import { requireOnboarding } from './guard';
-import { parseIssueNumberOrExit } from './issue-number';
+import { parseIssueNumber } from './issue-helpers';
 
 /**
  * `shipcode plan <issue-number>`
@@ -13,7 +13,7 @@ import { parseIssueNumberOrExit } from './issue-number';
 export async function planCommand(issueNumber: string) {
   if (!requireOnboarding()) return;
 
-  const num = parseIssueNumberOrExit(issueNumber);
+  const num = parseIssueNumber(issueNumber);
   const ctx = createCliContext(process.cwd());
 
   console.log(`Fetching issue #${num}...`);

--- a/apps/cli/src/commands/retry.ts
+++ b/apps/cli/src/commands/retry.ts
@@ -1,7 +1,7 @@
 import { createPipeline } from '@shipcode/pipeline';
 import { createCliContext } from '../context';
 import { requireOnboarding } from './guard';
-import { parseIssueNumberOrExit } from './issue-number';
+import { getThreadForIssueOrExit, parseIssueNumber } from './issue-helpers';
 
 /**
  * `shipcode retry <issue-number>`
@@ -12,14 +12,9 @@ import { parseIssueNumberOrExit } from './issue-number';
 export async function retryCommand(issueNumber: string) {
   if (!requireOnboarding()) return;
 
-  const num = parseIssueNumberOrExit(issueNumber);
+  const num = parseIssueNumber(issueNumber);
   const ctx = createCliContext(process.cwd());
-
-  const thread = ctx.threads.getByProjectAndGithubIssue(ctx.project.id, num);
-  if (!thread) {
-    console.error(`No thread found for issue #${num} in this project.`);
-    process.exit(1);
-  }
+  const thread = getThreadForIssueOrExit(ctx, num);
 
   const checkpoint = ctx.checkpoints.getLatest(thread.id);
   if (!checkpoint) {

--- a/apps/cli/src/commands/review.ts
+++ b/apps/cli/src/commands/review.ts
@@ -2,7 +2,7 @@ import { routeFromLabels } from '@shipcode/agents';
 import { createPipeline } from '@shipcode/pipeline';
 import { createCliContext } from '../context';
 import { requireOnboarding } from './guard';
-import { parseIssueNumberOrExit } from './issue-number';
+import { parseIssueNumber } from './issue-helpers';
 
 /**
  * `shipcode review <issue-number>`
@@ -12,7 +12,7 @@ import { parseIssueNumberOrExit } from './issue-number';
 export async function reviewCommand(issueNumber: string) {
   if (!requireOnboarding()) return;
 
-  const num = parseIssueNumberOrExit(issueNumber);
+  const num = parseIssueNumber(issueNumber);
   const ctx = createCliContext(process.cwd());
 
   console.log(`Fetching issue #${num}...`);

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -2,12 +2,12 @@ import { routeFromLabels } from '@shipcode/agents';
 import { createPipeline } from '@shipcode/pipeline';
 import { createCliContext } from '../context';
 import { requireOnboarding } from './guard';
-import { parseIssueNumberOrExit } from './issue-number';
+import { parseIssueNumber } from './issue-helpers';
 
 export async function runCommand(issueNumber: string) {
   if (!requireOnboarding()) return;
 
-  const num = parseIssueNumberOrExit(issueNumber);
+  const num = parseIssueNumber(issueNumber);
   const ctx = createCliContext(process.cwd());
 
   console.log(`Fetching issue #${num}...`);


### PR DESCRIPTION
## Summary
- centralize CLI issue number parsing in a shared command helper
- centralize repeated issue thread lookup/exit handling for approve, retry, and logs
- replace duplicate parse blocks across run/plan/review/approve/retry/logs

## Verification
- bunx @biomejs/biome@2.4.14 check apps/cli/src/commands/run.ts apps/cli/src/commands/plan.ts apps/cli/src/commands/review.ts apps/cli/src/commands/approve.ts apps/cli/src/commands/retry.ts apps/cli/src/commands/logs.ts apps/cli/src/commands/issue-helpers.ts --files-ignore-unknown=true
- git diff --check
- bun build apps/cli/src/commands/run.ts apps/cli/src/commands/plan.ts apps/cli/src/commands/review.ts apps/cli/src/commands/approve.ts apps/cli/src/commands/retry.ts apps/cli/src/commands/logs.ts --target=node --packages=external --outdir=/private/tmp/shipcode-cli-command-check

Note: codex/codex-automation labels are not present in this repo.