### PR TITLE
Fix stale web and kanban test expectations

### DIFF
--- a/packages/agents/src/cli-stdin-runner.test.ts
+++ b/packages/agents/src/cli-stdin-runner.test.ts
@@ -1,0 +1,83 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockSpawn = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({
+  spawn: mockSpawn,
+}));
+
+vi.mock('./health-check', () => ({
+  shellExecEnv: () => ({ PATH: '/usr/bin' }),
+}));
+
+import { runCliWithStdin } from './cli-stdin-runner';
+
+function createFakeProc() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    stdin: { write: (chunk: string) => boolean; end: () => void };
+    kill: (signal: string) => void;
+  };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  const stdinWrites: string[] = [];
+  let stdinEnded = false;
+  proc.stdin = {
+    write: (chunk: string) => {
+      stdinWrites.push(chunk);
+      return true;
+    },
+    end: () => {
+      stdinEnded = true;
+    },
+  };
+  proc.kill = vi.fn();
+  return {
+    proc,
+    stdinWrites,
+    isStdinEnded: () => stdinEnded,
+    close: (code: number, options?: { stdout?: string; stderr?: string }) => {
+      if (options?.stdout) proc.stdout.emit('data', options.stdout);
+      if (options?.stderr) proc.stderr.emit('data', options.stderr);
+      proc.emit('close', code);
+    },
+  };
+}
+
+describe('runCliWithStdin', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('pipes stdin and surfaces a short stdout-derived error when stderr is empty', async () => {
+    const fake = createFakeProc();
+    mockSpawn.mockReturnValueOnce(fake.proc);
+
+    const promise = runCliWithStdin({
+      cli: 'claude',
+      args: ['-p', '--output-format', 'json'],
+      input: 'PROMPT',
+      cwd: '/repo',
+      timeoutMs: 5_000,
+    });
+
+    await Promise.resolve();
+
+    expect(mockSpawn).toHaveBeenCalledWith(
+      'claude',
+      ['-p', '--output-format', 'json'],
+      expect.objectContaining({ cwd: '/repo', stdio: ['pipe', 'pipe', 'pipe'] }),
+    );
+    expect(fake.stdinWrites).toEqual(['PROMPT']);
+    expect(fake.isStdinEnded()).toBe(true);
+
+    fake.close(1, {
+      stdout:
+        '{"type":"result","subtype":"success","is_error":true,"result":"You\\u2019ve hit your limit"}',
+    });
+
+    await expect(promise).rejects.toThrow('Claude CLI exited 1: You’ve hit your limit');
+  });
+});

--- a/packages/agents/src/cli-stdin-runner.ts
+++ b/packages/agents/src/cli-stdin-runner.ts
@@ -1,0 +1,53 @@
+import { spawn } from 'node:child_process';
+import type { GeneratorCli } from '@shipcode/shared';
+import { extractCliFailureMessage, formatCliSpawnFailure } from './cli-error';
+import { shellExecEnv } from './health-check';
+
+export function runCliWithStdin(options: {
+  cli: GeneratorCli;
+  args: string[];
+  input: string;
+  cwd: string;
+  timeoutMs: number;
+}): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn(options.cli, options.args, {
+      cwd: options.cwd,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: shellExecEnv(),
+    });
+
+    let stdout = '';
+    let stderr = '';
+    proc.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    proc.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+
+    const label = options.cli === 'claude' ? 'Claude CLI' : 'Codex CLI';
+    const timer = setTimeout(() => {
+      proc.kill('SIGTERM');
+      reject(new Error(`${label} timed out after ${options.timeoutMs}ms`));
+    }, options.timeoutMs);
+
+    proc.on('error', (err) => {
+      clearTimeout(timer);
+      reject(new Error(formatCliSpawnFailure(label, err.message)));
+    });
+
+    proc.on('close', (code) => {
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve(stdout);
+        return;
+      }
+      const tidy = extractCliFailureMessage(stdout, stderr);
+      reject(new Error(`${label} exited ${code}: ${tidy}`));
+    });
+
+    proc.stdin.write(options.input);
+    proc.stdin.end();
+  });
+}

