### PR TITLE
[codex] Dedupe Kanban test fixtures

### DIFF
--- a/packages/ui/src/kanban-board/IssuePrLinks.test.tsx
+++ b/packages/ui/src/kanban-board/IssuePrLinks.test.tsx
@@ -1,14 +1,8 @@
 // @vitest-environment jsdom
 
 import { DndContext } from '@dnd-kit/core';
-import {
-  type AppSettings,
-  DEFAULT_SETTINGS,
-  type GitHubIssueCacheRecord,
-  type Project,
-} from '@shipcode/shared';
-import { act, type ComponentProps, type ReactElement } from 'react';
-import { createRoot } from 'react-dom/client';
+import { type AppSettings, DEFAULT_SETTINGS, type GitHubIssueCacheRecord } from '@shipcode/shared';
+import { act, type ComponentProps } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ActivePipelineCard } from '../ActivePipelineCard';
 import { KanbanBoard } from '../KanbanBoard';
@@ -16,118 +10,25 @@ import { DroppableColumn, StackedColumn } from './BoardColumns';
 import { COLUMNS } from './constants';
 import { DraggableCard } from './IssueCardParts';
 import { IssueListView } from './IssueListView';
+import { makeIssue as makeBaseIssue, makeProject, renderIntoDom } from './test-helpers';
 
 function makeIssue(overrides: Partial<GitHubIssueCacheRecord> = {}): GitHubIssueCacheRecord {
-  return {
-    id: 'issue-1',
-    projectId: 'project-1',
+  return makeBaseIssue({
     issueNumber: 38,
     title: 'Add demo pipeline task',
-    body: null,
-    labels: [],
-    assignee: null,
-    state: 'open',
     pipelineStatus: 'completed',
-    threadId: null,
-    claimedAt: null,
-    claimedBy: null,
-    lastPhaseUpdate: null,
-    lastStatusLabel: null,
-    plannerModelOverride: null,
-    reviewerModelOverride: null,
-    executorModelOverride: null,
-    verifierModelOverride: null,
-    plannerModelIdOverride: null,
-    reviewerModelIdOverride: null,
-    executorModelIdOverride: null,
-    verifierModelIdOverride: null,
-    plannerReasoningEffortOverride: null,
-    reviewerReasoningEffortOverride: null,
-    executorReasoningEffortOverride: null,
-    verifierReasoningEffortOverride: null,
-    revisionCountOverride: null,
-    requireApprovalOverride: null,
     linkedPrNumber: 91,
     linkedPrUrl: 'https://github.com/acme/repo/pull/91',
     linkedPrIsDraft: true,
-    ciBlocked: false,
-    failingChecks: [],
-    unresolvedReviewComments: [],
-    unresolvedReviewCommentCount: 0,
-    prLastSyncAt: null,
     fetchedAt: new Date('2026-04-14T00:00:00.000Z').toISOString(),
-    priorityRank: null,
-    priorityRaw: null,
-    priorityFetchedAt: null,
-    isQuickMode: false,
     ...overrides,
-  };
+  });
 }
 
 const SETTINGS: AppSettings = {
   ...DEFAULT_SETTINGS,
   requireApproval: false,
 };
