### PR TITLE
Centralize unified diff parsing

### DIFF
--- a/apps/desktop/src/main/ipc/register-project-handlers.ts
+++ b/apps/desktop/src/main/ipc/register-project-handlers.ts
@@ -35,6 +35,7 @@ import {
   DEFAULT_SETTINGS,
   PIPELINE_PHASE,
   parseGithubRemote,
+  parseUnifiedDiff,
   validateGithubProjectUrl,
 } from '@shipcode/shared';
 import { resolveWorktreeParent } from '@shipcode/shared/worktree-path';
@@ -94,103 +95,13 @@ function buildStarterIssueBody(repoFullName: string): string {
   ].join('\n');
 }
 
-function stripDiffPathQuotes(value: string): string {
-  if (value.startsWith('"') && value.endsWith('"') && value.length >= 2) {
-    return value.slice(1, -1);
-  }
-  return value;
-}
-
-function normalizeDiffPath(value: string | null | undefined): string | null {
-  if (!value) return null;
-  const unquoted = stripDiffPathQuotes(value.trim());
-  if (unquoted === '/dev/null') return null;
-  if (unquoted.startsWith('a/') || unquoted.startsWith('b/')) {
-    return unquoted.slice(2);
-  }
-  return unquoted;
-}
-
-function parseDiffGitHeader(line: string): { beforePath: string | null; afterPath: string | null } {
-  const match = /^diff --git "?a\/(.+?)"? "?b\/(.+?)"?$/.exec(line);
-  if (!match) {
-    return { beforePath: null, afterPath: null };
-  }
-  return {
-    beforePath: normalizeDiffPath(`a/${match[1]}`),
-    afterPath: normalizeDiffPath(`b/${match[2]}`),
-  };
-}
-
 function parseDiffRecords(diff: string, threadId: string): DiffRecord[] {
-  const normalized = diff.trim();
-  if (!normalized) return [];
-
   const now = new Date().toISOString();
-  const sections = normalized
-    .split(/^diff --git /m)
-    .map((section, index) => (index === 0 ? section : `diff --git ${section}`))
-    .filter((section) => section.trim().startsWith('diff --git '));
-
-  return sections.map((section, index) => {
-    const lines = section.split('\n');
-    const header = parseDiffGitHeader(lines[0] ?? '');
-
-    let action: DiffRecord['action'] = 'modify';
-    let beforePath = header.beforePath;
-    let afterPath = header.afterPath;
-    let beforeHash: string | null = null;
-    let afterHash: string | null = null;
-
-    for (const line of lines) {
-      if (line.startsWith('new file mode ')) {
-        action = 'create';
-        continue;
-      }
-      if (line.startsWith('deleted file mode ')) {
-        action = 'delete';
-        continue;
-      }
-      if (line.startsWith('rename from ')) {
-        action = 'rename';
-        beforePath = normalizeDiffPath(line.slice('rename from '.length));
-        continue;
-      }
-      if (line.startsWith('rename to ')) {
-        action = 'rename';
-        afterPath = normalizeDiffPath(line.slice('rename to '.length));
-        continue;
-      }
-      if (line.startsWith('index ')) {
-        const match = /^index ([0-9a-f]+)\.\.([0-9a-f]+)/i.exec(line);
-        if (match) {
-          beforeHash = match[1];
-          afterHash = match[2];
-        }
-        continue;
-      }
-      if (line.startsWith('--- ')) {
-        beforePath = normalizeDiffPath(line.slice(4));
-        continue;
-      }
-      if (line.startsWith('+++ ')) {
-        afterPath = normalizeDiffPath(line.slice(4));
-      }
-    }
-
-    const filePath =
-      action === 'delete'
-        ? (beforePath ?? afterPath ?? 'changes.patch')
-        : (afterPath ?? beforePath ?? 'changes.patch');
-
+  return parseUnifiedDiff(diff).map((record, index) => {
     return {
-      id: `${threadId}:${index}:${filePath}`,
+      id: `${threadId}:${index}:${record.filePath}`,
       threadId,
-      filePath,
-      action,
-      diffContent: section,
-      beforeHash,
-      afterHash,
+      ...record,
       createdAt: now,
     };
   });

--- a/packages/pipeline/src/pipeline/execution-phases.ts
+++ b/packages/pipeline/src/pipeline/execution-phases.ts
@@ -20,6 +20,7 @@ import {
   MAX_TEST_RETRIES,
   MAX_VERIFICATION_RETRIES,
   PIPELINE_PHASE,
+  parseUnifiedDiff,
   type ShipCodePlan,
 } from '@shipcode/shared';
 import {
@@ -28,7 +29,6 @@ import {
   type TaskNodeRecord,
 } from '@shipcode/shared/source';
 import { renderWorkflowPromptTemplate } from '../workflow-prompt';
-import { parseUnifiedDiff } from './diff-parser';
 import type { PipelineHelperEnv } from './shared';
 
 // Extract a short, human-readable error from an executor transcript.

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -31,5 +31,6 @@ export * from './staleness';
 export * from './task-graph';
 export * from './tokens';
 export * from './types';
+export * from './unified-diff';
 // worktree-path uses node:path — import directly from '@shipcode/shared/worktree-path'
 // to avoid Vite externalization warnings in renderer code.

--- a/packages/shared/src/unified-diff.ts
+++ b/packages/shared/src/unified-diff.ts
@@ -1,4 +1,12 @@
-import type { DiffInsert } from '@shipcode/db';
+import type { DiffRecord } from './types';
+
+export interface UnifiedDiffFile {
+  filePath: string;
+  action: DiffRecord['action'];
+  diffContent: string;
+  beforeHash: string | null;
+  afterHash: string | null;
+}
 
 function stripQuotes(value: string): string {
   if (value.startsWith('"') && value.endsWith('"') && value.length >= 2) {
@@ -28,7 +36,7 @@ function parseGitHeader(line: string): { beforePath: string | null; afterPath: s
   };
 }
 
-export function parseUnifiedDiff(diff: string): DiffInsert[] {
+export function parseUnifiedDiff(diff: string): UnifiedDiffFile[] {
   const normalized = diff.trim();
   if (!normalized) return [];
 
@@ -41,7 +49,7 @@ export function parseUnifiedDiff(diff: string): DiffInsert[] {
     const lines = section.split('\n');
     const header = parseGitHeader(lines[0] ?? '');
 
-    let action: DiffInsert['action'] = 'modify';
+    let action: DiffRecord['action'] = 'modify';
     let beforePath = header.beforePath;
     let afterPath = header.afterPath;
     let beforeHash: string | null = null;


### PR DESCRIPTION
## Summary
- Move unified git diff parsing into @shipcode/shared.
- Replace duplicate desktop IPC parsing with a thin DiffRecord mapper.
- Keep pipeline diff persistence on the same parser behavior.

## Validation
- bun install --frozen-lockfile
- bunx turbo run build --filter=@shipcode/shared --filter=@shipcode/db --filter=@shipcode/git --filter=@shipcode/agents --filter=@shipcode/pipeline --filter=@shipcode/ui
- bun run --cwd packages/shared typecheck
- bun run --cwd packages/pipeline typecheck
- bun run --cwd apps/desktop typecheck
- bunx biome check apps/desktop/src/main/ipc/register-project-handlers.ts packages/pipeline/src/pipeline/execution-phases.ts packages/shared/src/index.ts packages/shared/src/unified-diff.ts --files-ignore-unknown=true
- git diff --check
- Bun parser smoke test