### PR TITLE
Fix packaged CLI entrypoint smoke gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -277,6 +277,8 @@ jobs:
       - run: bun install
       - name: Build CLI and dependencies
         run: bun run turbo run build --filter=@shipshitdev/shipcode
+      - name: Smoke-test packaged CLI entrypoint
+        run: node apps/cli/dist/index.js --help
       - name: Publish to npm (OIDC / Trusted Publisher)
         run: cd apps/cli && npm publish --access public --provenance
         # No NODE_AUTH_TOKEN. Authentication happens via OIDC — the npm

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -35,6 +35,7 @@
     "nanoid": "5.1.11",
     "node-pty": "1.1.0",
     "simple-git": "3.36.0",
+    "yaml": "2.8.4",
     "zod": "4.4.2"
   },
   "devDependencies": {

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   outDir: 'dist',
   clean: true,
   banner: { js: '#!/usr/bin/env node' },
+  external: ['yaml'],
   noExternal: [
     '@shipcode/shared',
     '@shipcode/db',

--- a/bun.lock
+++ b/bun.lock
@@ -25,6 +25,7 @@
         "nanoid": "5.1.11",
         "node-pty": "1.1.0",
         "simple-git": "3.36.0",
+        "yaml": "2.8.4",
         "zod": "4.4.2",
       },
       "devDependencies": {


### PR DESCRIPTION
## Summary
- keep yaml external in the CLI bundle and ship it as a runtime dependency
- smoke-test the built CLI entrypoint in the publish workflow before npm publish

## Verification
- bun run --filter @shipshitdev/shipcode build
- node apps/cli/dist/index.js --help
- node apps/cli/dist/index.js onboard --help
- npm pack --dry-run
- install packed tarball in a temp project and run shipcode --help
- bun run format:check
- bun run lint:repo
- bun run typecheck
- bun run test
- bun run build
- npx vercel@50.7.1 build --cwd apps/web --prod
- hdiutil verify apps/desktop/out/ShipCode-0.1.0-arm64.dmg
- codesign --verify --deep --strict apps/desktop/out/mac-arm64/ShipCode.app