### PR TITLE
[codex] Dedupe renderer test helpers

### DIFF
--- a/apps/desktop/src/renderer/components/ProjectSettingsModal.test.tsx
+++ b/apps/desktop/src/renderer/components/ProjectSettingsModal.test.tsx
@@ -6,10 +6,10 @@ import {
   type IntegrationStatus,
   type Project,
 } from '@shipcode/shared';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAppStore } from '../stores/app-store';
+import { renderWithQueryClient } from '../test/render';
 import { ProjectSettingsModal } from './ProjectSettingsModal';
 
 vi.mock('electron-log/renderer', () => ({
@@ -19,20 +19,7 @@ vi.mock('electron-log/renderer', () => ({
 }));
 
 function renderWithProviders() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-        refetchOnWindowFocus: false,
-      },
-    },
-  });
-
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <ProjectSettingsModal />
-    </QueryClientProvider>,
-  );
+  return renderWithQueryClient(<ProjectSettingsModal />);
 }
 
 describe('ProjectSettingsModal', () => {

--- a/apps/desktop/src/renderer/components/ProjectSidebar.test.tsx
+++ b/apps/desktop/src/renderer/components/ProjectSidebar.test.tsx
@@ -1,33 +1,22 @@
 import {
-  type CliProviderUsageMap,
-  type CliProviderUsageStatus,
   type DashboardStats,
   DEFAULT_SETTINGS,
   type IntegrationStatus,
   type NotificationRecord,
   type Project,
 } from '@shipcode/shared';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAppStore } from '../stores/app-store';
+import {
+  makeProviderUsageStatus as makeUsage,
+  makeProviderUsageMap as makeUsageMap,
+} from '../test/provider-usage';
+import { renderWithQueryClient } from '../test/render';
 import { ProjectSidebar } from './ProjectSidebar';
 
 function renderWithProviders() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-        refetchOnWindowFocus: false,
-      },
-    },
-  });
-
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <ProjectSidebar />
-    </QueryClientProvider>,
-  );
+  return renderWithQueryClient(<ProjectSidebar />);
 }
 
 async function openProjectActionsMenu() {
@@ -178,81 +167,6 @@ const integrations: IntegrationStatus = {
     },
   },
 };
-
-function makeUsage(
-  provider: 'claude' | 'codex',
-  overrides: Partial<CliProviderUsageStatus>,
-): CliProviderUsageStatus {
-  return {
-    provider,
-    available: true,
-    stale: false,
-    state: 'ready',
-    source: 'cli',
-    version: '1.0.0',
-    accountEmail: 'vincent@shipshit.dev',
-    loginMethod: 'pro',
-    updatedAt: '2026-04-16T16:00:00.000Z',
-    checkedAt: '2026-04-16T16:01:00.000Z',
-    message: null,
-    creditsRemaining: null,
-    windows:
-      provider === 'claude'
-        ? [
-            {
-              key: 'session',
-              label: 'Session',
-              usedPercent: 10,
-              leftPercent: 90,
-              resetsAt: null,
-              resetDescription: null,
-            },
-            {
-              key: 'weekly',
-              label: 'Weekly',
-              usedPercent: 20,
-              leftPercent: 80,
-              resetsAt: null,
-              resetDescription: null,
-            },
-            {
-              key: 'model',
-              label: 'Sonnet',
-              usedPercent: 30,
-              leftPercent: 70,
-              resetsAt: null,
-              resetDescription: null,
-            },
-          ]
-        : [
-            {
-              key: 'session',
-              label: 'Session',
-              usedPercent: 10,
-              leftPercent: 90,
-              resetsAt: null,
-              resetDescription: null,
-            },
-            {
-              key: 'weekly',
-              label: 'Weekly',
-              usedPercent: 20,
-              leftPercent: 80,
-              resetsAt: null,
-              resetDescription: null,
-            },
-          ],
-    ...overrides,
-  };
-}
-
-function makeUsageMap(overrides: Partial<CliProviderUsageMap> = {}): CliProviderUsageMap {
-  return {
-    claude: makeUsage('claude', {}),
-    codex: makeUsage('codex', {}),
-    ...overrides,
-  };
-}
 
 describe('ProjectSidebar', () => {
   const invokeMock = vi.fn<(channel: string, args?: unknown) => Promise<unknown>>();

--- a/apps/desktop/src/renderer/components/SettingsPanel.test.tsx
+++ b/apps/desktop/src/renderer/components/SettingsPanel.test.tsx
@@ -1,25 +1,12 @@
 import { DEFAULT_SETTINGS, type IntegrationStatus } from '@shipcode/shared';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, screen } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAppStore } from '../stores/app-store';
