### PR TITLE
[codex] Centralize ANSI stripping

### DIFF
--- a/apps/desktop/src/main/git-workflows.ts
+++ b/apps/desktop/src/main/git-workflows.ts
@@ -7,16 +7,11 @@ import type {
   CleanupItem,
   Project,
 } from '@shipcode/shared';
+import { stripAnsi } from '@shipcode/shared';
 import log from './logger.service';
 
 interface ActiveWorktreeOwner {
   worktreePath: string | null;
-}
-
-const ANSI_ESCAPE_PATTERN = new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g');
-
-function stripAnsi(value: string): string {
-  return value.replace(ANSI_ESCAPE_PATTERN, '');
 }
 
 function summarizeCommitFailure(value: string): string {

--- a/apps/desktop/src/renderer/components/issue-detail/helpers.ts
+++ b/apps/desktop/src/renderer/components/issue-detail/helpers.ts
@@ -5,16 +5,10 @@ import type {
   ReviewRecord,
   ShipCodePlan,
 } from '@shipcode/shared';
-import { PIPELINE_PHASE, shipCodePlanSchema } from '@shipcode/shared';
+import { PIPELINE_PHASE, shipCodePlanSchema, stripAnsi } from '@shipcode/shared';
 
 export { formatRelativeTime as timeAgo } from '@shipcode/shared';
-
-// biome-ignore lint/suspicious/noControlCharactersInRegex: strips ANSI formatting from persisted terminal lines
-const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]|\x1b\].*?(?:\x07|\x1b\\)/g;
-
-export function stripAnsi(value: string): string {
-  return value.replace(ANSI_RE, '');
-}
+export { stripAnsi };
 
 export const ACTIVE_PHASES: PipelinePhase[] = [
   PIPELINE_PHASE.planning,
@@ -131,8 +125,7 @@ export function decodePhaseOption(value: string): {
 function resolveRawPlanText(raw: string): string {
   const lines = raw.split('\n');
   for (let i = lines.length - 1; i >= 0; i--) {
-    // biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI codes
-    const line = lines[i].replace(/\x1b\[[0-9;]*[a-zA-Z]/g, '').trim();
+    const line = stripAnsi(lines[i]).trim();
     if (!line) continue;
     try {
       const parsed = JSON.parse(line);

--- a/apps/desktop/src/renderer/components/terminal-transcript/TerminalTranscript.tsx
+++ b/apps/desktop/src/renderer/components/terminal-transcript/TerminalTranscript.tsx
@@ -1,5 +1,5 @@
 import type { CanonicalTerminalEvent, TerminalEventRecord } from '@shipcode/shared';
-import { ERROR_PATTERNS, formatClockTime } from '@shipcode/shared';
+import { ERROR_PATTERNS, formatClockTime, stripAnsi } from '@shipcode/shared';
 import { Badge, Button, cn } from '@shipshitdev/ui';
 import { memo, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -12,8 +12,6 @@ interface TerminalTranscriptProps {
   onAction?: (event: Extract<CanonicalTerminalEvent, { kind: 'action' }>) => void;
 }
 
-// biome-ignore lint/suspicious/noControlCharactersInRegex: strips ANSI formatting from persisted terminal lines
-const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]|\x1b\].*?(?:\x07|\x1b\\)/g;
 const DEFAULT_VISIBLE_EVENT_LIMIT = 300;
 
 const ERROR_LINE_RE = /(^|\s)(error|fatal|panic|exception|traceback|posix_spawnp failed)\b/i;
@@ -27,10 +25,6 @@ function classifyConsoleLine(content: string): ConsoleSeverity {
   if (EXIT_NONZERO_RE.test(content)) return 'error';
   if (WARNING_LINE_RE.test(content)) return 'warning';
   return 'info';
-}
-
-function stripAnsi(value: string): string {
-  return value.replace(ANSI_RE, '');
 }
 
 function formatTokens(usage: { prompt: number; completion: number } | undefined, costUsd?: number) {

--- a/packages/agents/src/health-check.ts
+++ b/packages/agents/src/health-check.ts
@@ -30,6 +30,7 @@ import {
   getSupportedReasoningEfforts,
   normalizeReasoningModelId,
   OPENROUTER_API_BASE,
+  stripAnsi,
 } from '@shipcode/shared';
 import * as pty from 'node-pty';
 
@@ -392,16 +393,12 @@ interface ClaudeAuthDetails {
   loginMethod: string | null;
 }
 
-function stripAnsiCodes(text: string): string {
-  const csiSource = String.raw`\\u001B\\[[0-?]*[ -/]*[@-~]`.replace(/\\\\/g, '\\');
-  const oscSource = String.raw`\\u001B\\][^\\u0007]*(?:\\u0007|\\u001B\\\\)`.replace(/\\\\/g, '\\');
-  const csiPattern = new RegExp(csiSource, 'g');
-  const oscPattern = new RegExp(oscSource, 'g');
-  return text.replace(csiPattern, '').replace(oscPattern, '').replace(/\r/g, '');
+function cleanTerminalText(text: string): string {
+  return stripAnsi(text).replace(/\r/g, '');
 }
 
 function normalizeForSearch(text: string): string {
-  return stripAnsiCodes(text).toLowerCase().replace(/\s+/g, '');
+  return cleanTerminalText(text).toLowerCase().replace(/\s+/g, '');
 }
 
 function escapeRegex(value: string): string {
@@ -774,7 +771,7 @@ export function parseCodexStatusText(
   // "codex --version" outputs "codex-cli X.Y.Z" — strip the binary name prefix so
   // the UI renders "vX.Y.Z" instead of "vcodex-cli X.Y.Z".
   const normalizedVersion = version ? (version.match(/\d+\.\d+[\w.-]*/)?.[0] ?? version) : null;
-  const clean = stripAnsiCodes(stdout);
+  const clean = cleanTerminalText(stdout);
   const creditsRemaining = firstNumber(/Credits:\s*([0-9][0-9., ]*)/i, clean);
   const sessionLine = firstCodexLimitBlock(clean, '5h limit');
   const weeklyLine = firstCodexLimitBlock(clean, 'Weekly limit');
@@ -838,7 +835,7 @@ export function parseClaudeUsageText(
   // "claude --version" outputs e.g. "2.1.92 (Claude Code)" — strip the parenthetical
   // so the UI renders "v2.1.92" instead of "v2.1.92 (Claude Code)".
   const normalizedVersion = version ? (version.match(/\d+\.\d+[\w.-]*/)?.[0] ?? version) : null;
-  const clean = stripAnsiCodes(stdout);
+  const clean = cleanTerminalText(stdout);
   const collapsed = clean.replace(/\s+/g, ' ').trim();
   const compact = normalizeForSearch(clean);
 

--- a/packages/agents/src/parsers/cli-ndjson.ts
+++ b/packages/agents/src/parsers/cli-ndjson.ts
@@ -8,7 +8,7 @@
  * so changes to one don't ripple through unrelated code.
  */
 
-import { sanitizeResolvedModel } from '@shipcode/shared';
+import { sanitizeResolvedModel, stripAnsi } from '@shipcode/shared';
 
 export interface CliUsage {
   inputTokens: number;
@@ -16,12 +16,7 @@ export interface CliUsage {
   costUsd: number;
 }
 
-// biome-ignore lint/suspicious/noControlCharactersInRegex: stripping ANSI escape codes
-const ANSI_RE = /\x1b\[[0-9;]*[a-zA-Z]/g;
-
-export function stripAnsi(text: string): string {
-  return text.replace(ANSI_RE, '');
-}
+export { stripAnsi };
 
 /**
  * Best-effort `JSON.parse` that returns `null` on syntax error instead of

--- a/packages/agents/src/providers/output-summary.ts
+++ b/packages/agents/src/providers/output-summary.ts
@@ -1,11 +1,6 @@
-import { clampTextBlock } from '@shipcode/shared';
+import { clampTextBlock, stripAnsi } from '@shipcode/shared';
 
-// biome-ignore lint/suspicious/noControlCharactersInRegex: intentional ANSI stripping for terminal summaries
-const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]|\x1b\].*?(?:\x07|\x1b\\)/g;
-
-export function stripAnsi(value: string): string {
-  return value.replace(ANSI_RE, '');
-}
+export { stripAnsi };
 
 export function summarizeTerminalText(
   raw: string | null | undefined,

--- a/packages/shared/src/ansi.ts
+++ b/packages/shared/src/ansi.ts
@@ -1,0 +1,9 @@
+const ESC = String.fromCharCode(27);
+const ANSI_ESCAPE_PATTERN = new RegExp(
+  `${ESC}\\[[0-?]*[ -/]*[@-~]|${ESC}\\][^\\u0007]*(?:\\u0007|${ESC}\\\\)`,
+  'g',
+);
+
+export function stripAnsi(value: string): string {
+  return value.replace(ANSI_ESCAPE_PATTERN, '');
+}

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,3 +1,4 @@
+export * from './ansi';
 export * from './branch-name';
 export * from './branches';
 export * from './cli-model-capabilities';


### PR DESCRIPTION
## Summary

- Add a shared `stripAnsi` helper in `@shipcode/shared`.
- Replace duplicate ANSI-stripping regex helpers across agents, desktop main, terminal transcript, issue-detail helpers, and health-check parsing.
- Keep compatibility re-exports for existing parser/provider imports while consolidating the implementation.

## Validation

- `bunx biome check --write packages/shared/src/ansi.ts packages/shared/src/index.ts apps/desktop/src/main/git-workflows.ts packages/agents/src/providers/output-summary.ts packages/agents/src/parsers/cli-ndjson.ts packages/agents/src/health-check.ts apps/desktop/src/renderer/components/issue-detail/helpers.ts apps/desktop/src/renderer/components/terminal-transcript/TerminalTranscript.tsx`
- `bunx biome check packages/shared/src/ansi.ts packages/shared/src/index.ts apps/desktop/src/main/git-workflows.ts packages/agents/src/providers/output-summary.ts packages/agents/src/parsers/cli-ndjson.ts packages/agents/src/health-check.ts apps/desktop/src/renderer/components/issue-detail/helpers.ts apps/desktop/src/renderer/components/terminal-transcript/TerminalTranscript.tsx`
- `git diff --check`
- `bun --eval "import { stripAnsi } from './packages/shared/src/ansi.ts'; const input = '\\u001b[31mred\\u001b[0m \\u001b]0;title\\u0007text'; if (stripAnsi(input) !== 'red text') process.exit(1);"`
- `bun install --frozen-lockfile`
- `bun run --filter @shipcode/shared typecheck`
- `bun run --filter @shipcode/agents typecheck`
- `bun run --filter @shipcode/desktop typecheck`