### PR TITLE
Disambiguate chat notification switch labels

### DIFF
--- a/apps/desktop/src/renderer/components/settings-panel/NotificationsSettingsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings-panel/NotificationsSettingsSection.tsx
@@ -127,6 +127,7 @@ export function NotificationsSettingsSection({
         <SettingsRow label="Chat: needs approval" htmlFor="chat-awaiting-approval">
           <Switch
             id="chat-awaiting-approval"
+            aria-label="Chat alert: Needs approval"
             checked={settings.chatNotificationEvents.awaitingApproval}
             onCheckedChange={(checked: boolean) =>
               onUpdate({
@@ -141,6 +142,7 @@ export function NotificationsSettingsSection({
         <SettingsRow label="Chat: pipeline failed" htmlFor="chat-failed">
           <Switch
             id="chat-failed"
+            aria-label="Chat alert: Pipeline failed"
             checked={settings.chatNotificationEvents.failed}
             onCheckedChange={(checked: boolean) =>
               onUpdate({
@@ -155,6 +157,7 @@ export function NotificationsSettingsSection({
         <SettingsRow label="Chat: CI blocked" htmlFor="chat-ci-blocked">
           <Switch
             id="chat-ci-blocked"
+            aria-label="Chat alert: CI blocked"
             checked={settings.chatNotificationEvents.ciBlocked}
             onCheckedChange={(checked: boolean) =>
               onUpdate({
@@ -169,6 +172,7 @@ export function NotificationsSettingsSection({
         <SettingsRow label="Chat: pipeline completed" htmlFor="chat-completed">
           <Switch
             id="chat-completed"
+            aria-label="Chat alert: Pipeline completed"
             checked={settings.chatNotificationEvents.completed}
             onCheckedChange={(checked: boolean) =>
               onUpdate({
@@ -186,6 +190,7 @@ export function NotificationsSettingsSection({
         >
           <Switch
             id="chat-verification-exhausted"
+            aria-label="Chat alert: Verification retries exhausted"
             checked={settings.chatNotificationEvents.verificationExhausted}
             onCheckedChange={(checked: boolean) =>
               onUpdate({

--- a/apps/desktop/src/renderer/components/settings-panel/SettingsLeafSections.test.tsx
+++ b/apps/desktop/src/renderer/components/settings-panel/SettingsLeafSections.test.tsx
@@ -139,6 +139,7 @@ describe('settings leaf sections', () => {
 
     expect(screen.getByRole('switch', { name: 'OS notifications' })).toBeDisabled();
     expect(screen.getByRole('switch', { name: 'Pipeline completed' })).toBeDisabled();
+    expect(screen.getByRole('switch', { name: 'Chat alert: Pipeline completed' })).toBeEnabled();
 
     cleanup();
 


### PR DESCRIPTION
## Summary
Branch captured from local ShipCode worktree and targeted at develop.

## Commits
- b4d500d Fix web install copy and commands
- be523ca Fix board filter toggles and card detail clicks
- 686c4f9 Disambiguate chat notification switch labels

## Verification
- Not rerun per branch yet; release-readiness gates passed on codex/release-readiness-20260503.