+import { renderWithQueryClient } from '../test/render';
 import { SettingsPanel } from './SettingsPanel';
 
 function renderWithProviders() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-        refetchOnWindowFocus: false,
-      },
-    },
-  });
-
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <SettingsPanel />
-    </QueryClientProvider>,
-  );
+  return renderWithQueryClient(<SettingsPanel />);
 }
 
 function makeDesktopApps() {

--- a/apps/desktop/src/renderer/components/Titlebar.test.tsx
+++ b/apps/desktop/src/renderer/components/Titlebar.test.tsx
@@ -1,33 +1,19 @@
 // @vitest-environment jsdom
 
-import type {
-  CliProviderUsageMap,
-  CliProviderUsageStatus,
-  Project,
-  SystemHealth,
-} from '@shipcode/shared';
+import type { Project, SystemHealth } from '@shipcode/shared';
 import { DEFAULT_SETTINGS } from '@shipcode/shared';
-import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { cleanup, fireEvent, screen, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAppStore } from '../stores/app-store';
+import {
+  makeProviderUsageStatus as makeUsage,
+  makeProviderUsageMap as makeUsageMap,
+} from '../test/provider-usage';
+import { renderWithQueryClient } from '../test/render';
 import { Titlebar } from './Titlebar';
 
 function renderWithProviders() {
-  const queryClient = new QueryClient({
-    defaultOptions: {
-      queries: {
-        retry: false,
-        refetchOnWindowFocus: false,
-      },
-    },
-  });
-
-  return render(
-    <QueryClientProvider client={queryClient}>
-      <Titlebar />
-    </QueryClientProvider>,
-  );
+  return renderWithQueryClient(<Titlebar />);
 }
 
 function makeProject(overrides: Partial<Project> = {}): Project {
@@ -66,81 +52,6 @@ function makeProject(overrides: Partial<Project> = {}): Project {
     notifyGithubUser: null,
     createdAt: '2026-04-16T00:00:00.000Z',
     updatedAt: '2026-04-16T00:00:00.000Z',
-    ...overrides,
-  };
-}
-
-function makeUsage(
-  provider: 'claude' | 'codex',
-  overrides: Partial<CliProviderUsageStatus>,
-): CliProviderUsageStatus {
-  return {
-    provider,
-    available: true,
-    stale: false,
-    state: 'ready',
-    source: 'cli',
-    version: '1.0.0',
-    accountEmail: 'vincent@shipshit.dev',
-    loginMethod: 'pro',
-    updatedAt: '2026-04-16T16:00:00.000Z',
-    checkedAt: '2026-04-16T16:01:00.000Z',
-    message: null,
-    creditsRemaining: null,
-    windows:
-      provider === 'claude'
-        ? [
-            {
-              key: 'session',
-              label: 'Session',
-              usedPercent: 10,
-              leftPercent: 90,
-              resetsAt: null,
-              resetDescription: null,
-            },
-            {
-              key: 'weekly',
-              label: 'Weekly',
-              usedPercent: 20,
-              leftPercent: 80,
-              resetsAt: null,
-              resetDescription: null,
-            },
-            {
-              key: 'model',
-              label: 'Sonnet',
-              usedPercent: 30,
-              leftPercent: 70,
-              resetsAt: null,
-              resetDescription: null,
-            },
-          ]
-        : [
-            {
-              key: 'session',
-              label: 'Session',
-              usedPercent: 10,
-              leftPercent: 90,
-              resetsAt: null,
-              resetDescription: null,
-            },
-            {
-              key: 'weekly',
-              label: 'Weekly',
-              usedPercent: 20,
-              leftPercent: 80,
-              resetsAt: null,
-              resetDescription: null,
-            },
-          ],
-    ...overrides,
-  };
-}
-
-function makeUsageMap(overrides: Partial<CliProviderUsageMap> = {}): CliProviderUsageMap {
-  return {
-    claude: makeUsage('claude', {}),
-    codex: makeUsage('codex', {}),
     ...overrides,
   };
 }

--- a/apps/desktop/src/renderer/test/provider-usage.ts
+++ b/apps/desktop/src/renderer/test/provider-usage.ts
@@ -1,0 +1,62 @@
+import type {
+  CliProviderUsageMap,
+  CliProviderUsageProvider,
+  CliProviderUsageStatus,
+  CliProviderUsageWindow,
+} from '@shipcode/shared';
+
+function usageWindow(
+  key: CliProviderUsageWindow['key'],
+  label: string,
+  usedPercent: number,
+): CliProviderUsageWindow {
+  return {
+    key,
+    label,
+    usedPercent,
+    leftPercent: 100 - usedPercent,
+    resetsAt: null,
+    resetDescription: null,
+  };
+}
+
+const providerWindows: Record<CliProviderUsageProvider, CliProviderUsageWindow[]> = {
+  claude: [
+    usageWindow('session', 'Session', 10),
+    usageWindow('weekly', 'Weekly', 20),
+    usageWindow('model', 'Sonnet', 30),
+  ],
+  codex: [usageWindow('session', 'Session', 10), usageWindow('weekly', 'Weekly', 20)],
+};
+
+export function makeProviderUsageStatus(
+  provider: CliProviderUsageProvider,
+  overrides: Partial<CliProviderUsageStatus> = {},
+): CliProviderUsageStatus {
+  return {
+    provider,
+    available: true,
+    stale: false,
+    state: 'ready',
+    source: 'cli',
+    version: '1.0.0',
+    accountEmail: 'vincent@shipshit.dev',
+    loginMethod: 'pro',
+    updatedAt: '2026-04-16T16:00:00.000Z',
+    checkedAt: '2026-04-16T16:01:00.000Z',
+    message: null,
+    creditsRemaining: null,
+    windows: providerWindows[provider].map((window) => ({ ...window })),
+    ...overrides,
+  };
+}
+
+export function makeProviderUsageMap(
+  overrides: Partial<CliProviderUsageMap> = {},
+): CliProviderUsageMap {
+  return {
+    claude: makeProviderUsageStatus('claude'),
+    codex: makeProviderUsageStatus('codex'),
+    ...overrides,
+  };
+}

--- a/apps/desktop/src/renderer/test/render.tsx
+++ b/apps/desktop/src/renderer/test/render.tsx
@@ -1,0 +1,16 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { type RenderResult, render } from '@testing-library/react';
+import type { ReactNode } from 'react';
+
+export function renderWithQueryClient(ui: ReactNode): RenderResult {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        refetchOnWindowFocus: false,
+      },
+    },
+  });
+
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}


### PR DESCRIPTION
## Summary

- Add shared renderer test helpers for React Query rendering and CLI provider usage fixtures.
- Replace repeated local boilerplate in Titlebar, ProjectSidebar, SettingsPanel, and ProjectSettingsModal specs.
- Reduce the cleanup diff by 123 net LOC without changing product behavior.

## Validation

- `bun install --frozen-lockfile`
- `bunx biome check apps/desktop/src/renderer/components/Titlebar.test.tsx apps/desktop/src/renderer/components/ProjectSidebar.test.tsx apps/desktop/src/renderer/components/SettingsPanel.test.tsx apps/desktop/src/renderer/components/ProjectSettingsModal.test.tsx apps/desktop/src/renderer/test/provider-usage.ts apps/desktop/src/renderer/test/render.tsx --files-ignore-unknown=true`
- `git diff --check`
- `bun --filter @shipcode/desktop test -- src/renderer/components/Titlebar.test.tsx src/renderer/components/ProjectSidebar.test.tsx src/renderer/components/SettingsPanel.test.tsx src/renderer/components/ProjectSettingsModal.test.tsx`
- `bun --filter @shipcode/desktop typecheck`
