### PR TITLE
Add CLI command coverage and retry routing

### DIFF
--- a/apps/cli/src/commands/approve.test.ts
+++ b/apps/cli/src/commands/approve.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  createCliContextMock,
+  requireOnboardingMock,
+  createPipelineMock,
+  rehydrateContextMock,
+  startExecutionMock,
+  getThreadByIssueMock,
+  getLatestPlanMock,
+  updatePlanStatusMock,
+} = vi.hoisted(() => ({
+  createCliContextMock: vi.fn(),
+  requireOnboardingMock: vi.fn(),
+  createPipelineMock: vi.fn(),
+  rehydrateContextMock: vi.fn(),
+  startExecutionMock: vi.fn(),
+  getThreadByIssueMock: vi.fn(),
+  getLatestPlanMock: vi.fn(),
+  updatePlanStatusMock: vi.fn(),
+}));
+
+vi.mock('../context', () => ({
+  createCliContext: createCliContextMock,
+}));
+
+vi.mock('./guard', () => ({
+  requireOnboarding: requireOnboardingMock,
+}));
+
+vi.mock('@shipcode/pipeline', () => ({
+  createPipeline: createPipelineMock,
+}));
+
+vi.mock('@shipcode/shared', () => ({
+  PIPELINE_PHASE: {
+    awaitingApproval: 'awaiting_approval',
+  },
+}));
+
+import { approveCommand } from './approve';
+
+describe('approveCommand', () => {
+  const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
+    throw new Error(`process.exit:${code ?? ''}`);
+  });
+
+  const structuredPlan = {
+    objective: 'Increase coverage',
+    files: [],
+    steps: [],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireOnboardingMock.mockReturnValue(true);
+    createPipelineMock.mockReturnValue({
+      rehydrateContext: rehydrateContextMock,
+      startExecution: startExecutionMock,
+    });
+    createCliContextMock.mockReturnValue({
+      project: {
+        id: 'project-1',
+        path: '/repo',
+      },
+      pipelineDeps: { deps: true },
+      threads: {
+        getByProjectAndGithubIssue: getThreadByIssueMock,
+      },
+      plans: {
+        getLatest: getLatestPlanMock,
+        updateStatus: updatePlanStatusMock,
+      },
+    });
+    getThreadByIssueMock.mockReturnValue({
+      id: 'thread-1',
+      title: 'Ship coverage',
+      status: 'awaiting_approval',
+    });
+    getLatestPlanMock.mockReturnValue({
+      id: 'plan-1',
+      structured: structuredPlan,
+    });
+    startExecutionMock.mockResolvedValue(undefined);
+  });
+
+  it('exits on invalid issue numbers before looking up a thread', async () => {
+    await expect(approveCommand('abc')).rejects.toThrow('process.exit:1');
+
+    expect(errorSpy).toHaveBeenCalledWith('Invalid issue number:', 'abc');
+    expect(getThreadByIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('exits when no thread exists for the issue', async () => {
+    getThreadByIssueMock.mockReturnValueOnce(null);
+
+    await expect(approveCommand('42')).rejects.toThrow('process.exit:1');
+
+    expect(errorSpy).toHaveBeenCalledWith('No thread found for issue #42 in this project.');
+  });
+
+  it('exits when the thread is not awaiting approval', async () => {
+    getThreadByIssueMock.mockReturnValueOnce({
+      id: 'thread-1',
+      title: 'Ship coverage',
+      status: 'executing',
+    });
+
+    await expect(approveCommand('42')).rejects.toThrow('process.exit:1');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'Thread is in "executing" state, not "awaiting_approval". Cannot approve.',
+    );
+  });
+
+  it('exits when the latest plan is missing or unstructured', async () => {
+    getLatestPlanMock.mockReturnValueOnce({ id: 'plan-1', structured: null });
+
+    await expect(approveCommand('42')).rejects.toThrow('process.exit:1');
+
+    expect(errorSpy).toHaveBeenCalledWith('No plan found for this thread.');
+  });
+
+  it('marks the plan approved and resumes execution from the structured plan', async () => {
+    await approveCommand('42');
+
+    expect(createPipelineMock).toHaveBeenCalledWith({ deps: true });
+    expect(rehydrateContextMock).toHaveBeenCalledWith('thread-1', '/repo', 'Ship coverage');
+    expect(updatePlanStatusMock).toHaveBeenCalledWith('plan-1', 'approved');
+    expect(startExecutionMock).toHaveBeenCalledWith('thread-1', structuredPlan);
+    expect(logSpy).toHaveBeenCalledWith('Plan objective: Increase coverage');
+    expect(logSpy).toHaveBeenCalledWith('\nExecution started.');
+  });
+});