-
-function makeProject(overrides: Partial<Project> = {}): Project {
-  return {
-    id: 'project-1',
-    name: 'ShipCode',
-    path: '/tmp/shipcode',
-    gitRemote: 'git@github.com:shipshitdev/shipcode.git',
-    githubRepoId: null,
-    githubRepoFullName: null,
-    starterIssueNumber: null,
-    starterIssueCreatedAt: null,
-    githubProjectUrl: null,
-    plannerModelOverride: null,
-    reviewerModelOverride: null,
-    executorModelOverride: null,
-    verifierModelOverride: null,
-    plannerModelIdOverride: null,
-    reviewerModelIdOverride: null,
-    executorModelIdOverride: null,
-    verifierModelIdOverride: null,
-    plannerReasoningEffortOverride: null,
-    reviewerReasoningEffortOverride: null,
-    executorReasoningEffortOverride: null,
-    verifierReasoningEffortOverride: null,
-    revisionCountOverride: null,
-    requireApprovalOverride: null,
-    discordRouting: 'inherit',
-    discordWebhookUrlOverride: null,
-    telegramRouting: 'inherit',
-    telegramChatIdOverride: null,
-    defaultBranch: 'main',
-    pinned: false,
-    archived: false,
-    hidden: false,
-    notifyGithubUser: null,
-    createdAt: '2026-04-14T00:00:00.000Z',
-    updatedAt: '2026-04-14T00:00:00.000Z',
-    ...overrides,
-  };
-}
-
-function renderIntoDom(element: ReactElement) {
-  const container = document.createElement('div');
-  document.body.appendChild(container);
-  const root = createRoot(container);
-
-  act(() => {
-    root.render(element);
-  });
-
-  return {
-    container,
-    cleanup: () => {
-      act(() => {
-        root.unmount();
-      });
-      container.remove();
-    },
-  };
-}
 
 function expectBadgeGeometry(element: HTMLElement) {
   expect(element.className).toContain('rounded-md');

--- a/packages/ui/src/kanban-board/KanbanBoard.copy.test.tsx
+++ b/packages/ui/src/kanban-board/KanbanBoard.copy.test.tsx
@@ -1,9 +1,8 @@
 // @vitest-environment jsdom
 
-import type { AppSettings, GitHubIssueCacheRecord, Project } from '@shipcode/shared';
+import type { AppSettings } from '@shipcode/shared';
 import { DEFAULT_SETTINGS } from '@shipcode/shared';
-import { act, type ReactElement, type ReactNode } from 'react';
-import { createRoot } from 'react-dom/client';
+import { act, type ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@dnd-kit/core', async () => {
@@ -30,113 +29,7 @@ vi.mock('@dnd-kit/core', async () => {
 });
 
 import { KanbanBoard } from '../KanbanBoard';
-
-function makeIssue(overrides: Partial<GitHubIssueCacheRecord> = {}): GitHubIssueCacheRecord {
-  return {
-    id: 'issue-1',
-    projectId: 'project-1',
-    issueNumber: 80,
-    title: 'Copy branch name action',
-    body: null,
-    labels: [],
-    assignee: null,
-    state: 'open',
-    pipelineStatus: 'todo',
-    threadId: null,
-    claimedAt: null,
-    claimedBy: null,
-    lastPhaseUpdate: null,
-    lastStatusLabel: null,
-    plannerModelOverride: null,
-    reviewerModelOverride: null,
-    executorModelOverride: null,
-    verifierModelOverride: null,
-    plannerModelIdOverride: null,
-    reviewerModelIdOverride: null,
-    executorModelIdOverride: null,
-    verifierModelIdOverride: null,
-    plannerReasoningEffortOverride: null,
-    reviewerReasoningEffortOverride: null,
-    executorReasoningEffortOverride: null,
-    verifierReasoningEffortOverride: null,
-    revisionCountOverride: null,
-    requireApprovalOverride: null,
-    linkedPrNumber: null,
-    linkedPrUrl: null,
-    linkedPrIsDraft: false,
-    ciBlocked: false,
-    failingChecks: [],
-    unresolvedReviewComments: [],
-    unresolvedReviewCommentCount: 0,
-    prLastSyncAt: null,
-    fetchedAt: '2026-04-28T00:00:00.000Z',
-    priorityRank: null,
-    priorityRaw: null,
-    priorityFetchedAt: null,
-    isQuickMode: false,
-    ...overrides,
-  };
-}
-
-function makeProject(overrides: Partial<Project> = {}): Project {
-  return {
-    id: 'project-1',
-    name: 'ShipCode',
-    path: '/tmp/shipcode',
-    gitRemote: 'git@github.com:shipshitdev/shipcode.git',
-    githubRepoId: null,
-    githubRepoFullName: null,
-    starterIssueNumber: null,
-    starterIssueCreatedAt: null,
-    githubProjectUrl: null,
-    plannerModelOverride: null,
-    reviewerModelOverride: null,
-    executorModelOverride: null,
-    verifierModelOverride: null,
-    plannerModelIdOverride: null,
-    reviewerModelIdOverride: null,
-    executorModelIdOverride: null,
-    verifierModelIdOverride: null,
-    plannerReasoningEffortOverride: null,
-    reviewerReasoningEffortOverride: null,
-    executorReasoningEffortOverride: null,
-    verifierReasoningEffortOverride: null,
-    revisionCountOverride: null,
-    requireApprovalOverride: null,
-    discordRouting: 'inherit',
-    discordWebhookUrlOverride: null,
-    telegramRouting: 'inherit',
-    telegramChatIdOverride: null,
-    defaultBranch: 'main',
-    pinned: false,
-    archived: false,
-    hidden: false,
-    notifyGithubUser: null,
-    createdAt: '2026-04-28T00:00:00.000Z',
-    updatedAt: '2026-04-28T00:00:00.000Z',
-    ...overrides,
-  };
-}
-
-function renderIntoDom(element: ReactElement) {
-  const container = document.createElement('div');
-  document.body.appendChild(container);
-  const root = createRoot(container);
-
-  act(() => {
-    root.render(element);
-  });
-
-  return {
-    container,
-    cleanup: () => {
-      act(() => {
-        root.unmount();
-      });
-      container.remove();
-    },
-  };
-}
+import { makeIssue, makeProject, renderIntoDom } from './test-helpers';
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -153,7 +46,7 @@ describe('KanbanBoard branch-copy affordance', () => {
 
     const view = renderIntoDom(
       <KanbanBoard
-        issues={[makeIssue()]}
+        issues={[makeIssue({ issueNumber: 80, title: 'Copy branch name action' })]}
         project={makeProject()}
         settings={DEFAULT_SETTINGS as AppSettings}
         onIssueClick={onIssueClick}

--- a/packages/ui/src/kanban-board/KanbanBoard.dnd.test.tsx
+++ b/packages/ui/src/kanban-board/KanbanBoard.dnd.test.tsx
@@ -1,9 +1,8 @@
 // @vitest-environment jsdom
 
-import type { AppSettings, GitHubIssueCacheRecord, Project } from '@shipcode/shared';
+import type { AppSettings } from '@shipcode/shared';
 import { DEFAULT_SETTINGS } from '@shipcode/shared';
-import { act, type ReactElement, type ReactNode } from 'react';
-import { createRoot } from 'react-dom/client';
+import type { ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 const captured: { sensors: unknown } = { sensors: null };
@@ -33,112 +32,7 @@ vi.mock('@dnd-kit/core', async () => {
 });
 
 import { KanbanBoard } from '../KanbanBoard';
-
-function makeIssue(overrides: Partial<GitHubIssueCacheRecord> = {}): GitHubIssueCacheRecord {
-  return {
-    id: 'issue-1',
-    projectId: 'project-1',
-    issueNumber: 19,
-    title: 'Queued issue',
-    body: null,
-    labels: [],
-    assignee: null,
-    state: 'open',
-    pipelineStatus: 'queued',
-    threadId: 'thread-1',
-    claimedAt: null,
-    claimedBy: null,
-    lastPhaseUpdate: null,
-    lastStatusLabel: null,
-    plannerModelOverride: null,
-    reviewerModelOverride: null,
-    executorModelOverride: null,
-    verifierModelOverride: null,
-    plannerModelIdOverride: null,
-    reviewerModelIdOverride: null,
-    executorModelIdOverride: null,
-    verifierModelIdOverride: null,
-    plannerReasoningEffortOverride: null,
-    reviewerReasoningEffortOverride: null,
-    executorReasoningEffortOverride: null,
-    verifierReasoningEffortOverride: null,
-    revisionCountOverride: null,
-    requireApprovalOverride: null,
-    linkedPrNumber: null,
-    linkedPrUrl: null,
-    linkedPrIsDraft: false,
-    ciBlocked: false,
-    failingChecks: [],
-    unresolvedReviewComments: [],
-    unresolvedReviewCommentCount: 0,
-    prLastSyncAt: null,
-    fetchedAt: '2026-04-22T00:00:00.000Z',
-    priorityRank: null,
-    priorityRaw: null,
-    priorityFetchedAt: null,
-    isQuickMode: false,
-    ...overrides,
-  };
-}
-
-function makeProject(overrides: Partial<Project> = {}): Project {
-  return {
-    id: 'project-1',
-    name: 'ShipCode',
-    path: '/tmp/shipcode',
-    gitRemote: 'git@github.com:shipshitdev/shipcode.git',
-    githubRepoId: null,
-    githubRepoFullName: null,
-    starterIssueNumber: null,
-    starterIssueCreatedAt: null,
-    githubProjectUrl: null,
-    plannerModelOverride: null,
-    reviewerModelOverride: null,
-    executorModelOverride: null,
-    verifierModelOverride: null,
-    plannerModelIdOverride: null,
-    reviewerModelIdOverride: null,
-    executorModelIdOverride: null,
-    verifierModelIdOverride: null,
-    plannerReasoningEffortOverride: null,
-    reviewerReasoningEffortOverride: null,
-    executorReasoningEffortOverride: null,
-    verifierReasoningEffortOverride: null,
-    revisionCountOverride: null,
-    requireApprovalOverride: null,
-    discordRouting: 'inherit',
-    discordWebhookUrlOverride: null,
-    telegramRouting: 'inherit',
-    telegramChatIdOverride: null,
-    defaultBranch: 'main',
-    pinned: false,
-    archived: false,
-    hidden: false,
-    notifyGithubUser: null,
-    createdAt: '2026-04-22T00:00:00.000Z',
-    updatedAt: '2026-04-22T00:00:00.000Z',
-    ...overrides,
-  };
-}
-
-function renderIntoDom(element: ReactElement) {
-  const container = document.createElement('div');
-  document.body.appendChild(container);
-  const root = createRoot(container);
-
-  act(() => {
-    root.render(element);
-  });
-
-  return {
-    cleanup: () => {
-      act(() => {
-        root.unmount();
-      });
-      container.remove();
-    },
-  };
-}
+import { makeIssue, makeProject, renderIntoDom } from './test-helpers';
 
 describe('KanbanBoard drag activation', () => {
   it('uses a pointer distance threshold so draggable cards remain clickable', () => {
@@ -146,7 +40,15 @@ describe('KanbanBoard drag activation', () => {
 
     const view = renderIntoDom(
       <KanbanBoard
-        issues={[makeIssue()]}
+        issues={[
+          makeIssue({
+            issueNumber: 19,
+            title: 'Queued issue',
+            pipelineStatus: 'queued',
+            threadId: 'thread-1',
+            fetchedAt: '2026-04-22T00:00:00.000Z',
+          }),
+        ]}
         project={makeProject()}
         settings={DEFAULT_SETTINGS as AppSettings}
         onIssueClick={vi.fn()}

--- a/packages/ui/src/kanban-board/KanbanBoard.keyboard.test.tsx
+++ b/packages/ui/src/kanban-board/KanbanBoard.keyboard.test.tsx
@@ -1,14 +1,8 @@
 // @vitest-environment jsdom
 
-import type {
-  AppSettings,
-  GitHubIssueCacheRecord,
-  IssuePipelineStatus,
-  Project,
-} from '@shipcode/shared';
+import type { AppSettings, IssuePipelineStatus } from '@shipcode/shared';
 import { DEFAULT_SETTINGS } from '@shipcode/shared';
-import { act, type ReactElement, type ReactNode } from 'react';
-import { createRoot } from 'react-dom/client';
+import { act, type ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@dnd-kit/core', async () => {
@@ -35,118 +29,7 @@ vi.mock('@dnd-kit/core', async () => {
 });
 
 import { KanbanBoard } from '../KanbanBoard';
-
-function makeIssue(overrides: Partial<GitHubIssueCacheRecord> = {}): GitHubIssueCacheRecord {
-  return {
-    id: 'issue-1',
-    projectId: 'project-1',
-    issueNumber: 10,
-    title: 'Todo top',
-    body: null,
-    labels: [],
-    assignee: null,
-    state: 'open',
-    pipelineStatus: 'todo',
-    threadId: null,
-    claimedAt: null,
-    claimedBy: null,
-    lastPhaseUpdate: null,
-    lastStatusLabel: null,
-    plannerModelOverride: null,
-    reviewerModelOverride: null,
-    executorModelOverride: null,
-    verifierModelOverride: null,
-    plannerModelIdOverride: null,
-    reviewerModelIdOverride: null,
-    executorModelIdOverride: null,
-    verifierModelIdOverride: null,
-    plannerReasoningEffortOverride: null,
-    reviewerReasoningEffortOverride: null,
-    executorReasoningEffortOverride: null,
-    verifierReasoningEffortOverride: null,
-    revisionCountOverride: null,
-    requireApprovalOverride: null,
-    linkedPrNumber: null,
-    linkedPrUrl: null,
-    linkedPrIsDraft: false,
-    ciBlocked: false,
-    failingChecks: [],
-    unresolvedReviewComments: [],
-    unresolvedReviewCommentCount: 0,
-    prLastSyncAt: null,
-    fetchedAt: '2026-04-28T00:00:00.000Z',
-    priorityRank: null,
-    priorityRaw: null,
-    priorityFetchedAt: null,
-    isQuickMode: false,
-    ...overrides,
-  };
-}
-
-function makeProject(overrides: Partial<Project> = {}): Project {
-  return {
-    id: 'project-1',
-    name: 'ShipCode',
-    path: '/tmp/shipcode',
-    gitRemote: 'git@github.com:shipshitdev/shipcode.git',
-    githubRepoId: null,
-    githubRepoFullName: null,
-    starterIssueNumber: null,
-    starterIssueCreatedAt: null,
-    githubProjectUrl: null,
-    plannerModelOverride: null,
-    reviewerModelOverride: null,
-    executorModelOverride: null,
-    verifierModelOverride: null,
-    plannerModelIdOverride: null,
-    reviewerModelIdOverride: null,
-    executorModelIdOverride: null,
-    verifierModelIdOverride: null,
-    plannerReasoningEffortOverride: null,
-    reviewerReasoningEffortOverride: null,
-    executorReasoningEffortOverride: null,
-    verifierReasoningEffortOverride: null,
-    revisionCountOverride: null,
-    requireApprovalOverride: null,
-    discordRouting: 'inherit',
-    discordWebhookUrlOverride: null,
-    telegramRouting: 'inherit',
-    telegramChatIdOverride: null,
-    defaultBranch: 'main',
-    pinned: false,
-    archived: false,
-    hidden: false,
-    notifyGithubUser: null,
-    createdAt: '2026-04-28T00:00:00.000Z',
-    updatedAt: '2026-04-28T00:00:00.000Z',
-    ...overrides,
-  };
-}
-
-function renderIntoDom(element: ReactElement) {
-  const container = document.createElement('div');
-  document.body.appendChild(container);
-  const root = createRoot(container);
-
-  act(() => {
-    root.render(element);
-  });
-
-  return {
-    container,
-    rerender: (nextElement: ReactElement) => {
-      act(() => {
-        root.render(nextElement);
-      });
-    },
-    cleanup: () => {
-      act(() => {
-        root.unmount();
-      });
-      container.remove();
-    },
-  };
-}
+import { makeIssue, makeProject, renderIntoDom } from './test-helpers';
 
 function focusedCard(container: HTMLElement): HTMLElement {
   const card = container.querySelector('[data-keyboard-focused="true"]');

--- a/packages/ui/src/kanban-board/KanbanBoard.staleness.test.tsx
+++ b/packages/ui/src/kanban-board/KanbanBoard.staleness.test.tsx
@@ -1,9 +1,8 @@
 // @vitest-environment jsdom
 
-import type { AppSettings, GitHubIssueCacheRecord, Project } from '@shipcode/shared';
+import type { AppSettings, GitHubIssueCacheRecord } from '@shipcode/shared';
 import { DEFAULT_SETTINGS } from '@shipcode/shared';
-import { act, type ReactElement, type ReactNode } from 'react';
-import { createRoot } from 'react-dom/client';
+import { act, type ReactNode } from 'react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@dnd-kit/core', async () => {
@@ -30,113 +29,18 @@ vi.mock('@dnd-kit/core', async () => {
 });
 
 import { KanbanBoard } from '../KanbanBoard';
+import { makeIssue as makeBaseIssue, makeProject, renderIntoDom } from './test-helpers';
 
 function makeIssue(overrides: Partial<GitHubIssueCacheRecord> = {}): GitHubIssueCacheRecord {
-  return {
-    id: 'issue-1',
-    projectId: 'project-1',
+  return makeBaseIssue({
     issueNumber: 1,
     title: 'Stale queued issue',
-    body: null,
-    labels: [],
-    assignee: null,
-    state: 'open',
     pipelineStatus: 'queued',
-    threadId: null,
-    claimedAt: null,
-    claimedBy: null,
     lastPhaseUpdate: '2000-01-01T00:00:00.000Z',
-    lastStatusLabel: null,
-    plannerModelOverride: null,
-    reviewerModelOverride: null,
-    executorModelOverride: null,
-    verifierModelOverride: null,
-    plannerModelIdOverride: null,
-    reviewerModelIdOverride: null,
-    executorModelIdOverride: null,
-    verifierModelIdOverride: null,
-    plannerReasoningEffortOverride: null,
-    reviewerReasoningEffortOverride: null,
-    executorReasoningEffortOverride: null,
-    verifierReasoningEffortOverride: null,
-    revisionCountOverride: null,
-    requireApprovalOverride: null,
-    linkedPrNumber: null,
-    linkedPrUrl: null,
-    linkedPrIsDraft: false,
-    ciBlocked: false,
-    failingChecks: [],
-    unresolvedReviewComments: [],
-    unresolvedReviewCommentCount: 0,
-    prLastSyncAt: null,
     updatedAt: '2000-01-01T00:00:00.000Z',
     fetchedAt: '2000-01-01T00:00:00.000Z',
-    priorityRank: null,
-    priorityRaw: null,
-    priorityFetchedAt: null,
-    isQuickMode: false,
     ...overrides,
-  };
-}
-
-function makeProject(overrides: Partial<Project> = {}): Project {
-  return {
-    id: 'project-1',
-    name: 'ShipCode',
-    path: '/tmp/shipcode',
-    gitRemote: 'git@github.com:shipshitdev/shipcode.git',
-    githubRepoId: null,
-    githubRepoFullName: null,
-    starterIssueNumber: null,
-    starterIssueCreatedAt: null,
-    githubProjectUrl: null,
-    plannerModelOverride: null,
-    reviewerModelOverride: null,
-    executorModelOverride: null,
-    verifierModelOverride: null,
-    plannerModelIdOverride: null,
-    reviewerModelIdOverride: null,
-    executorModelIdOverride: null,
-    verifierModelIdOverride: null,
-    plannerReasoningEffortOverride: null,
-    reviewerReasoningEffortOverride: null,
-    executorReasoningEffortOverride: null,
-    verifierReasoningEffortOverride: null,
-    revisionCountOverride: null,
-    requireApprovalOverride: null,
-    discordRouting: 'inherit',
-    discordWebhookUrlOverride: null,
-    telegramRouting: 'inherit',
-    telegramChatIdOverride: null,
-    defaultBranch: 'main',
-    pinned: false,
-    archived: false,
-    hidden: false,
-    notifyGithubUser: null,
-    createdAt: '2026-04-28T00:00:00.000Z',
-    updatedAt: '2026-04-28T00:00:00.000Z',
-    ...overrides,
-  };
-}
-
-function renderIntoDom(element: ReactElement) {
-  const container = document.createElement('div');
-  document.body.appendChild(container);
-  const root = createRoot(container);
-
-  act(() => {
-    root.render(element);
   });
-
-  return {
-    container,
-    cleanup: () => {
-      act(() => {
-        root.unmount();
-      });
-      container.remove();
-    },
-  };
 }
 
 afterEach(() => {

--- a/packages/ui/src/kanban-board/test-helpers.tsx
+++ b/packages/ui/src/kanban-board/test-helpers.tsx
@@ -1,0 +1,115 @@
+import type { GitHubIssueCacheRecord, Project } from '@shipcode/shared';
+import { act, type ReactElement } from 'react';
+import { createRoot } from 'react-dom/client';
+
+export function makeIssue(overrides: Partial<GitHubIssueCacheRecord> = {}): GitHubIssueCacheRecord {
+  return {
+    id: 'issue-1',
+    projectId: 'project-1',
+    issueNumber: 1,
+    title: 'Test issue',
+    body: null,
+    labels: [],
+    assignee: null,
+    state: 'open',
+    pipelineStatus: 'todo',
+    threadId: null,
+    claimedAt: null,
+    claimedBy: null,
+    lastPhaseUpdate: null,
+    lastStatusLabel: null,
+    plannerModelOverride: null,
+    reviewerModelOverride: null,
+    executorModelOverride: null,
+    verifierModelOverride: null,
+    plannerModelIdOverride: null,
+    reviewerModelIdOverride: null,
+    executorModelIdOverride: null,
+    verifierModelIdOverride: null,
+    plannerReasoningEffortOverride: null,
+    reviewerReasoningEffortOverride: null,
+    executorReasoningEffortOverride: null,
+    verifierReasoningEffortOverride: null,
+    revisionCountOverride: null,
+    requireApprovalOverride: null,
+    linkedPrNumber: null,
+    linkedPrUrl: null,
+    linkedPrIsDraft: false,
+    ciBlocked: false,
+    failingChecks: [],
+    unresolvedReviewComments: [],
+    unresolvedReviewCommentCount: 0,
+    prLastSyncAt: null,
+    fetchedAt: '2026-04-28T00:00:00.000Z',
+    priorityRank: null,
+    priorityRaw: null,
+    priorityFetchedAt: null,
+    isQuickMode: false,
+    ...overrides,
+  };
+}
+
+export function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    id: 'project-1',
+    name: 'ShipCode',
+    path: '/tmp/shipcode',
+    gitRemote: 'git@github.com:shipshitdev/shipcode.git',
+    githubRepoId: null,
+    githubRepoFullName: null,
+    starterIssueNumber: null,
+    starterIssueCreatedAt: null,
+    githubProjectUrl: null,
+    plannerModelOverride: null,
+    reviewerModelOverride: null,
+    executorModelOverride: null,
+    verifierModelOverride: null,
+    plannerModelIdOverride: null,
+    reviewerModelIdOverride: null,
+    executorModelIdOverride: null,
+    verifierModelIdOverride: null,
+    plannerReasoningEffortOverride: null,
+    reviewerReasoningEffortOverride: null,
+    executorReasoningEffortOverride: null,
+    verifierReasoningEffortOverride: null,
+    revisionCountOverride: null,
+    requireApprovalOverride: null,
+    discordRouting: 'inherit',
+    discordWebhookUrlOverride: null,
+    telegramRouting: 'inherit',
+    telegramChatIdOverride: null,
+    defaultBranch: 'main',
+    pinned: false,
+    archived: false,
+    hidden: false,
+    notifyGithubUser: null,
+    createdAt: '2026-04-28T00:00:00.000Z',
+    updatedAt: '2026-04-28T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+export function renderIntoDom(element: ReactElement) {
+  const container = document.createElement('div');
+  document.body.appendChild(container);
+  const root = createRoot(container);
+
+  act(() => {
+    root.render(element);
+  });
+
+  return {
+    container,
+    rerender: (nextElement: ReactElement) => {
+      act(() => {
+        root.render(nextElement);
+      });
+    },
+    cleanup: () => {
+      act(() => {
+        root.unmount();
+      });
+      container.remove();
+    },
+  };
+}


### PR DESCRIPTION
## Summary

- Add shared Kanban board test helpers for issue/project fixtures and DOM rendering.
- Replace repeated local fixture/render boilerplate across Kanban PR, copy, drag, keyboard, and staleness specs.
- Reduce the UI test diff by 402 net LOC without changing product behavior.

## Validation

- `bunx biome check packages/ui/src/kanban-board/test-helpers.tsx packages/ui/src/kanban-board/IssuePrLinks.test.tsx packages/ui/src/kanban-board/KanbanBoard.copy.test.tsx packages/ui/src/kanban-board/KanbanBoard.dnd.test.tsx packages/ui/src/kanban-board/KanbanBoard.keyboard.test.tsx packages/ui/src/kanban-board/KanbanBoard.staleness.test.tsx --files-ignore-unknown=true`
- `git diff --check`
- `bun install --frozen-lockfile`
- `bun --filter @shipcode/shared build`
- `bun --filter @shipcode/ui test -- src/kanban-board/IssuePrLinks.test.tsx src/kanban-board/KanbanBoard.copy.test.tsx src/kanban-board/KanbanBoard.dnd.test.tsx src/kanban-board/KanbanBoard.keyboard.test.tsx src/kanban-board/KanbanBoard.staleness.test.tsx`
- `bun --filter @shipcode/ui typecheck`
- `bun --filter @shipcode/ui build`