--- a/packages/agents/src/memory-generator.test.ts
+++ b/packages/agents/src/memory-generator.test.ts
@@ -1,0 +1,80 @@
+import { EventEmitter } from 'node:events';
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const mockSpawn = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({
+  spawn: mockSpawn,
+}));
+
+vi.mock('./health-check', () => ({
+  shellExecEnv: () => ({ PATH: '/usr/bin' }),
+}));
+
+import { generateMemoryFiles } from './memory-generator';
+
+function createFakeProc() {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    stdin: { write: (chunk: string) => boolean; end: () => void };
+    kill: (signal: string) => void;
+  };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+  proc.stdin = {
+    write: () => true,
+    end: () => {},
+  };
+  proc.kill = vi.fn();
+  return {
+    proc,
+    close: (code: number, options?: { stdout?: string; stderr?: string }) => {
+      if (options?.stdout) proc.stdout.emit('data', options.stdout);
+      if (options?.stderr) proc.stderr.emit('data', options.stderr);
+      proc.emit('close', code);
+    },
+  };
+}
+
+describe('generateMemoryFiles', () => {
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('writes the generated memory files from a Claude result envelope', async () => {
+    const fake = createFakeProc();
+    mockSpawn.mockReturnValueOnce(fake.proc);
+
+    const projectPath = mkdtempSync(join(tmpdir(), 'shipcode-memory-generator-'));
+    writeFileSync(join(projectPath, 'README.md'), '# Repo\n', 'utf8');
+
+    const promise = generateMemoryFiles(projectPath, 'claude');
+
+    await Promise.resolve();
+
+    fake.close(0, {
+      stdout: JSON.stringify({
+        result:
+          '```shipcode-memory\n{"goal":"Goal body","architecture":"Architecture body","constraints":"Constraints body","doDont":"Do body"}\n```',
+      }),
+    });
+
+    await expect(promise).resolves.toMatchObject({
+      success: true,
+      written: ['goal.md', 'architecture.md', 'constraints.md', 'do-dont.md'],
+    });
+
+    expect(readFileSync(join(projectPath, '.agents/memory/goal.md'), 'utf8')).toContain(
+      'Goal body',
+    );
+    expect(readFileSync(join(projectPath, '.agents/memory/architecture.md'), 'utf8')).toContain(
+      'Architecture body',
+    );
+
+    rmSync(projectPath, { recursive: true, force: true });
+  });
+});