--- a/apps/cli/src/commands/logs.test.ts
+++ b/apps/cli/src/commands/logs.test.ts
@@ -1,16 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const {
-  createCliContextMock,
-  requireOnboardingMock,
-  getThreadForIssueOrExitMock,
-  listByThreadMock,
-} = vi.hoisted(() => ({
-  createCliContextMock: vi.fn(),
-  requireOnboardingMock: vi.fn(),
-  getThreadForIssueOrExitMock: vi.fn(),
-  listByThreadMock: vi.fn(),
-}));
+const { createCliContextMock, requireOnboardingMock, getThreadByIssueMock, listByThreadMock } =
+  vi.hoisted(() => ({
+    createCliContextMock: vi.fn(),
+    requireOnboardingMock: vi.fn(),
+    getThreadByIssueMock: vi.fn(),
+    listByThreadMock: vi.fn(),
+  }));
 
 vi.mock('../context', () => ({
   createCliContext: createCliContextMock,
@@ -20,26 +16,31 @@ vi.mock('./guard', () => ({
   requireOnboarding: requireOnboardingMock,
 }));
 
-vi.mock('./issue-helpers', () => ({
-  parseIssueNumber: (value: string) => Number(value),
-  getThreadForIssueOrExit: getThreadForIssueOrExitMock,
-}));
-
 import { logsCommand } from './logs';
 
 describe('logsCommand', () => {
   const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
   const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+  vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
+    throw new Error(`process.exit:${code ?? ''}`);
+  });
 
   beforeEach(() => {
     vi.clearAllMocks();
     requireOnboardingMock.mockReturnValue(true);
     createCliContextMock.mockReturnValue({
+      project: {
+        id: 'project-1',
+      },
+      threads: {
+        getByProjectAndGithubIssue: getThreadByIssueMock,
+      },
       terminalEvents: {
         listByThread: listByThreadMock,
       },
     });
-    getThreadForIssueOrExitMock.mockReturnValue({
+    getThreadByIssueMock.mockReturnValue({
       id: 'thread-1',
       title: 'Add terminal log output',
       status: 'running',
@@ -53,14 +54,29 @@ describe('logsCommand', () => {
     await logsCommand('42');
 
     expect(createCliContextMock).not.toHaveBeenCalled();
-    expect(getThreadForIssueOrExitMock).not.toHaveBeenCalled();
+    expect(getThreadByIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('exits on invalid issue numbers before looking up a thread', async () => {
+    await expect(logsCommand('abc')).rejects.toThrow('process.exit:1');
+
+    expect(errorSpy).toHaveBeenCalledWith('Invalid issue number:', 'abc');
+    expect(getThreadByIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('exits when no thread exists for the issue', async () => {
+    getThreadByIssueMock.mockReturnValueOnce(null);
+
+    await expect(logsCommand('42')).rejects.toThrow('process.exit:1');
+
+    expect(errorSpy).toHaveBeenCalledWith('No thread found for issue #42 in this project.');
   });
 
   it('prints a friendly empty state when a thread has no terminal events', async () => {
     await logsCommand('42');
 
     expect(createCliContextMock).toHaveBeenCalledWith(process.cwd());
-    expect(getThreadForIssueOrExitMock).toHaveBeenCalledWith(expect.any(Object), 42);
+    expect(getThreadByIssueMock).toHaveBeenCalledWith('project-1', 42);
     expect(logSpy).toHaveBeenCalledWith('Logs for issue #42: Add terminal log output');
     expect(logSpy).toHaveBeenCalledWith('Status: running\n');
     expect(logSpy).toHaveBeenCalledWith('No terminal events recorded.');
@@ -116,6 +132,14 @@ describe('logsCommand', () => {
         createdAt: '2026-05-08T12:00:12.000Z',
         event: { kind: 'turn_start' },
       },
+      {
+        createdAt: '2026-05-08T12:00:13.000Z',
+        event: { kind: 'turn_end' },
+      },
+      {
+        createdAt: '2026-05-08T12:00:14.000Z',
+        event: { kind: 'action', summary: 'hidden action' },
+      },
     ]);
 
     await logsCommand('42');
@@ -131,5 +155,7 @@ describe('logsCommand', () => {
     expect(logSpy).toHaveBeenCalledWith('[12:00:09] Clarification answered (2 questions)');
     expect(logSpy).toHaveBeenCalledWith('[12:00:10] Done — cost: $0.1235');
     expect(logSpy).toHaveBeenCalledWith('[12:00:11] Done');
+    expect(logSpy).not.toHaveBeenCalledWith(expect.stringContaining('hidden action'));
+    expect(writeSpy).not.toHaveBeenCalledWith(expect.stringContaining('hidden action'));
   });
 });

--- a/apps/cli/src/commands/pipeline-commands.test.ts
+++ b/apps/cli/src/commands/pipeline-commands.test.ts
@@ -18,6 +18,7 @@ const {
   getReviewByPlanIdMock,
   updatePlanStatusMock,
   getLatestCheckpointMock,
+  getLatestVerificationMock,
 } = vi.hoisted(() => ({
   createCliContextMock: vi.fn(),
   requireOnboardingMock: vi.fn(),
@@ -36,6 +37,7 @@ const {
   getReviewByPlanIdMock: vi.fn(),
   updatePlanStatusMock: vi.fn(),
   getLatestCheckpointMock: vi.fn(),
+  getLatestVerificationMock: vi.fn(),
 }));
 
 vi.mock('../context', () => ({
@@ -114,6 +116,9 @@ describe('pipeline CLI commands', () => {
       checkpoints: {
         getLatest: getLatestCheckpointMock,
       },
+      verifications: {
+        getLatest: getLatestVerificationMock,
+      },
     });
     getThreadForIssueOrExitMock.mockReturnValue({
       id: 'thread-1',
@@ -144,6 +149,7 @@ describe('pipeline CLI commands', () => {
       phase: 'executing',
       reason: 'verification failed',
     });
+    getLatestVerificationMock.mockReturnValue(null);
   });
 
   it('does not create a context when onboarding is incomplete', async () => {

--- a/apps/cli/src/commands/plan.test.ts
+++ b/apps/cli/src/commands/plan.test.ts
@@ -1,0 +1,157 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  createCliContextMock,
+  requireOnboardingMock,
+  routeFromLabelsMock,
+  createPipelineMock,
+  startFromGitHubIssueMock,
+  ghGetIssueMock,
+  getThreadByIssueMock,
+  getLatestPlanMock,
+} = vi.hoisted(() => ({
+  createCliContextMock: vi.fn(),
+  requireOnboardingMock: vi.fn(),
+  routeFromLabelsMock: vi.fn(),
+  createPipelineMock: vi.fn(),
+  startFromGitHubIssueMock: vi.fn(),
+  ghGetIssueMock: vi.fn(),
+  getThreadByIssueMock: vi.fn(),
+  getLatestPlanMock: vi.fn(),
+}));
+
+vi.mock('../context', () => ({
+  createCliContext: createCliContextMock,
+}));
+
+vi.mock('./guard', () => ({
+  requireOnboarding: requireOnboardingMock,
+}));
+
+vi.mock('@shipcode/agents', () => ({
+  routeFromLabels: routeFromLabelsMock,
+}));
+
+vi.mock('@shipcode/pipeline', () => ({
+  createPipeline: createPipelineMock,
+}));
+
+import { planCommand } from './plan';
+
+describe('planCommand', () => {
+  const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
+    throw new Error(`process.exit:${code ?? ''}`);
+  });
+
+  const structuredPlan = {
+    id: 'plan-1',
+    threadId: 'thread-1',
+    version: 1,
+    objective: 'Increase coverage',
+    files: [],
+    steps: [],
+    acceptanceCriteria: [],
+    outOfScope: [],
+    estimatedComplexity: 'low',
+    dependencies: [],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireOnboardingMock.mockReturnValue(true);
+    routeFromLabelsMock.mockReturnValue({
+      executorModel: 'openrouter',
+      modelOverride: 'openrouter/auto',
+    });
+    createPipelineMock.mockReturnValue({
+      startFromGitHubIssue: startFromGitHubIssueMock,
+    });
+    createCliContextMock.mockReturnValue({
+      project: {
+        id: 'project-1',
+        path: '/repo',
+        defaultBranch: 'main',
+      },
+      pipelineDeps: { deps: true },
+      ghCli: {
+        getIssue: ghGetIssueMock,
+      },
+      threads: {
+        getByProjectAndGithubIssue: getThreadByIssueMock,
+      },
+      plans: {
+        getLatest: getLatestPlanMock,
+      },
+    });
+    ghGetIssueMock.mockResolvedValue({
+      number: 42,
+      title: 'Ship coverage',
+      body: 'Add tests',
+      labels: ['shipcode:agent:openrouter/auto'],
+    });
+    getThreadByIssueMock.mockReturnValue({
+      id: 'thread-1',
+      status: 'awaiting_approval',
+    });
+    getLatestPlanMock.mockReturnValue({
+      id: 'plan-1',
+      structured: structuredPlan,
+    });
+    startFromGitHubIssueMock.mockResolvedValue(undefined);
+  });
+
+  it('fetches the issue, routes labels, starts the pipeline, and prints the generated plan', async () => {
+    await planCommand('42');
+
+    expect(ghGetIssueMock).toHaveBeenCalledWith(42);
+    expect(startFromGitHubIssueMock).toHaveBeenCalledWith(
+      'project-1',
+      '/repo',
+      {
+        number: 42,
+        title: 'Ship coverage',
+        body: 'Add tests',
+        labels: ['shipcode:agent:openrouter/auto'],
+      },
+      'openrouter',
+      { baseBranch: 'main', executorModelOverride: 'openrouter/auto' },
+    );
+    expect(logSpy).toHaveBeenCalledWith('\n--- Plan Output ---');
+    expect(logSpy).toHaveBeenCalledWith(JSON.stringify(structuredPlan, null, 2));
+    expect(logSpy).toHaveBeenCalledWith('\nThread status: awaiting_approval');
+  });
+
+  it('falls back to Claude routing when label routing returns an error', async () => {
+    routeFromLabelsMock.mockReturnValueOnce({ error: 'bad label' });
+
+    await planCommand('42');
+
+    expect(startFromGitHubIssueMock).toHaveBeenCalledWith(
+      'project-1',
+      '/repo',
+      expect.any(Object),
+      'claude',
+      { baseBranch: 'main', executorModelOverride: null },
+    );
+  });
+
+  it('exits when the pipeline run does not persist a thread', async () => {
+    getThreadByIssueMock.mockReturnValueOnce(null);
+
+    await expect(planCommand('42')).rejects.toThrow('process.exit:1');
+
+    expect(errorSpy).toHaveBeenCalledWith('Thread not found after pipeline run.');
+  });
+
+  it('prints the no-output branch when no structured plan is available', async () => {
+    getLatestPlanMock.mockReturnValueOnce(null);
+
+    await planCommand('42');
+
+    expect(logSpy).toHaveBeenCalledWith(
+      '\nNo plan generated (pipeline may have failed or entered clarification).',
+    );
+  });
+});

--- a/apps/cli/src/commands/prd.test.ts
+++ b/apps/cli/src/commands/prd.test.ts
@@ -104,10 +104,35 @@ describe('prdCommand', () => {
       reasoningEffort: 'low',
     });
     expect(logSpy).toHaveBeenCalledWith('Found existing issue #12: Coverage PRD');
+    expect(logSpy).toHaveBeenCalledWith('\nTo update issue #12:');
     expect(logSpy).toHaveBeenCalledWith('  gh issue edit 12 --body-file <file>');
   });
 
-  it('uses the fallback template and new issue instructions when no match is found', async () => {
+  it('generates a new draft with the repo skill when issue search returns no matches', async () => {
+    execSyncMock.mockReturnValueOnce(JSON.stringify([]));
+
+    await prdCommand('New coverage plan');
+
+    expect(readFileSyncMock).toHaveBeenCalledWith(
+      expect.stringContaining('skills/writing-prds/SKILL.md'),
+      'utf-8',
+    );
+    expect(enhancePrdDraftMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        draftBody: '# New coverage plan\n\nTODO: Fill in PRD sections.',
+        skillContent: 'PRD skill content',
+      }),
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      'No existing issue found for "New coverage plan". Generating new PRD...\n',
+    );
+    expect(logSpy).toHaveBeenCalledWith('\nTo create a new issue:');
+    expect(logSpy).toHaveBeenCalledWith(
+      '  gh issue create --title "New coverage plan" --body-file <file>',
+    );
+  });
+
+  it('uses the fallback template and new issue instructions when search fails', async () => {
     existsSyncMock.mockReturnValueOnce(false);
     execSyncMock.mockImplementationOnce(() => {
       throw new Error('gh unavailable');

--- a/apps/cli/src/commands/retry.test.ts
+++ b/apps/cli/src/commands/retry.test.ts
@@ -1,0 +1,226 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  createCliContextMock,
+  requireOnboardingMock,
+  createPipelineMock,
+  rehydrateContextMock,
+  startExecutionMock,
+  startVerificationMock,
+  startShippingMock,
+  startPlanGenerationMock,
+  getThreadByIssueMock,
+  getLatestPlanMock,
+  getLatestCheckpointMock,
+  getLatestVerificationMock,
+} = vi.hoisted(() => ({
+  createCliContextMock: vi.fn(),
+  requireOnboardingMock: vi.fn(),
+  createPipelineMock: vi.fn(),
+  rehydrateContextMock: vi.fn(),
+  startExecutionMock: vi.fn(),
+  startVerificationMock: vi.fn(),
+  startShippingMock: vi.fn(),
+  startPlanGenerationMock: vi.fn(),
+  getThreadByIssueMock: vi.fn(),
+  getLatestPlanMock: vi.fn(),
+  getLatestCheckpointMock: vi.fn(),
+  getLatestVerificationMock: vi.fn(),
+}));
+
+vi.mock('../context', () => ({
+  createCliContext: createCliContextMock,
+}));
+
+vi.mock('./guard', () => ({
+  requireOnboarding: requireOnboardingMock,
+}));
+
+vi.mock('@shipcode/pipeline', () => ({
+  createPipeline: createPipelineMock,
+}));
+
+import { retryCommand } from './retry';
+
+describe('retryCommand', () => {
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+  vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
+    throw new Error(`process.exit:${code ?? ''}`);
+  });
+
+  const structuredPlan = {
+    objective: 'Increase coverage',
+    files: [],
+    steps: [],
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireOnboardingMock.mockReturnValue(true);
+    createPipelineMock.mockReturnValue({
+      rehydrateContext: rehydrateContextMock,
+      startExecution: startExecutionMock,
+      startVerification: startVerificationMock,
+      startShipping: startShippingMock,
+      startPlanGeneration: startPlanGenerationMock,
+    });
+    createCliContextMock.mockReturnValue({
+      project: {
+        id: 'project-1',
+        path: '/repo',
+      },
+      pipelineDeps: { deps: true },
+      threads: {
+        getByProjectAndGithubIssue: getThreadByIssueMock,
+      },
+      plans: {
+        getLatest: getLatestPlanMock,
+      },
+      checkpoints: {
+        getLatest: getLatestCheckpointMock,
+      },
+      verifications: {
+        getLatest: getLatestVerificationMock,
+      },
+    });
+    getThreadByIssueMock.mockReturnValue({
+      id: 'thread-1',
+      title: 'Ship coverage',
+      status: 'failed',
+      prompt: 'Fix tests',
+      worktreePath: '/tmp/worktree',
+    });
+    getLatestPlanMock.mockReturnValue({
+      id: 'plan-1',
+      structured: structuredPlan,
+    });
+    getLatestCheckpointMock.mockReturnValue({
+      phase: 'executing',
+      reason: 'verification failed',
+    });
+    getLatestVerificationMock.mockReturnValue(null);
+  });
+
+  it('exits on invalid issue numbers before looking up a thread', async () => {
+    await expect(retryCommand('abc')).rejects.toThrow('process.exit:1');
+
+    expect(errorSpy).toHaveBeenCalledWith('Invalid issue number:', 'abc');
+    expect(getThreadByIssueMock).not.toHaveBeenCalled();
+  });
+
+  it('exits when no thread exists for the issue', async () => {
+    getThreadByIssueMock.mockReturnValueOnce(null);
+
+    await expect(retryCommand('42')).rejects.toThrow('process.exit:1');
+
+    expect(errorSpy).toHaveBeenCalledWith('No thread found for issue #42 in this project.');
+  });
+
+  it('exits when there is no checkpoint', async () => {
+    getLatestCheckpointMock.mockReturnValueOnce(null);
+
+    await expect(retryCommand('42')).rejects.toThrow('process.exit:1');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      'No checkpoint found for this thread. Nothing to retry from.',
+    );
+  });
+
+  it('exits when execution retry has no structured plan', async () => {
+    getLatestPlanMock.mockReturnValueOnce({ id: 'plan-1', structured: null });
+
+    await expect(retryCommand('42')).rejects.toThrow('process.exit:1');
+
+    expect(errorSpy).toHaveBeenCalledWith('No plan found for retry.');
+  });
+
+  it('resumes execution from an executing checkpoint', async () => {
+    await retryCommand('42');
+
+    expect(rehydrateContextMock).toHaveBeenCalledWith('thread-1', '/repo', 'Ship coverage');
+    expect(startExecutionMock).toHaveBeenCalledWith('thread-1', structuredPlan);
+  });
+
+  it('resumes execution when current-plan verification failed with structured findings', async () => {
+    getLatestCheckpointMock.mockReturnValueOnce({
+      phase: 'verifying',
+      reason: 'verification failed',
+    });
+    getLatestVerificationMock.mockReturnValueOnce({
+      id: 'verification-1',
+      threadId: 'thread-1',
+      planId: 'plan-1',
+      result: 'failed',
+      structured: {
+        result: 'failed',
+        summary: 'Needs fixes',
+        criteriaResults: [],
+        issues: [{ severity: 'high', title: 'Test failed' }],
+      },
+    });
+
+    await retryCommand('42');
+
+    expect(startExecutionMock).toHaveBeenCalledWith('thread-1', structuredPlan);
+    expect(startVerificationMock).not.toHaveBeenCalled();
+  });
+
+  it('re-runs verification when current-plan verification failed without structured findings', async () => {
+    getLatestCheckpointMock.mockReturnValueOnce({
+      phase: 'verifying',
+      reason: 'verification failed',
+    });
+    getLatestVerificationMock.mockReturnValueOnce({
+      id: 'verification-1',
+      threadId: 'thread-1',
+      planId: 'plan-1',
+      result: 'failed',
+      structured: null,
+    });
+
+    await retryCommand('42');
+
+    expect(startVerificationMock).toHaveBeenCalledWith('thread-1');
+    expect(startExecutionMock).not.toHaveBeenCalled();
+  });
+
+  it('re-runs verification when the latest verification is for an older plan', async () => {
+    getLatestCheckpointMock.mockReturnValueOnce({
+      phase: 'verifying',
+      reason: 'verification failed',
+    });
+    getLatestVerificationMock.mockReturnValueOnce({
+      id: 'verification-1',
+      threadId: 'thread-1',
+      planId: 'older-plan',
+      result: 'failed',
+      structured: { result: 'failed', summary: 'Old feedback', criteriaResults: [], issues: [] },
+    });
+
+    await retryCommand('42');
+
+    expect(startVerificationMock).toHaveBeenCalledWith('thread-1');
+  });
+
+  it('resumes shipping from a shipping checkpoint', async () => {
+    getLatestCheckpointMock.mockReturnValueOnce({ phase: 'shipping', reason: 'push failed' });
+
+    await retryCommand('42');
+
+    expect(startShippingMock).toHaveBeenCalledWith('thread-1');
+  });
+
+  it('falls back to plan generation for unknown checkpoint phases', async () => {
+    getLatestCheckpointMock.mockReturnValueOnce({ phase: 'planning', reason: 'manual retry' });
+
+    await retryCommand('42');
+
+    expect(startPlanGenerationMock).toHaveBeenCalledWith(
+      'thread-1',
+      'Fix tests',
+      '/repo',
+      '/tmp/worktree',
+    );
+  });
+});

--- a/apps/cli/src/commands/retry.ts
+++ b/apps/cli/src/commands/retry.ts
@@ -40,9 +40,25 @@ export async function retryCommand(issueNumber: string) {
       await pipeline.startExecution(thread.id, latestPlan.structured);
       break;
     }
-    case 'verifying':
-      await pipeline.startVerification(thread.id);
+    case 'verifying': {
+      const latestPlan = ctx.plans.getLatest(thread.id);
+      if (!latestPlan?.structured) {
+        console.error('No plan found for retry.');
+        process.exit(1);
+      }
+
+      const latestVerification = ctx.verifications.getLatest(thread.id);
+      if (
+        latestVerification?.planId === latestPlan.id &&
+        latestVerification.result === 'failed' &&
+        latestVerification.structured
+      ) {
+        await pipeline.startExecution(thread.id, latestPlan.structured);
+      } else {
+        await pipeline.startVerification(thread.id);
+      }
       break;
+    }
     case 'shipping':
       await pipeline.startShipping(thread.id);
       break;

--- a/apps/cli/src/commands/review.test.ts
+++ b/apps/cli/src/commands/review.test.ts
@@ -1,0 +1,164 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const {
+  createCliContextMock,
+  requireOnboardingMock,
+  routeFromLabelsMock,
+  createPipelineMock,
+  startFromGitHubIssueMock,
+  ghGetIssueMock,
+  getThreadByIssueMock,
+  getLatestPlanMock,
+  getReviewByPlanIdMock,
+} = vi.hoisted(() => ({
+  createCliContextMock: vi.fn(),
+  requireOnboardingMock: vi.fn(),
+  routeFromLabelsMock: vi.fn(),
+  createPipelineMock: vi.fn(),
+  startFromGitHubIssueMock: vi.fn(),
+  ghGetIssueMock: vi.fn(),
+  getThreadByIssueMock: vi.fn(),
+  getLatestPlanMock: vi.fn(),
+  getReviewByPlanIdMock: vi.fn(),
+}));
+
+vi.mock('../context', () => ({
+  createCliContext: createCliContextMock,
+}));
+
+vi.mock('./guard', () => ({
+  requireOnboarding: requireOnboardingMock,
+}));
+
+vi.mock('@shipcode/agents', () => ({
+  routeFromLabels: routeFromLabelsMock,
+}));
+
+vi.mock('@shipcode/pipeline', () => ({
+  createPipeline: createPipelineMock,
+}));
+
+import { reviewCommand } from './review';
+
+describe('reviewCommand', () => {
+  const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null) => {
+    throw new Error(`process.exit:${code ?? ''}`);
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    requireOnboardingMock.mockReturnValue(true);
+    routeFromLabelsMock.mockReturnValue({
+      executorModel: 'codex',
+      modelOverride: 'gpt-5.4',
+    });
+    createPipelineMock.mockReturnValue({
+      startFromGitHubIssue: startFromGitHubIssueMock,
+    });
+    createCliContextMock.mockReturnValue({
+      project: {
+        id: 'project-1',
+        path: '/repo',
+        defaultBranch: 'develop',
+      },
+      pipelineDeps: { deps: true },
+      ghCli: {
+        getIssue: ghGetIssueMock,
+      },
+      threads: {
+        getByProjectAndGithubIssue: getThreadByIssueMock,
+      },
+      plans: {
+        getLatest: getLatestPlanMock,
+      },
+      reviews: {
+        getByPlanId: getReviewByPlanIdMock,
+      },
+    });
+    ghGetIssueMock.mockResolvedValue({
+      number: 7,
+      title: 'Review branch',
+      body: 'Check plan',
+      labels: ['shipcode:agent:codex/gpt-5.4'],
+    });
+    getThreadByIssueMock.mockReturnValue({
+      id: 'thread-1',
+      status: 'awaiting_approval',
+    });
+    getLatestPlanMock.mockReturnValue({
+      id: 'plan-1',
+      structured: { objective: 'Ship review tests' },
+    });
+    getReviewByPlanIdMock.mockReturnValue({
+      id: 'review-1',
+      decision: 'approve',
+    });
+    startFromGitHubIssueMock.mockResolvedValue(undefined);
+  });
+
+  it('fetches the issue, routes labels, starts the pipeline, and prints the generated review', async () => {
+    await reviewCommand('7');
+
+    expect(ghGetIssueMock).toHaveBeenCalledWith(7);
+    expect(startFromGitHubIssueMock).toHaveBeenCalledWith(
+      'project-1',
+      '/repo',
+      {
+        number: 7,
+        title: 'Review branch',
+        body: 'Check plan',
+        labels: ['shipcode:agent:codex/gpt-5.4'],
+      },
+      'codex',
+      { baseBranch: 'develop', executorModelOverride: 'gpt-5.4' },
+    );
+    expect(getReviewByPlanIdMock).toHaveBeenCalledWith('plan-1');
+    expect(logSpy).toHaveBeenCalledWith('\n--- Review Output ---');
+    expect(logSpy).toHaveBeenCalledWith(
+      JSON.stringify({ id: 'review-1', decision: 'approve' }, null, 2),
+    );
+    expect(logSpy).toHaveBeenCalledWith('\nThread status: awaiting_approval');
+  });
+
+  it('falls back to Claude routing when label routing returns an error', async () => {
+    routeFromLabelsMock.mockReturnValueOnce({ error: 'bad label' });
+
+    await reviewCommand('7');
+
+    expect(startFromGitHubIssueMock).toHaveBeenCalledWith(
+      'project-1',
+      '/repo',
+      expect.any(Object),
+      'claude',
+      { baseBranch: 'develop', executorModelOverride: null },
+    );
+  });
+
+  it('exits when the pipeline run does not persist a thread', async () => {
+    getThreadByIssueMock.mockReturnValueOnce(null);
+
+    await expect(reviewCommand('7')).rejects.toThrow('process.exit:1');
+
+    expect(errorSpy).toHaveBeenCalledWith('Thread not found after pipeline run.');
+  });
+
+  it('prints no-output branches when the plan or review is missing', async () => {
+    getLatestPlanMock.mockReturnValueOnce(null);
+
+    await reviewCommand('7');
+
+    expect(logSpy).toHaveBeenCalledWith(
+      '\nNo plan generated (pipeline may have failed before plan phase).',
+    );
+
+    getReviewByPlanIdMock.mockReturnValueOnce(null);
+
+    await reviewCommand('7');
+
+    expect(logSpy).toHaveBeenCalledWith(
+      '\nNo review generated (pipeline may have stopped before review phase).',
+    );
+  });
+});


### PR DESCRIPTION
Opened from existing remote branch `shipcode/2YVwUe7Kj2KUgwbFmX9qQ` for review and CI monitoring.