### PR TITLE
[codex] Centralize ANSI stripping

### DIFF
--- a/apps/desktop/src/main/git-workflows.ts
+++ b/apps/desktop/src/main/git-workflows.ts
@@ -7,16 +7,11 @@ import type {
   CleanupItem,
   Project,
 } from '@shipcode/shared';
+import { stripAnsi } from '@shipcode/shared';
 import log from './logger.service';
 
 interface ActiveWorktreeOwner {
   worktreePath: string | null;
-}
-
-const ANSI_ESCAPE_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g');
-
-function stripAnsi(value: string): string {
-  return value.replace(ANSI_ESCAPE_PATTERN, '');
 }
 
 function summarizeCommitFailure(value: string): string {

--- a/apps/desktop/src/renderer/components/issue-detail/helpers.ts
+++ b/apps/desktop/src/renderer/components/issue-detail/helpers.ts
@@ -7,14 +7,7 @@ import type {
 } from '@shipcode/shared';
 import { PIPELINE_PHASE, shipCodePlanSchema } from '@shipcode/shared';
 
-export { formatRelativeTime as timeAgo } from '@shipcode/shared';
-
-// biome-ignore lint/suspicious/noControlCharactersInRegex: strips ANSI formatting from persisted terminal lines
-const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]|\x1b\].*?(?:\x07|\x1b\\)/g;
-
-export function stripAnsi(value: string): string {
-  return value.replace(ANSI_RE, '');
-}
+export { formatRelativeTime as timeAgo, stripAnsi } from '@shipcode/shared';
 
 export const ACTIVE_PHASES: PipelinePhase[] = [
   PIPELINE_PHASE.planning,

--- a/apps/desktop/src/renderer/components/terminal-transcript/TerminalTranscript.tsx
+++ b/apps/desktop/src/renderer/components/terminal-transcript/TerminalTranscript.tsx
@@ -1,5 +1,5 @@
 import type { CanonicalTerminalEvent, TerminalEventRecord } from '@shipcode/shared';
-import { ERROR_PATTERNS } from '@shipcode/shared';
+import { ERROR_PATTERNS, stripAnsi } from '@shipcode/shared';
 import { Badge, Button, cn } from '@shipshitdev/ui';
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -12,8 +12,6 @@ interface TerminalTranscriptProps {
   onAction?: (event: Extract<CanonicalTerminalEvent, { kind: 'action' }>) => void;
 }
 
-// biome-ignore lint/suspicious/noControlCharactersInRegex: strips ANSI formatting from persisted terminal lines
-const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]|\x1b\].*?(?:\x07|\x1b\\)/g;
 const DEFAULT_VISIBLE_EVENT_LIMIT = 300;
 
 const ERROR_LINE_RE = /(^|\s)(error|fatal|panic|exception|traceback|posix_spawnp failed)\b/i;
@@ -27,10 +25,6 @@ function classifyConsoleLine(content: string): ConsoleSeverity {
   if (EXIT_NONZERO_RE.test(content)) return 'error';
   if (WARNING_LINE_RE.test(content)) return 'warning';
   return 'info';
-}
-
-function stripAnsi(value: string): string {
-  return value.replace(ANSI_RE, '');
 }
 
 function formatClock(isoLike: string): string {

--- a/packages/agents/src/parsers/cli-ndjson.ts
+++ b/packages/agents/src/parsers/cli-ndjson.ts
@@ -8,19 +8,14 @@
  * so changes to one don't ripple through unrelated code.
  */
 
-import { sanitizeResolvedModel } from '@shipcode/shared';
+import { sanitizeResolvedModel, stripAnsi } from '@shipcode/shared';
+
+export { stripAnsi };
 
 export interface CliUsage {
   inputTokens: number;
   outputTokens: number;
   costUsd: number;
-}
-
-// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escape codes
-const ANSI_RE = /\x1b\[[0-9;]*[a-zA-Z]/g;
-
-export function stripAnsi(text: string): string {
-  return text.replace(ANSI_RE, '');
 }
 
 /**

--- a/packages/agents/src/providers/output-summary.ts
+++ b/packages/agents/src/providers/output-summary.ts
@@ -1,11 +1,6 @@
-import { clampTextBlock } from '@shipcode/shared';
+import { clampTextBlock, stripAnsi } from '@shipcode/shared';
 
-// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional ANSI stripping for terminal summaries
-const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]|\x1b\].*?(?:\x07|\x1b\\)/g;
-
-export function stripAnsi(value: string): string {
-  return value.replace(ANSI_RE, '');
-}
+export { stripAnsi };
 
 export function summarizeTerminalText(
   raw: string | null | undefined,

--- a/packages/shared/src/ansi.ts
+++ b/packages/shared/src/ansi.ts
@@ -1,0 +1,6 @@
+// biome-ignore lint/suspicious/noControlCharactersInRegex: strips terminal ANSI control sequences
+const ANSI_ESCAPE_PATTERN = /\x1b\[[0-?]*[ -/]*[@-~]|\x1b\][^\x07]*(?:\x07|\x1b\\)/g;
+
+export function stripAnsi(value: string): string {
+  return value.replace(ANSI_ESCAPE_PATTERN, '');
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
+export * from './ansi';
 export * from './branch-name';
 export * from './branches';
 export * from './cli-model-capabilities';


### PR DESCRIPTION
## Summary
- Add a shared `stripAnsi` helper in `@shipcode/shared`.
- Replace duplicated ANSI regex helpers in agent parsing/output summaries and desktop renderer/main code.
- Preserve existing re-export surfaces used by parser/provider and issue-detail imports.

## Validation
- `bunx biome check packages/shared/src/ansi.ts packages/shared/src/index.ts packages/agents/src/parsers/cli-ndjson.ts packages/agents/src/providers/output-summary.ts apps/desktop/src/main/git-workflows.ts apps/desktop/src/renderer/components/terminal-transcript/TerminalTranscript.tsx apps/desktop/src/renderer/components/issue-detail/helpers.ts --files-ignore-unknown=true`
- `git diff --check`

## Notes
- Package typecheck was blocked locally by missing `@types/node`.
- Package tests were blocked locally by missing `vitest`.