### PR TITLE
Deduplicate pipeline error clamping, CLI helper, and test fakes

### DIFF
--- a/apps/cli/src/commands/issue-helpers.ts
+++ b/apps/cli/src/commands/issue-helpers.ts
@@ -1,10 +1,7 @@
 import type { Thread } from '@shipcode/shared';
 import type { CliContext } from '../context';
-import { parseIssueNumberOrExit } from './issue-number';
 
-export function parseIssueNumber(issueNumber: string): number {
-  return parseIssueNumberOrExit(issueNumber);
-}
+export { parseIssueNumberOrExit as parseIssueNumber } from './issue-number';
 
 export function getThreadForIssueOrExit(ctx: CliContext, issueNumber: number): Thread {
   const thread = ctx.threads.getByProjectAndGithubIssue(ctx.project.id, issueNumber);

--- a/apps/desktop/src/main/ipc/register-pipeline-handlers.ts
+++ b/apps/desktop/src/main/ipc/register-pipeline-handlers.ts
@@ -7,6 +7,7 @@ import type {
   Thread,
 } from '@shipcode/shared';
 import {
+  clampError,
   clarificationAnswerSchema,
   EXECUTION_PHASES,
   PAUSABLE_PIPELINE_PHASES,
@@ -944,8 +945,7 @@ export function registerPipelineHandlers({
           timeout: 15_000,
         });
       } catch (error) {
-        const raw = error instanceof Error ? error.message : String(error);
-        const clamped = raw.split('\n')[0]?.slice(0, 280) ?? 'Unknown checkpoint restore error';
+        const clamped = clampError(error);
         emitTerminalEvent(threadId, {
           kind: 'error',
           message: `Auto Fix checkpoint restore failed: ${clamped}`,
@@ -1085,9 +1085,7 @@ export function registerPipelineHandlers({
 
       return { prNumber, prUrl };
     } catch (err) {
-      const raw = err instanceof Error ? err.message : String(err);
-      const clamped = raw.split('\n')[0]?.slice(0, 280) ?? 'Unknown error';
-      throw new Error(clamped);
+      throw new Error(clampError(err));
     } finally {
       createPrInFlight.delete(threadId);
     }

--- a/packages/agents/src/automation-formatter.test.ts
+++ b/packages/agents/src/automation-formatter.test.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from 'node:events';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mockSpawn = vi.hoisted(() => vi.fn());
@@ -18,6 +17,7 @@ import {
   formatAutomationPrompt,
 } from './automation-formatter';
 import { OpenRouterClient } from './providers/openrouter-http';
+import { createFakeProc } from './test-fake-proc';
 
 function sseResponse(chunks: string[]): Response {
   const encoder = new TextEncoder();
@@ -33,37 +33,6 @@ function sseResponse(chunks: string[]): Response {
   });
 }
 
-function createFakeProc() {
-  const proc = new EventEmitter() as EventEmitter & {
-    stdout: EventEmitter;
-    stderr: EventEmitter;
-    stdin: { write: (chunk: string) => boolean; end: () => void };
-  };
-  proc.stdout = new EventEmitter();
-  proc.stderr = new EventEmitter();
-  const stdinWrites: string[] = [];
-  let stdinEnded = false;
-  proc.stdin = {
-    write: (chunk: string) => {
-      stdinWrites.push(chunk);
-      return true;
-    },
-    end: () => {
-      stdinEnded = true;
-    },
-  };
-  return {
-    proc,
-    stdinWrites,
-    isStdinEnded: () => stdinEnded,
-    close: (code: number, options?: { stdout?: string; stderr?: string }) => {
-      if (options?.stdout) proc.stdout.emit('data', options.stdout);
-      if (options?.stderr) proc.stderr.emit('data', options.stderr);
-      proc.emit('close', code);
-    },
-  };
-}
-
 describe('formatAutomationPrompt', () => {
   afterEach(() => {
     vi.clearAllMocks();
@@ -71,7 +40,7 @@ describe('formatAutomationPrompt', () => {
   });
 
   it('pipes the formatter prompt through Claude stdin', async () => {
-    const fake = createFakeProc();
+    const fake = createFakeProc({ captureStdin: true });
     mockSpawn.mockReturnValueOnce(fake.proc);
 
     const promise = formatAutomationPrompt({
@@ -104,7 +73,7 @@ describe('formatAutomationPrompt', () => {
   });
 
   it('uses Codex CLI when selected', async () => {
-    const fake = createFakeProc();
+    const fake = createFakeProc({ captureStdin: true });
     mockSpawn.mockReturnValueOnce(fake.proc);
 
     const promise = formatAutomationPrompt({

--- a/packages/agents/src/cli-stdin-runner.test.ts
+++ b/packages/agents/src/cli-stdin-runner.test.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from 'node:events';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mockSpawn = vi.hoisted(() => vi.fn());
@@ -12,39 +11,7 @@ vi.mock('./health-check', () => ({
 }));
 
 import { runCliWithStdin } from './cli-stdin-runner';
-
-function createFakeProc() {
-  const proc = new EventEmitter() as EventEmitter & {
-    stdout: EventEmitter;
-    stderr: EventEmitter;
-    stdin: { write: (chunk: string) => boolean; end: () => void };
-    kill: (signal: string) => void;
-  };
-  proc.stdout = new EventEmitter();
-  proc.stderr = new EventEmitter();
-  const stdinWrites: string[] = [];
-  let stdinEnded = false;
-  proc.stdin = {
-    write: (chunk: string) => {
-      stdinWrites.push(chunk);
-      return true;
-    },
-    end: () => {
-      stdinEnded = true;
-    },
-  };
-  proc.kill = vi.fn();
-  return {
-    proc,
-    stdinWrites,
-    isStdinEnded: () => stdinEnded,
-    close: (code: number, options?: { stdout?: string; stderr?: string }) => {
-      if (options?.stdout) proc.stdout.emit('data', options.stdout);
-      if (options?.stderr) proc.stderr.emit('data', options.stderr);
-      proc.emit('close', code);
-    },
-  };
-}
+import { createFakeProc } from './test-fake-proc';
 
 describe('runCliWithStdin', () => {
   afterEach(() => {
@@ -53,7 +20,7 @@ describe('runCliWithStdin', () => {
   });
 
   it('pipes stdin and surfaces a short stdout-derived error when stderr is empty', async () => {
-    const fake = createFakeProc();
+    const fake = createFakeProc({ captureStdin: true, kill: true });
     mockSpawn.mockReturnValueOnce(fake.proc);
 
     const promise = runCliWithStdin({

--- a/packages/agents/src/context-generator.test.ts
+++ b/packages/agents/src/context-generator.test.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from 'node:events';
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -16,28 +15,7 @@ vi.mock('node:child_process', () => {
 });
 
 import { generateContextFiles } from './context-generator';
-
-function createFakeProc() {
-  const proc = new EventEmitter() as EventEmitter & {
-    stdout: EventEmitter;
-    stderr: EventEmitter;
-    stdin: { write: (chunk: string) => boolean; end: () => void };
-  };
-  proc.stdout = new EventEmitter();
-  proc.stderr = new EventEmitter();
-  proc.stdin = {
-    write: () => true,
-    end: () => undefined,
-  };
-  return {
-    proc,
-    close: (code: number, options?: { stdout?: string; stderr?: string }) => {
-      if (options?.stdout) proc.stdout.emit('data', options.stdout);
-      if (options?.stderr) proc.stderr.emit('data', options.stderr);
-      proc.emit('close', code);
-    },
-  };
-}
+import { createFakeProc } from './test-fake-proc';
 
 describe('generateContextFiles', () => {
   afterEach(() => {

--- a/packages/agents/src/memory-generator.test.ts
+++ b/packages/agents/src/memory-generator.test.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from 'node:events';
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -20,34 +19,7 @@ import {
   listMemoryFiles,
   readMemoryFile,
 } from './memory-generator';
-
-function createFakeProc() {
-  const proc = new EventEmitter() as EventEmitter & {
-    stdout: EventEmitter;
-    stderr: EventEmitter;
-    stdin: { chunks: string[]; write: (chunk: string) => boolean; end: () => void };
-    kill: (signal: string) => void;
-  };
-  proc.stdout = new EventEmitter();
-  proc.stderr = new EventEmitter();
-  proc.stdin = {
-    chunks: [],
-    write: (chunk: string) => {
-      proc.stdin.chunks.push(chunk);
-      return true;
-    },
-    end: () => {},
-  };
-  proc.kill = vi.fn();
-  return {
-    proc,
-    close: (code: number, options?: { stdout?: string; stderr?: string }) => {
-      if (options?.stdout) proc.stdout.emit('data', options.stdout);
-      if (options?.stderr) proc.stderr.emit('data', options.stderr);
-      proc.emit('close', code);
-    },
-  };
-}
+import { createFakeProc } from './test-fake-proc';
 
 describe('generateMemoryFiles', () => {
   afterEach(() => {
@@ -55,7 +27,7 @@ describe('generateMemoryFiles', () => {
   });
 
   it('writes the generated memory files from a Claude result envelope', async () => {
-    const fake = createFakeProc();
+    const fake = createFakeProc({ kill: true });
     mockSpawn.mockReturnValueOnce(fake.proc);
 
     const projectPath = mkdtempSync(join(tmpdir(), 'shipcode-memory-generator-'));
@@ -118,7 +90,7 @@ describe('generateMemoryFiles', () => {
   });
 
   it('passes missing source markers to Codex and parses a raw fenced response', async () => {
-    const fake = createFakeProc();
+    const fake = createFakeProc({ captureStdin: true, kill: true });
     mockSpawn.mockReturnValueOnce(fake.proc);
     const projectPath = mkdtempSync(join(tmpdir(), 'shipcode-memory-codex-'));
 
@@ -130,7 +102,7 @@ describe('generateMemoryFiles', () => {
       expect.arrayContaining(['exec', '-', '--sandbox', 'read-only']),
       expect.objectContaining({ cwd: projectPath }),
     );
-    expect(fake.proc.stdin.chunks.join('')).toContain('### README.md\n(not found)');
+    expect(fake.stdinWrites.join('')).toContain('### README.md\n(not found)');
 
     fake.close(0, {
       stdout:

--- a/packages/agents/src/prd-generator.test.ts
+++ b/packages/agents/src/prd-generator.test.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from 'node:events';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mockSpawn = vi.hoisted(() => vi.fn());
@@ -13,37 +12,7 @@ vi.mock('./health-check', () => ({
 }));
 
 import { buildPrdPrompt, enhancePrdDraft, extractPrd } from './prd-generator';
-
-function createFakeProc() {
-  const proc = new EventEmitter() as EventEmitter & {
-    stdout: EventEmitter;
-    stderr: EventEmitter;
-    stdin: { write: (chunk: string) => boolean; end: () => void };
-  };
-  proc.stdout = new EventEmitter();
-  proc.stderr = new EventEmitter();
-  const stdinWrites: string[] = [];
-  let stdinEnded = false;
-  proc.stdin = {
-    write: (chunk: string) => {
-      stdinWrites.push(chunk);
-      return true;
-    },
-    end: () => {
-      stdinEnded = true;
-    },
-  };
-  return {
-    proc,
-    stdinWrites,
-    isStdinEnded: () => stdinEnded,
-    close: (code: number, options?: { stdout?: string; stderr?: string }) => {
-      if (options?.stdout) proc.stdout.emit('data', options.stdout);
-      if (options?.stderr) proc.stderr.emit('data', options.stderr);
-      proc.emit('close', code);
-    },
-  };
-}
+import { createFakeProc } from './test-fake-proc';
 
 describe('enhancePrdDraft', () => {
   afterEach(() => {
@@ -51,7 +20,7 @@ describe('enhancePrdDraft', () => {
   });
 
   it('surfaces Claude stdout result when the CLI exits non-zero with empty stderr', async () => {
-    const fake = createFakeProc();
+    const fake = createFakeProc({ captureStdin: true });
     mockSpawn.mockReturnValueOnce(fake.proc);
 
     const promise = enhancePrdDraft({
@@ -81,7 +50,7 @@ describe('enhancePrdDraft', () => {
   });
 
   it('passes explicit Claude model without adding thinking tokens for low effort', async () => {
-    const fake = createFakeProc();
+    const fake = createFakeProc({ captureStdin: true });
     mockSpawn.mockReturnValueOnce(fake.proc);
 
     const promise = enhancePrdDraft({
@@ -122,7 +91,7 @@ describe('enhancePrdDraft', () => {
   });
 
   it('uses Codex CLI when selected', async () => {
-    const fake = createFakeProc();
+    const fake = createFakeProc({ captureStdin: true });
     mockSpawn.mockReturnValueOnce(fake.proc);
 
     const promise = enhancePrdDraft({

--- a/packages/agents/src/skill-rewriter.test.ts
+++ b/packages/agents/src/skill-rewriter.test.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from 'node:events';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 const mockSpawn = vi.hoisted(() => vi.fn());
@@ -17,40 +16,10 @@ import {
   extractRewrittenSkill,
   rewriteSkillDraft,
 } from './skill-rewriter';
+import { createFakeProc } from './test-fake-proc';
 
 const VALID_PLAN_SKILL =
   '---\nname: plan-generation\n---\nUse {{USER_PROMPT}} for {{THREAD_ID}} and emit {{OUTPUT_SCHEMA}}.';
-
-function createFakeProc() {
-  const proc = new EventEmitter() as EventEmitter & {
-    stdout: EventEmitter;
-    stderr: EventEmitter;
-    stdin: { write: (chunk: string) => boolean; end: () => void };
-  };
-  proc.stdout = new EventEmitter();
-  proc.stderr = new EventEmitter();
-  const stdinWrites: string[] = [];
-  let stdinEnded = false;
-  proc.stdin = {
-    write: (chunk: string) => {
-      stdinWrites.push(chunk);
-      return true;
-    },
-    end: () => {
-      stdinEnded = true;
-    },
-  };
-  return {
-    proc,
-    stdinWrites,
-    isStdinEnded: () => stdinEnded,
-    close: (code: number, options?: { stdout?: string; stderr?: string }) => {
-      if (options?.stdout) proc.stdout.emit('data', options.stdout);
-      if (options?.stderr) proc.stderr.emit('data', options.stderr);
-      proc.emit('close', code);
-    },
-  };
-}
 
 describe('rewriteSkillDraft', () => {
   afterEach(() => {
@@ -132,7 +101,7 @@ describe('rewriteSkillDraft', () => {
   });
 
   it('pipes the rewrite prompt through Claude stdin and returns valid skill content', async () => {
-    const fake = createFakeProc();
+    const fake = createFakeProc({ captureStdin: true });
     mockSpawn.mockReturnValueOnce(fake.proc);
 
     const promise = rewriteSkillDraft({
@@ -167,7 +136,7 @@ describe('rewriteSkillDraft', () => {
   });
 
   it('rejects rewritten content that loses required slots', async () => {
-    const fake = createFakeProc();
+    const fake = createFakeProc({ captureStdin: true });
     mockSpawn.mockReturnValueOnce(fake.proc);
 
     const promise = rewriteSkillDraft({
@@ -194,7 +163,7 @@ describe('rewriteSkillDraft', () => {
   });
 
   it('rejects rewritten content that invents unsupported runtime slots', async () => {
-    const fake = createFakeProc();
+    const fake = createFakeProc({ captureStdin: true });
     mockSpawn.mockReturnValueOnce(fake.proc);
 
     const promise = rewriteSkillDraft({

--- a/packages/agents/src/test-fake-proc.ts
+++ b/packages/agents/src/test-fake-proc.ts
@@ -1,0 +1,37 @@
+import { EventEmitter } from 'node:events';
+import { vi } from 'vitest';
+
+export function createFakeProc(options: { captureStdin?: boolean; kill?: boolean } = {}) {
+  const proc = new EventEmitter() as EventEmitter & {
+    stdout: EventEmitter;
+    stderr: EventEmitter;
+    stdin: { write: (chunk: string) => boolean; end: () => void };
+    kill?: (signal: string) => void;
+  };
+  proc.stdout = new EventEmitter();
+  proc.stderr = new EventEmitter();
+
+  const stdinWrites: string[] = [];
+  let stdinEnded = false;
+  proc.stdin = {
+    write: (chunk: string) => {
+      if (options.captureStdin) stdinWrites.push(chunk);
+      return true;
+    },
+    end: () => {
+      stdinEnded = true;
+    },
+  };
+  if (options.kill) proc.kill = vi.fn();
+
+  return {
+    proc,
+    stdinWrites,
+    isStdinEnded: () => stdinEnded,
+    close: (code: number, output?: { stdout?: string; stderr?: string }) => {
+      if (output?.stdout) proc.stdout.emit('data', output.stdout);
+      if (output?.stderr) proc.stderr.emit('data', output.stderr);
+      proc.emit('close', code);
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Re-export `parseIssueNumber` from `issue-number.ts` instead of wrapping it
- Use shared `clampError` in pipeline IPC handlers (removes 2 inline clamp patterns)
- Extract `createFakeProc` test helper to `test-fake-proc.ts` — deduplicates across automation-formatter, memory-generator, prd-generator, cli-stdin-runner, and skill-rewriter tests

## Test plan
- [ ] `bun run test packages/agents` passes
- [ ] `bun run test apps/cli` passes
- [ ] Pipeline error clamping behaves identically