--- a/packages/agents/src/memory-generator.ts
+++ b/packages/agents/src/memory-generator.ts
@@ -1,9 +1,7 @@
-import { spawn } from 'node:child_process';
 import { mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { GeneratorCli, MemoryFileInfo, RepoMemoryStatus } from '@shipcode/shared';
-import { extractCliFailureMessage, formatCliSpawnFailure } from './cli-error';
-import { shellExecEnv } from './health-check';
+import { runCliWithStdin } from './cli-stdin-runner';
 
 const MEMORY_DIR = '.agents/memory';
 const OBSOLETE_CONTEXT_DIR = '.agents/context';
@@ -291,67 +289,19 @@ function runMemoryCliWithStdin(
   cwd: string,
   timeoutMs: number,
 ): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const command = cli;
-    const label = cli === 'claude' ? 'Claude CLI' : 'Codex CLI';
-    const args =
-      cli === 'claude'
-        ? [
-            '-p',
-            '--output-format',
-            'json',
-            '--max-turns',
-            '1',
-            '--tools',
-            '',
-            '--dangerously-skip-permissions',
-          ]
-        : [
-            '-a',
-            'never',
-            '-c',
-            'model_reasoning_effort=high',
-            'exec',
-            '-',
-            '--sandbox',
-            'read-only',
-          ];
-    const proc = spawn(command, args, {
-      cwd,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: shellExecEnv(),
-    });
+  const args =
+    cli === 'claude'
+      ? [
+          '-p',
+          '--output-format',
+          'json',
+          '--max-turns',
+          '1',
+          '--tools',
+          '',
+          '--dangerously-skip-permissions',
+        ]
+      : ['-a', 'never', '-c', 'model_reasoning_effort=high', 'exec', '-', '--sandbox', 'read-only'];
 
-    let stdout = '';
-    let stderr = '';
-    proc.stdout.on('data', (chunk) => {
-      stdout += chunk;
-    });
-    proc.stderr.on('data', (chunk) => {
-      stderr += chunk;
-    });
-
-    const timer = setTimeout(() => {
-      proc.kill('SIGTERM');
-      reject(new Error(`${label} timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-
-    proc.on('error', (err) => {
-      clearTimeout(timer);
-      reject(new Error(formatCliSpawnFailure(label, err.message)));
-    });
-
-    proc.on('close', (code) => {
-      clearTimeout(timer);
-      if (code === 0) {
-        resolve(stdout);
-        return;
-      }
-      const tidy = extractCliFailureMessage(stdout, stderr);
-      reject(new Error(`${label} exited ${code}: ${tidy}`));
-    });
-
-    proc.stdin.write(prompt);
-    proc.stdin.end();
-  });
+  return runCliWithStdin({ cli, args, input: prompt, cwd, timeoutMs });
 }

--- a/packages/agents/src/prd-generator.test.ts
+++ b/packages/agents/src/prd-generator.test.ts
@@ -8,6 +8,10 @@ vi.mock('node:child_process', () => ({
   spawn: mockSpawn,
 }));
 
+vi.mock('./health-check', () => ({
+  shellExecEnv: () => ({ PATH: '/usr/bin' }),
+}));
+
 import { enhancePrdDraft } from './prd-generator';
 
 function createFakeProc() {

--- a/packages/agents/src/prd-generator.ts
+++ b/packages/agents/src/prd-generator.ts
@@ -1,7 +1,5 @@
-import { spawn } from 'node:child_process';
 import type { GeneratorCli, ReasoningEffort } from '@shipcode/shared';
-import { extractCliFailureMessage, formatCliSpawnFailure } from './cli-error';
-import { shellExecEnv } from './health-check';
+import { runCliWithStdin } from './cli-stdin-runner';
 import {
   mapReasoningEffortToClaudeThinkingTokens,
   mapReasoningEffortToCodex,
@@ -135,81 +133,41 @@ function runPrdCliWithStdin(
   modelId?: string | null,
   reasoningEffort?: ReasoningEffort,
 ): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const command = cli;
-    const label = cli === 'claude' ? 'Claude CLI' : 'Codex CLI';
-    const args =
-      cli === 'claude'
-        ? [
-            '-p',
-            ...(modelId ? ['--model', modelId] : []),
-            '--output-format',
-            'json',
-            '--max-turns',
-            '3',
-            ...(() => {
-              const thinkingTokens = mapReasoningEffortToClaudeThinkingTokens(
-                reasoningEffort,
-                modelId,
-              );
-              return thinkingTokens === null
-                ? []
-                : (['--max-thinking-tokens', String(thinkingTokens)] as string[]);
-            })(),
-            '--dangerously-skip-permissions',
-            '--disallowedTools',
-            'Edit,Write,Bash,NotebookEdit,Read,Glob,Grep,Task,WebSearch,WebFetch',
-          ]
-        : [
-            '-a',
-            'never',
-            ...(modelId ? ['-m', modelId] : []),
-            '-c',
-            `model_reasoning_effort=${mapReasoningEffortToCodex(reasoningEffort, modelId)}`,
-            'exec',
-            '-',
-            '--sandbox',
-            'read-only',
-          ];
-    const proc = spawn(command, args, {
-      cwd,
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: shellExecEnv(),
-    });
+  const args =
+    cli === 'claude'
+      ? [
+          '-p',
+          ...(modelId ? ['--model', modelId] : []),
+          '--output-format',
+          'json',
+          '--max-turns',
+          '3',
+          ...(() => {
+            const thinkingTokens = mapReasoningEffortToClaudeThinkingTokens(
+              reasoningEffort,
+              modelId,
+            );
+            return thinkingTokens === null
+              ? []
+              : (['--max-thinking-tokens', String(thinkingTokens)] as string[]);
+          })(),
+          '--dangerously-skip-permissions',
+          '--disallowedTools',
+          'Edit,Write,Bash,NotebookEdit,Read,Glob,Grep,Task,WebSearch,WebFetch',
+        ]
+      : [
+          '-a',
+          'never',
+          ...(modelId ? ['-m', modelId] : []),
+          '-c',
+          `model_reasoning_effort=${mapReasoningEffortToCodex(reasoningEffort, modelId)}`,
+          'exec',
+          '-',
+          '--sandbox',
+          'read-only',
+        ];
 
-    let stdout = '';
-    let stderr = '';
-    proc.stdout.on('data', (chunk) => {
-      stdout += chunk;
-    });
-    proc.stderr.on('data', (chunk) => {
-      stderr += chunk;
-    });
-
-    const timer = setTimeout(() => {
-      proc.kill('SIGTERM');
-      reject(new Error(`${label} timed out after ${timeoutMs}ms`));
-    }, timeoutMs);
-
-    proc.on('error', (err) => {
-      clearTimeout(timer);
-      // ENOENT etc — surface a short message, never echo the prompt.
-      reject(new Error(formatCliSpawnFailure(label, err.message)));
-    });
-
-    proc.on('close', (code) => {
-      clearTimeout(timer);
-      if (code === 0) {
-        resolve(stdout);
-        return;
-      }
-      const tidy = extractCliFailureMessage(stdout, stderr);
-      reject(new Error(`${label} exited ${code}: ${tidy}`));
-    });
-
-    proc.stdin.write(prompt);
-    proc.stdin.end();
-  });
+  return runCliWithStdin({ cli, args, input: prompt, cwd, timeoutMs });
 }
 
 /**


### PR DESCRIPTION
## Summary
Branch captured from local ShipCode worktree and targeted at develop.

## Commits
- 3d6c055 Extract shared CLI stdin runner
- 336c400 Fix stale web and kanban test expectations

## Verification
- Not rerun per branch yet; release-readiness gates passed on codex/release-readiness-20260503.