### PR TITLE
[codex] Centralize terminal clock formatting

### DIFF
--- a/apps/desktop/src/main/ipc/register-support-handlers.ts
+++ b/apps/desktop/src/main/ipc/register-support-handlers.ts
@@ -17,6 +17,7 @@ import {
 import {
   clampError,
   type ExecutorModel,
+  formatClockTime,
   type GeneratorCli,
   providerDisplay,
 } from '@shipcode/shared';
@@ -270,12 +271,7 @@ export function registerSupportHandlers({
     }
 
     if ((state === 'running' || state === 'exited') && proc?.threadId) {
-      const ts = new Date().toLocaleTimeString('en-US', {
-        hour12: false,
-        hour: '2-digit',
-        minute: '2-digit',
-        second: '2-digit',
-      });
+      const ts = formatClockTime(new Date());
       const agentColor =
         type === 'claude' ? '\x1b[36m' : type === 'codex' ? '\x1b[33m' : '\x1b[35m';
       const exitColor = state === 'exited' ? '\x1b[2m' : '';

--- a/apps/desktop/src/main/pipeline-bridge.ts
+++ b/apps/desktop/src/main/pipeline-bridge.ts
@@ -7,6 +7,7 @@ import type {
 import type { PipelineEmitter, PipelineEvent } from '@shipcode/pipeline';
 import {
   type ActivityKind,
+  formatClockTime,
   formatResolvedModelDisplay,
   PIPELINE_PHASE,
   type PipelinePhase,
@@ -29,17 +30,8 @@ interface EmitterDeps {
   onExecutionSlotFreed?: () => void;
 }
 
-function formatClock(isoLike: string): string {
-  return new Date(isoLike).toLocaleTimeString('en-US', {
-    hour12: false,
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-  });
-}
-
 function formatTimestampPrefix(isoLike: string): string {
-  return `\x1b[90m[${formatClock(isoLike)}]\x1b[0m`;
+  return `\x1b[90m[${formatClockTime(isoLike)}]\x1b[0m`;
 }
 
 // Phase transitions that map to human-visible activity entries.

--- a/apps/desktop/src/renderer/components/terminal-drawer/useTerminalDrawer.ts
+++ b/apps/desktop/src/renderer/components/terminal-drawer/useTerminalDrawer.ts
@@ -5,7 +5,7 @@ import type {
   PlanRecord,
   Thread,
 } from '@shipcode/shared';
-import { PIPELINE_PHASE } from '@shipcode/shared';
+import { formatClockTime, PIPELINE_PHASE } from '@shipcode/shared';
 import { useQuery } from '@tanstack/react-query';
 import { useCallback, useMemo, useRef, useState } from 'react';
 import { STABLE_APP_STATE_STALE_TIME } from '../../query-stale-times';
@@ -221,15 +221,7 @@ export function useTerminalDrawer() {
     resolvedHeight: isMaximized ? undefined : height,
     runningTargets,
     showEmptyState: displayTarget === null,
-    startedAt:
-      firstEventCreatedAt != null
-        ? new Date(firstEventCreatedAt).toLocaleTimeString('en-US', {
-            hour12: false,
-            hour: '2-digit',
-            minute: '2-digit',
-            second: '2-digit',
-          })
-        : null,
+    startedAt: firstEventCreatedAt != null ? formatClockTime(firstEventCreatedAt) : null,
     terminalThreadId: visibleTerminalThreadId,
     toggleMaximize,
     toggleTerminal,

--- a/apps/desktop/src/renderer/components/terminal-transcript/TerminalTranscript.tsx
+++ b/apps/desktop/src/renderer/components/terminal-transcript/TerminalTranscript.tsx
@@ -1,5 +1,5 @@
 import type { CanonicalTerminalEvent, TerminalEventRecord } from '@shipcode/shared';
-import { ERROR_PATTERNS } from '@shipcode/shared';
+import { ERROR_PATTERNS, formatClockTime } from '@shipcode/shared';
 import { Badge, Button, cn } from '@shipshitdev/ui';
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -33,15 +33,6 @@ function stripAnsi(value: string): string {
   return value.replace(ANSI_RE, '');
 }
 
-function formatClock(isoLike: string): string {
-  return new Date(isoLike).toLocaleTimeString('en-US', {
-    hour12: false,
-    hour: '2-digit',
-    minute: '2-digit',
-    second: '2-digit',
-  });
-}
-
 function formatTokens(usage: { prompt: number; completion: number } | undefined, costUsd?: number) {
   const parts: string[] = [];
   if (usage) parts.push(`${usage.prompt}+${usage.completion} tok`);
@@ -65,7 +56,7 @@ function TranscriptMeta({
         compact && 'text-[9px]',
       )}
     >
-      <span>{formatClock(createdAt)}</span>
+      <span>{formatClockTime(createdAt)}</span>
       {children}
     </div>
   );

--- a/packages/shared/src/format-clock-time.ts
+++ b/packages/shared/src/format-clock-time.ts
@@ -1,0 +1,9 @@
+export function formatClockTime(input: string | number | Date): string {
+  const date = input instanceof Date ? input : new Date(input);
+  return date.toLocaleTimeString('en-US', {
+    hour12: false,
+    hour: '2-digit',
+    minute: '2-digit',
+    second: '2-digit',
+  });
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,7 @@ export * from './branches';
 export * from './cli-model-capabilities';
 export * from './constants';
 export * from './errors';
+export * from './format-clock-time';
 export * from './format-cost';
 export * from './format-duration';
 export * from './format-relative-time';


### PR DESCRIPTION
## Summary

- Added a shared `formatClockTime` helper for terminal-style HH:MM:SS timestamps.
- Replaced duplicate inline clock formatting in pipeline bridge, support lifecycle events, terminal drawer, and terminal transcript.
- Reduces repeated timestamp formatting code without changing display behavior.

## Validation

- `bunx biome check packages/shared/src/format-clock-time.ts packages/shared/src/index.ts apps/desktop/src/main/pipeline-bridge.ts apps/desktop/src/main/ipc/register-support-handlers.ts apps/desktop/src/renderer/components/terminal-transcript/TerminalTranscript.tsx apps/desktop/src/renderer/components/terminal-drawer/useTerminalDrawer.ts --files-ignore-unknown=true`
- `git diff --check`

## Notes

- Package typecheck/tests were blocked in this worktree before commit by missing local dependencies (`@types/node`, `react/jsx-dev-runtime`).
