### PR TITLE
Triage rules engine for incoming issues (#86)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -72,6 +72,7 @@ import {
   SkillsQueries,
   TerminalEventQueries,
   ThreadQueries,
+  TriageRuleQueries,
   VerificationQueries,
 } from '@shipcode/db';
 import { TaskGraphQueries } from '@shipcode/db/source';
@@ -216,6 +217,7 @@ function createWindow() {
     featureQaResults: new FeatureQaResultQueries(db),
     projectFailures: new ProjectFailureQueries(db),
     taskGraphs: new TaskGraphQueries(db),
+    triageRules: new TriageRuleQueries(db),
   };
   threadQueries = queries.threads;
 

--- a/apps/desktop/src/main/ipc/register-github-handlers.ts
+++ b/apps/desktop/src/main/ipc/register-github-handlers.ts
@@ -191,7 +191,7 @@ export function registerGitHubHandlers({
         }
 
         const ghCli = new GhCli(project.path);
-        const triageRules = queries.triageRules.list(projectId);
+        const triageRules = queries.triageRules?.list(projectId) ?? [];
         const githubRemoteRef = parseGithubRemote(project.gitRemote);
         let githubRepoFullName =
           project.githubRepoFullName ??

--- a/apps/desktop/src/main/ipc/register-github-handlers.ts
+++ b/apps/desktop/src/main/ipc/register-github-handlers.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import {
+  applyTriageRulesOnce,
   checkProjectReadiness,
   enhancePrdDraft,
   fetchProjectPriorities,
@@ -190,6 +191,7 @@ export function registerGitHubHandlers({
         }
 
         const ghCli = new GhCli(project.path);
+        const triageRules = queries.triageRules.list(projectId);
         const githubRemoteRef = parseGithubRemote(project.gitRemote);
         let githubRepoFullName =
           project.githubRepoFullName ??
@@ -211,7 +213,8 @@ export function registerGitHubHandlers({
         });
 
         // Batch upsert in a single transaction to avoid per-issue WAL overhead.
-        const newIssues: Array<{ number: number; url: string }> = [];
+        const newIssues: Array<{ number: number; url: string; record: GitHubIssueCacheRecord }> =
+          [];
         queries.githubIssues.runInTransaction(() => {
           for (const issue of issues) {
             const existingIssue = queries.githubIssues.getByNumber(projectId, issue.number);
@@ -231,8 +234,8 @@ export function registerGitHubHandlers({
               syncOpenIssueState(queries, record);
             }
 
-            if (!existingIssue) {
-              newIssues.push({ number: issue.number, url: issue.url });
+            if (!existingIssue && record.state === 'open' && !record.rulesAppliedAt) {
+              newIssues.push({ number: issue.number, url: issue.url, record });
             }
           }
         });
@@ -246,6 +249,34 @@ export function registerGitHubHandlers({
               'github:refresh-issues',
             ),
           ),
+        );
+
+        await Promise.all(
+          newIssues.map(async ({ record }) => {
+            const result = await applyTriageRulesOnce({
+              issue: record,
+              rules: triageRules,
+              ghCli,
+              markApplied: (issueId) => queries.githubIssues.markTriageRulesApplied(issueId),
+              recordFailure: (issueId, reason) =>
+                queries.githubIssues.recordTriageRulesFailure(issueId, reason),
+              onWarn: (message, err) => log.warn(message, err),
+            });
+
+            if (result.status !== 'applied') return;
+
+            const refreshedIssue = result.refreshedIssue;
+            queries.githubIssues.upsert({
+              projectId,
+              issueNumber: refreshedIssue.number,
+              title: refreshedIssue.title,
+              body: refreshedIssue.body,
+              labels: refreshedIssue.labels,
+              assignee: refreshedIssue.assignee,
+              state: refreshedIssue.state,
+              updatedAt: refreshedIssue.updatedAt ?? null,
+            });
+          }),
         );
 
         const staleApprovalCount = force ? queries.githubIssues.resetStaleApproval(projectId) : 0;

--- a/apps/desktop/src/main/ipc/register-project-handlers.ts
+++ b/apps/desktop/src/main/ipc/register-project-handlers.ts
@@ -914,8 +914,10 @@ export function registerProjectHandlers({
   ipcMain.handle('project:list-triage-rules', (_event, { projectId }: { projectId: string }) => {
     const project = queries.projects.getById(projectId);
     if (!project) throw new Error(`Project ${projectId} not found`);
+    const triageRules = queries.triageRules;
+    if (!triageRules) throw new Error('Triage rules are unavailable');
     try {
-      return queries.triageRules.list(projectId);
+      return triageRules.list(projectId);
     } catch (err) {
       log.warn('[project:list-triage-rules] failed:', err);
       throw new Error(clampError(err));
@@ -923,10 +925,12 @@ export function registerProjectHandlers({
   });
 
   ipcMain.handle(
-    'project:replace-triage-rules',
+    'project:set-triage-rules',
     (_event, { projectId, rules }: { projectId: string; rules: TriageRuleDraft[] }) => {
       const project = queries.projects.getById(projectId);
       if (!project) throw new Error(`Project ${projectId} not found`);
+      const triageRules = queries.triageRules;
+      if (!triageRules) throw new Error('Triage rules are unavailable');
       if (!Array.isArray(rules)) {
         throw new Error('Triage rules must be an array');
       }
@@ -934,9 +938,9 @@ export function registerProjectHandlers({
         throw new Error(`A project can have at most ${TRIAGE_RULE_LIMIT} triage rules`);
       }
       try {
-        return queries.triageRules.replaceForProject(projectId, rules);
+        return triageRules.replaceForProject(projectId, rules);
       } catch (err) {
-        log.warn('[project:replace-triage-rules] failed:', err);
+        log.warn('[project:set-triage-rules] failed:', err);
         throw new Error(clampError(err));
       }
     },

--- a/apps/desktop/src/main/ipc/register-project-handlers.ts
+++ b/apps/desktop/src/main/ipc/register-project-handlers.ts
@@ -30,6 +30,7 @@ import type {
   ProjectOpenTarget,
   ShipCodePlan,
   TerminalOpenTarget,
+  TriageRuleDraft,
 } from '@shipcode/shared';
 import {
   clampError,
@@ -39,6 +40,7 @@ import {
   parseUnifiedDiff,
   SHIPCODE_DEFAULT_LABELS,
   SHIPCODE_PIPELINE_LABELS,
+  TRIAGE_RULE_LIMIT,
   validateGithubProjectUrl,
 } from '@shipcode/shared';
 import { resolveWorktreeParent } from '@shipcode/shared/worktree-path';
@@ -908,6 +910,37 @@ export function registerProjectHandlers({
   ipcMain.handle('project:get', (_event, { projectId }: { projectId: string }) => {
     return enrichProjectPath(queries.projects.getById(projectId));
   });
+
+  ipcMain.handle('project:list-triage-rules', (_event, { projectId }: { projectId: string }) => {
+    const project = queries.projects.getById(projectId);
+    if (!project) throw new Error(`Project ${projectId} not found`);
+    try {
+      return queries.triageRules.list(projectId);
+    } catch (err) {
+      log.warn('[project:list-triage-rules] failed:', err);
+      throw new Error(clampError(err));
+    }
+  });
+
+  ipcMain.handle(
+    'project:replace-triage-rules',
+    (_event, { projectId, rules }: { projectId: string; rules: TriageRuleDraft[] }) => {
+      const project = queries.projects.getById(projectId);
+      if (!project) throw new Error(`Project ${projectId} not found`);
+      if (!Array.isArray(rules)) {
+        throw new Error('Triage rules must be an array');
+      }
+      if (rules.length > TRIAGE_RULE_LIMIT) {
+        throw new Error(`A project can have at most ${TRIAGE_RULE_LIMIT} triage rules`);
+      }
+      try {
+        return queries.triageRules.replaceForProject(projectId, rules);
+      } catch (err) {
+        log.warn('[project:replace-triage-rules] failed:', err);
+        throw new Error(clampError(err));
+      }
+    },
+  );
 
   ipcMain.handle(
     'project:open-path',

--- a/apps/desktop/src/main/ipc/register-project-handlers.ts
+++ b/apps/desktop/src/main/ipc/register-project-handlers.ts
@@ -925,7 +925,7 @@ export function registerProjectHandlers({
   });
 
   ipcMain.handle(
-    'project:set-triage-rules',
+    'project:replace-triage-rules',
     (_event, { projectId, rules }: { projectId: string; rules: TriageRuleDraft[] }) => {
       const project = queries.projects.getById(projectId);
       if (!project) throw new Error(`Project ${projectId} not found`);
@@ -940,7 +940,7 @@ export function registerProjectHandlers({
       try {
         return triageRules.replaceForProject(projectId, rules);
       } catch (err) {
-        log.warn('[project:set-triage-rules] failed:', err);
+        log.warn('[project:replace-triage-rules] failed:', err);
         throw new Error(clampError(err));
       }
     },

--- a/apps/desktop/src/main/ipc/types.ts
+++ b/apps/desktop/src/main/ipc/types.ts
@@ -25,6 +25,7 @@ import type {
   SkillsQueries,
   TerminalEventQueries,
   ThreadQueries,
+  TriageRuleQueries,
   VerificationQueries,
 } from '@shipcode/db';
 import type { TaskGraphQueries } from '@shipcode/db/source';
@@ -62,6 +63,7 @@ export interface Queries {
   featureQaResults: FeatureQaResultQueries;
   projectFailures?: ProjectFailureQueries;
   taskGraphs?: TaskGraphQueries;
+  triageRules: TriageRuleQueries;
 }
 
 export interface IpcHandlerDeps {

--- a/apps/desktop/src/main/ipc/types.ts
+++ b/apps/desktop/src/main/ipc/types.ts
@@ -63,7 +63,7 @@ export interface Queries {
   featureQaResults: FeatureQaResultQueries;
   projectFailures?: ProjectFailureQueries;
   taskGraphs?: TaskGraphQueries;
-  triageRules: TriageRuleQueries;
+  triageRules?: TriageRuleQueries;
 }
 
 export interface IpcHandlerDeps {

--- a/apps/desktop/src/renderer/components/ProjectSettingsModal.tsx
+++ b/apps/desktop/src/renderer/components/ProjectSettingsModal.tsx
@@ -16,7 +16,7 @@ import { Button, Keycap, Modal, ModalFooter } from '@shipshitdev/ui';
 import { LoadingButtonContent } from '@shipshitdev/ui/common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import log from 'electron-log/renderer';
-import { Bell, Code2, FolderGit, Settings, Terminal, Workflow } from 'lucide-react';
+import { Bell, Code2, FolderGit, Settings, Tags, Terminal, Workflow } from 'lucide-react';
 import {
   type Dispatch,
   type SetStateAction,
@@ -53,6 +53,7 @@ import {
   type ProjectOverrideState,
   type ProjectTab,
 } from './project-settings-modal/shared';
+import { TriageRulesTab } from './project-settings-modal/TriageRulesTab';
 import { SettingsNavigation, type SettingsNavigationItem } from './SettingsNavigation';
 
 const PROJECT_SETTINGS_SECTIONS = [
@@ -80,6 +81,11 @@ const PROJECT_SETTINGS_SECTIONS = [
     key: 'github',
     label: 'GitHub',
     icon: <FolderGit size={14} />,
+  },
+  {
+    key: 'triage',
+    label: 'Triage rules',
+    icon: <Tags size={14} />,
   },
   {
     key: 'context',
@@ -1055,6 +1061,13 @@ function useProjectSettingsModalView() {
                     isActive={activeTab === 'github'}
                     statusMapping={project?.githubStatusMapping ?? null}
                     hasProjectUrl={!!project?.githubProjectUrl}
+                  />
+                )}
+
+                {activeTab === 'triage' && (
+                  <TriageRulesTab
+                    projectId={projectSettingsModalProjectId ?? ''}
+                    isActive={activeTab === 'triage'}
                   />
                 )}
 

--- a/apps/desktop/src/renderer/components/project-settings-modal/TriageRulesTab.tsx
+++ b/apps/desktop/src/renderer/components/project-settings-modal/TriageRulesTab.tsx
@@ -135,7 +135,7 @@ export function TriageRulesTab({ projectId, isActive }: { projectId: string; isA
 
   const saveMutation = useMutation({
     mutationFn: () =>
-      window.shipcode.invoke<TriageRule[]>('project:replace-triage-rules', {
+      window.shipcode.invoke<TriageRule[]>('project:set-triage-rules', {
         projectId,
         rules: rules.map(toDraft),
       }),

--- a/apps/desktop/src/renderer/components/project-settings-modal/TriageRulesTab.tsx
+++ b/apps/desktop/src/renderer/components/project-settings-modal/TriageRulesTab.tsx
@@ -135,7 +135,7 @@ export function TriageRulesTab({ projectId, isActive }: { projectId: string; isA
 
   const saveMutation = useMutation({
     mutationFn: () =>
-      window.shipcode.invoke<TriageRule[]>('project:set-triage-rules', {
+      window.shipcode.invoke('project:replace-triage-rules', {
         projectId,
         rules: rules.map(toDraft),
       }),

--- a/apps/desktop/src/renderer/components/project-settings-modal/TriageRulesTab.tsx
+++ b/apps/desktop/src/renderer/components/project-settings-modal/TriageRulesTab.tsx
@@ -1,0 +1,490 @@
+import {
+  clampError,
+  TRIAGE_RULE_LIMIT,
+  type TriageRule,
+  type TriageRuleCondition,
+  type TriageRuleConditionKind,
+  type TriageRuleDraft,
+} from '@shipcode/shared';
+import {
+  Button,
+  Input,
+  Label,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  SettingsRow,
+  Switch,
+} from '@shipshitdev/ui';
+import { LoadingButtonContent } from '@shipshitdev/ui/common';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import log from 'electron-log/renderer';
+import { ArrowDown, ArrowUp, Plus, Save, Trash2 } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+type EditableTriageRuleCondition = TriageRuleCondition & { clientId: string };
+type EditableTriageRule = Omit<TriageRuleDraft, 'conditions'> & {
+  clientId: string;
+  conditions: Omit<TriageRuleDraft['conditions'], 'items'> & {
+    items: EditableTriageRuleCondition[];
+  };
+};
+
+const CONDITION_KIND_LABELS: Record<TriageRuleConditionKind, string> = {
+  label_includes: 'Label includes',
+  label_excludes: 'Label excludes',
+  title_contains: 'Title contains',
+};
+
+function newClientId(): string {
+  return globalThis.crypto?.randomUUID?.() ?? `rule-${Date.now()}-${Math.random()}`;
+}
+
+function toEditableRule(rule: TriageRule): EditableTriageRule {
+  return {
+    id: rule.id,
+    clientId: rule.id,
+    name: rule.name,
+    enabled: rule.enabled,
+    conditions: {
+      operator: rule.conditions.operator,
+      items: rule.conditions.items.map((condition) => ({
+        ...condition,
+        clientId: newClientId(),
+      })),
+    },
+    actions: {
+      addLabels: [...rule.actions.addLabels],
+      removeLabels: [...rule.actions.removeLabels],
+    },
+  };
+}
+
+function createRule(): EditableTriageRule {
+  return {
+    clientId: newClientId(),
+    name: 'New rule',
+    enabled: true,
+    conditions: {
+      operator: 'all',
+      items: [{ clientId: newClientId(), kind: 'title_contains', value: '' }],
+    },
+    actions: {
+      addLabels: [],
+      removeLabels: [],
+    },
+  };
+}
+
+function labelsToText(labels: readonly string[]): string {
+  return labels.join(', ');
+}
+
+function textToLabels(value: string): string[] {
+  return value
+    .split(',')
+    .map((label) => label.trim())
+    .filter(Boolean);
+}
+
+function toDraft(rule: EditableTriageRule): TriageRuleDraft {
+  return {
+    ...(rule.id ? { id: rule.id } : {}),
+    name: rule.name,
+    enabled: rule.enabled,
+    conditions: {
+      operator: rule.conditions.operator,
+      items: rule.conditions.items.map(({ kind, value }) => ({ kind, value })),
+    },
+    actions: {
+      addLabels: [...rule.actions.addLabels],
+      removeLabels: [...rule.actions.removeLabels],
+    },
+  };
+}
+
+function replaceAt<T>(items: readonly T[], index: number, next: T): T[] {
+  return items.map((item, itemIndex) => (itemIndex === index ? next : item));
+}
+
+export function TriageRulesTab({ projectId, isActive }: { projectId: string; isActive: boolean }) {
+  const queryClient = useQueryClient();
+  const [rules, setRules] = useState<EditableTriageRule[]>([]);
+  const [dirty, setDirty] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+
+  const rulesQuery = useQuery<TriageRule[]>({
+    queryKey: ['project-triage-rules', projectId],
+    queryFn: () => window.shipcode.invoke('project:list-triage-rules', { projectId }),
+    enabled: isActive && !!projectId,
+  });
+
+  useEffect(() => {
+    setRules([]);
+    setDirty(false);
+    setSaveError(null);
+    if (!projectId) return;
+  }, [projectId]);
+
+  useEffect(() => {
+    if (!rulesQuery.data || dirty) return;
+    setRules(rulesQuery.data.map(toEditableRule));
+  }, [dirty, rulesQuery.data]);
+
+  const saveMutation = useMutation({
+    mutationFn: () =>
+      window.shipcode.invoke<TriageRule[]>('project:replace-triage-rules', {
+        projectId,
+        rules: rules.map(toDraft),
+      }),
+    onSuccess: (saved) => {
+      setRules(saved.map(toEditableRule));
+      setDirty(false);
+      setSaveError(null);
+      queryClient.setQueryData(['project-triage-rules', projectId], saved);
+    },
+    onError: (err: unknown) => {
+      log.error('[TriageRulesTab] save failed', err);
+      setSaveError(clampError(err));
+    },
+  });
+
+  const canAdd = rules.length < TRIAGE_RULE_LIMIT;
+  const enabledCount = useMemo(() => rules.filter((rule) => rule.enabled).length, [rules]);
+
+  function updateRule(index: number, updater: (rule: EditableTriageRule) => EditableTriageRule) {
+    setRules((current) => replaceAt(current, index, updater(current[index])));
+    setDirty(true);
+    setSaveError(null);
+  }
+
+  function updateCondition(
+    ruleIndex: number,
+    conditionIndex: number,
+    patch: Partial<TriageRuleCondition>,
+  ) {
+    updateRule(ruleIndex, (rule) => ({
+      ...rule,
+      conditions: {
+        ...rule.conditions,
+        items: replaceAt(rule.conditions.items, conditionIndex, {
+          ...rule.conditions.items[conditionIndex],
+          ...patch,
+        }),
+      },
+    }));
+  }
+
+  function addCondition(ruleIndex: number) {
+    updateRule(ruleIndex, (rule) => ({
+      ...rule,
+      conditions: {
+        ...rule.conditions,
+        items: [
+          ...rule.conditions.items,
+          { clientId: newClientId(), kind: 'title_contains', value: '' },
+        ],
+      },
+    }));
+  }
+
+  function removeCondition(ruleIndex: number, conditionIndex: number) {
+    updateRule(ruleIndex, (rule) => ({
+      ...rule,
+      conditions: {
+        ...rule.conditions,
+        items: rule.conditions.items.filter((_, index) => index !== conditionIndex),
+      },
+    }));
+  }
+
+  function moveRule(index: number, direction: -1 | 1) {
+    const nextIndex = index + direction;
+    if (nextIndex < 0 || nextIndex >= rules.length) return;
+    setRules((current) => {
+      const next = [...current];
+      [next[index], next[nextIndex]] = [next[nextIndex], next[index]];
+      return next;
+    });
+    setDirty(true);
+    setSaveError(null);
+  }
+
+  if (rulesQuery.isLoading) {
+    return <div className="text-[12px] text-muted-foreground">Loading triage rules...</div>;
+  }
+
+  if (rulesQuery.error) {
+    return (
+      <div className="rounded-md border border-danger/30 bg-danger/10 px-3 py-2 text-[12px] text-danger">
+        {clampError(rulesQuery.error)}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-5">
+      <div className="text-xs text-muted-foreground">
+        Rules run once for each newly discovered GitHub issue. The first enabled match wins.
+      </div>
+
+      <SettingsRow
+        label="Rules"
+        description={`${enabledCount} enabled / ${rules.length} total. New issues with no match are marked as evaluated.`}
+      >
+        <div className="flex gap-2">
+          <Button
+            type="button"
+            variant="secondary"
+            size="sm"
+            onClick={() => {
+              if (!canAdd) return;
+              setRules((current) => [...current, createRule()]);
+              setDirty(true);
+              setSaveError(null);
+            }}
+            disabled={!canAdd}
+          >
+            <Plus size={14} />
+            Add
+          </Button>
+          <Button
+            type="button"
+            size="sm"
+            onClick={() => saveMutation.mutate()}
+            disabled={!dirty || saveMutation.isPending}
+          >
+            <LoadingButtonContent loading={saveMutation.isPending}>
+              <Save size={14} />
+              Save
+            </LoadingButtonContent>
+          </Button>
+        </div>
+      </SettingsRow>
+
+      {rules.length >= TRIAGE_RULE_LIMIT ? (
+        <div className="rounded-md border border-warning/30 bg-warning/10 px-3 py-2 text-[12px] text-warning">
+          This project has the maximum {TRIAGE_RULE_LIMIT} triage rules.
+        </div>
+      ) : null}
+
+      {saveError ? (
+        <div className="rounded-md border border-danger/30 bg-danger/10 px-3 py-2 text-[12px] text-danger">
+          {saveError}
+        </div>
+      ) : null}
+
+      {rules.length === 0 ? (
+        <div className="rounded-md border border-border bg-secondary/30 px-3 py-4 text-[12px] text-muted-foreground">
+          No triage rules configured.
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {rules.map((rule, ruleIndex) => (
+            <div
+              key={rule.clientId}
+              className="rounded-md border border-border bg-secondary/25 p-3"
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <Label htmlFor={`triage-rule-name-${rule.clientId}`} className="text-[11px]">
+                    Name
+                  </Label>
+                  <Input
+                    id={`triage-rule-name-${rule.clientId}`}
+                    value={rule.name}
+                    onChange={(event) =>
+                      updateRule(ruleIndex, (current) => ({
+                        ...current,
+                        name: event.target.value,
+                      }))
+                    }
+                    className="mt-1"
+                  />
+                </div>
+                <div className="flex items-center gap-1.5 pt-5">
+                  <Switch
+                    checked={rule.enabled}
+                    onCheckedChange={(checked) =>
+                      updateRule(ruleIndex, (current) => ({ ...current, enabled: checked }))
+                    }
+                    aria-label={`Enable ${rule.name || 'triage rule'}`}
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    title="Move rule up"
+                    aria-label="Move rule up"
+                    onClick={() => moveRule(ruleIndex, -1)}
+                    disabled={ruleIndex === 0}
+                  >
+                    <ArrowUp size={14} />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    title="Move rule down"
+                    aria-label="Move rule down"
+                    onClick={() => moveRule(ruleIndex, 1)}
+                    disabled={ruleIndex === rules.length - 1}
+                  >
+                    <ArrowDown size={14} />
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    title="Delete rule"
+                    aria-label="Delete rule"
+                    onClick={() => {
+                      setRules((current) => current.filter((_, index) => index !== ruleIndex));
+                      setDirty(true);
+                      setSaveError(null);
+                    }}
+                  >
+                    <Trash2 size={14} />
+                  </Button>
+                </div>
+              </div>
+
+              <div className="mt-4 space-y-3">
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <div className="text-[12px] font-medium text-primary">Conditions</div>
+                    <div className="text-[11px] text-muted-foreground">
+                      {rule.conditions.operator === 'all'
+                        ? 'Every condition must match.'
+                        : 'Any condition can match.'}
+                    </div>
+                  </div>
+                  <Select
+                    value={rule.conditions.operator}
+                    onValueChange={(value) =>
+                      updateRule(ruleIndex, (current) => ({
+                        ...current,
+                        conditions: {
+                          ...current.conditions,
+                          operator: value === 'any' ? 'any' : 'all',
+                        },
+                      }))
+                    }
+                  >
+                    <SelectTrigger className="w-[150px]">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="all">All</SelectItem>
+                      <SelectItem value="any">Any</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div className="space-y-2">
+                  {rule.conditions.items.map((condition, conditionIndex) => (
+                    <div
+                      key={condition.clientId}
+                      className="grid gap-2 sm:grid-cols-[160px_1fr_auto]"
+                    >
+                      <Select
+                        value={condition.kind}
+                        onValueChange={(value) =>
+                          updateCondition(ruleIndex, conditionIndex, {
+                            kind: value as TriageRuleConditionKind,
+                          })
+                        }
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {Object.entries(CONDITION_KIND_LABELS).map(([value, label]) => (
+                            <SelectItem key={value} value={value}>
+                              {label}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                      <Input
+                        value={condition.value}
+                        onChange={(event) =>
+                          updateCondition(ruleIndex, conditionIndex, {
+                            value: event.target.value,
+                          })
+                        }
+                        placeholder={condition.kind === 'title_contains' ? 'bug' : 'complexity:low'}
+                      />
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon-sm"
+                        title="Delete condition"
+                        aria-label="Delete condition"
+                        onClick={() => removeCondition(ruleIndex, conditionIndex)}
+                      >
+                        <Trash2 size={14} />
+                      </Button>
+                    </div>
+                  ))}
+                  <Button
+                    type="button"
+                    variant="secondary"
+                    size="xs"
+                    onClick={() => addCondition(ruleIndex)}
+                  >
+                    <Plus size={12} />
+                    Condition
+                  </Button>
+                </div>
+              </div>
+
+              <div className="mt-4 grid gap-3 md:grid-cols-2">
+                <div className="flex flex-col gap-1">
+                  <Label htmlFor={`triage-add-labels-${rule.clientId}`} className="text-[11px]">
+                    Add labels
+                  </Label>
+                  <Input
+                    id={`triage-add-labels-${rule.clientId}`}
+                    value={labelsToText(rule.actions.addLabels)}
+                    onChange={(event) =>
+                      updateRule(ruleIndex, (current) => ({
+                        ...current,
+                        actions: {
+                          ...current.actions,
+                          addLabels: textToLabels(event.target.value),
+                        },
+                      }))
+                    }
+                    placeholder="agent:claude, complexity:low"
+                  />
+                </div>
+                <div className="flex flex-col gap-1">
+                  <Label htmlFor={`triage-remove-labels-${rule.clientId}`} className="text-[11px]">
+                    Remove labels
+                  </Label>
+                  <Input
+                    id={`triage-remove-labels-${rule.clientId}`}
+                    value={labelsToText(rule.actions.removeLabels)}
+                    onChange={(event) =>
+                      updateRule(ruleIndex, (current) => ({
+                        ...current,
+                        actions: {
+                          ...current.actions,
+                          removeLabels: textToLabels(event.target.value),
+                        },
+                      }))
+                    }
+                    placeholder="status:needs-triage"
+                  />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/project-settings-modal/shared.ts
+++ b/apps/desktop/src/renderer/components/project-settings-modal/shared.ts
@@ -22,6 +22,7 @@ export const PROJECT_TABS = [
   'pipeline',
   'models',
   'github',
+  'triage',
   'context',
   'notifications',
 ] as const;

--- a/packages/agents/src/github/gh-cli.ts
+++ b/packages/agents/src/github/gh-cli.ts
@@ -48,6 +48,18 @@ function formatMetadataOption(value: string): string {
     .join('-');
 }
 
+function uniqueLabels(labels: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const label of labels) {
+    const trimmed = label.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  return result;
+}
+
 function getGraphqlErrors(response: { errors?: Array<{ message?: string }> }): string | null {
   if (!response.errors || response.errors.length === 0) return null;
   return response.errors.map((err) => err.message ?? '<unknown>').join('; ');
@@ -72,6 +84,17 @@ export interface IssueProjectMetadata {
   priority?: string;
   complexity?: string;
   blastRadius?: string;
+}
+
+export interface IssueLabelActions {
+  addLabels?: string[];
+  removeLabels?: string[];
+}
+
+export interface IssueLabelActionResult {
+  added: string[];
+  removed: string[];
+  skipped: string[];
 }
 
 interface ProjectMetadataQueryResponse {
@@ -279,6 +302,43 @@ export class GhCli {
         // Addition is best-effort.
       }
     }
+  }
+
+  async applyIssueLabelActions(
+    issueNumber: number,
+    actions: IssueLabelActions,
+  ): Promise<IssueLabelActionResult> {
+    const addLabels = uniqueLabels(actions.addLabels ?? []);
+    const removeLabels = uniqueLabels(actions.removeLabels ?? []);
+    const availableAdds = await this.filterExistingLabels(addLabels);
+    const availableAddSet = new Set(availableAdds);
+    const skipped = addLabels.filter((label) => !availableAddSet.has(label));
+    const issue = await this.getIssue(issueNumber);
+    const current = new Set(issue.labels);
+    const added: string[] = [];
+    const removed: string[] = [];
+
+    for (const label of availableAdds) {
+      if (current.has(label)) continue;
+      await execFileAsync('gh', ['issue', 'edit', String(issueNumber), '--add-label', label], {
+        cwd: this.cwd,
+        env: this.env,
+      });
+      current.add(label);
+      added.push(label);
+    }
+
+    for (const label of removeLabels) {
+      if (!current.has(label)) continue;
+      await execFileAsync('gh', ['issue', 'edit', String(issueNumber), '--remove-label', label], {
+        cwd: this.cwd,
+        env: this.env,
+      });
+      current.delete(label);
+      removed.push(label);
+    }
+
+    return { added, removed, skipped };
   }
 
   async listIssues(label: string): Promise<GitHubIssue[]> {

--- a/packages/agents/src/github/issue-poller.ts
+++ b/packages/agents/src/github/issue-poller.ts
@@ -1,5 +1,57 @@
-import type { GitHubIssue } from '@shipcode/shared';
-import type { GhCli } from './gh-cli';
+import type { GitHubIssue, GitHubIssueCacheRecord, TriageRule } from '@shipcode/shared';
+import { clampError, evaluateTriageRules } from '@shipcode/shared';
+import type { GhCli, IssueLabelActionResult } from './gh-cli';
+
+export interface ApplyTriageRulesOnceOptions {
+  issue: GitHubIssueCacheRecord;
+  rules: readonly TriageRule[];
+  ghCli: Pick<GhCli, 'applyIssueLabelActions' | 'getIssue'>;
+  markApplied: (issueId: string) => void;
+  recordFailure: (issueId: string, reason: string) => void;
+  onWarn?: (message: string, error: unknown) => void;
+}
+
+export type ApplyTriageRulesOnceResult =
+  | { status: 'skipped'; reason: 'already-applied' }
+  | { status: 'no-match' }
+  | {
+      status: 'applied';
+      rule: TriageRule;
+      actionResult: IssueLabelActionResult;
+      refreshedIssue: GitHubIssue;
+    }
+  | { status: 'failed'; rule: TriageRule; reason: string };
+
+export async function applyTriageRulesOnce({
+  issue,
+  rules,
+  ghCli,
+  markApplied,
+  recordFailure,
+  onWarn,
+}: ApplyTriageRulesOnceOptions): Promise<ApplyTriageRulesOnceResult> {
+  if (issue.rulesAppliedAt) {
+    return { status: 'skipped', reason: 'already-applied' };
+  }
+
+  const rule = evaluateTriageRules(issue, rules);
+  if (!rule) {
+    markApplied(issue.id);
+    return { status: 'no-match' };
+  }
+
+  try {
+    const actionResult = await ghCli.applyIssueLabelActions(issue.issueNumber, rule.actions);
+    const refreshedIssue = await ghCli.getIssue(issue.issueNumber);
+    markApplied(issue.id);
+    return { status: 'applied', rule, actionResult, refreshedIssue };
+  } catch (error) {
+    const reason = clampError(error);
+    recordFailure(issue.id, reason);
+    onWarn?.(`[triage-rules] failed to apply rule ${rule.id} to #${issue.issueNumber}`, error);
+    return { status: 'failed', rule, reason };
+  }
+}
 
 export class IssuePoller {
   private intervalId: NodeJS.Timeout | null = null;

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -24,7 +24,11 @@ export {
 } from './context-generator';
 export { loadRepoContext, loadStructuredRepoContext } from './context-loader';
 export { GhCli } from './github/gh-cli';
-export { IssuePoller } from './github/issue-poller';
+export type {
+  ApplyTriageRulesOnceOptions,
+  ApplyTriageRulesOnceResult,
+} from './github/issue-poller';
+export { applyTriageRulesOnce, IssuePoller } from './github/issue-poller';
 export type { IssueTriageRecommendation, IssueTriageRunResult } from './github/issue-triage';
 export {
   buildTriagePrompt,

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -75,6 +75,7 @@ import {
   migrateV51,
   migrateV52,
   migrateV53,
+  migrateV54,
 } from './schema';
 
 export { ActivityQueries } from './queries/activity';
@@ -111,6 +112,7 @@ export { SkillsQueries } from './queries/skills';
 export { TaskGraphQueries } from './queries/task-graphs';
 export { TerminalEventQueries } from './queries/terminal-events';
 export { ThreadQueries } from './queries/threads';
+export { TriageRuleQueries } from './queries/triage-rules';
 export { VerificationQueries } from './queries/verifications';
 export { transaction } from './utils';
 
@@ -184,6 +186,7 @@ export function getDatabase(dataDir: string): DatabaseSync {
   migrateV51(db);
   migrateV52(db);
   migrateV53(db);
+  migrateV54(db);
 
   // Startup cleanup: reset unclaimed queued issues to todo on every launch.
   // An unclaimed queued issue has no active worker holding it — it's stale state

--- a/packages/db/src/queries/github-issues.ts
+++ b/packages/db/src/queries/github-issues.ts
@@ -61,6 +61,8 @@ interface GitHubIssueCacheRow {
   priority_rank: string | null;
   priority_raw: string | null;
   priority_fetched_at: string | null;
+  rules_applied_at: string | null;
+  triage_failure_reason: string | null;
   is_quick_mode: number | null;
 }
 
@@ -280,6 +282,28 @@ export class GitHubIssueQueries {
         `UPDATE github_issue_cache SET pipeline_status = ?, last_phase_update = ${ISO_NOW_SQL} WHERE id = ?`,
       )
       .run(status, id);
+  }
+
+  markTriageRulesApplied(id: string): void {
+    this.db
+      .prepare(
+        `UPDATE github_issue_cache
+            SET rules_applied_at = ${ISO_NOW_SQL},
+                triage_failure_reason = NULL
+          WHERE id = ?`,
+      )
+      .run(id);
+  }
+
+  recordTriageRulesFailure(id: string, reason: string): void {
+    this.db
+      .prepare(
+        `UPDATE github_issue_cache
+            SET rules_applied_at = ${ISO_NOW_SQL},
+                triage_failure_reason = ?
+          WHERE id = ?`,
+      )
+      .run(reason, id);
   }
 
   updateState(id: string, state: 'open' | 'closed'): void {
@@ -809,6 +833,8 @@ export class GitHubIssueQueries {
           : null,
       priorityRaw: row.priority_raw ?? null,
       priorityFetchedAt: toIsoUtc(row.priority_fetched_at),
+      rulesAppliedAt: toIsoUtc(row.rules_applied_at),
+      triageFailureReason: row.triage_failure_reason ?? null,
       isQuickMode: !!row.is_quick_mode,
     };
   }

--- a/packages/db/src/queries/triage-rules.ts
+++ b/packages/db/src/queries/triage-rules.ts
@@ -1,0 +1,163 @@
+import type { DatabaseSync } from 'node:sqlite';
+import {
+  ISO_NOW_SQL,
+  normalizeTriageRuleDraft,
+  TRIAGE_RULE_LIMIT,
+  type TriageRule,
+  type TriageRuleActions,
+  type TriageRuleConditions,
+  type TriageRuleDraft,
+  toIsoUtc,
+} from '@shipcode/shared';
+import { nanoid } from 'nanoid';
+import { asRow, asRows, transaction } from '../utils';
+
+interface TriageRuleRow {
+  id: string;
+  project_id: string;
+  order_index: number;
+  name: string;
+  enabled: number;
+  conditions: string;
+  actions: string;
+  created_at: string;
+  updated_at: string;
+}
+
+export class TriageRuleQueries {
+  constructor(private db: DatabaseSync) {}
+
+  list(projectId: string): TriageRule[] {
+    const rows = this.db
+      .prepare(
+        'SELECT * FROM triage_rules WHERE project_id = ? ORDER BY order_index ASC, created_at ASC',
+      )
+      .all(projectId);
+    return asRows<TriageRuleRow>(rows).map(mapTriageRule);
+  }
+
+  getById(id: string): TriageRule | null {
+    const row = this.db.prepare('SELECT * FROM triage_rules WHERE id = ?').get(id);
+    return row ? mapTriageRule(asRow<TriageRuleRow>(row)) : null;
+  }
+
+  create(projectId: string, draft: TriageRuleDraft): TriageRule {
+    const count = this.countForProject(projectId);
+    if (count >= TRIAGE_RULE_LIMIT) {
+      throw new Error(`A project can have at most ${TRIAGE_RULE_LIMIT} triage rules`);
+    }
+
+    const normalized = normalizeTriageRuleDraft(draft);
+    const id = normalized.id ?? nanoid();
+    this.insert(projectId, id, count, normalized);
+
+    const created = this.getById(id);
+    if (!created) throw new Error(`Failed to create triage rule ${id}`);
+    return created;
+  }
+
+  update(id: string, draft: TriageRuleDraft): TriageRule {
+    const normalized = normalizeTriageRuleDraft(draft);
+    this.db
+      .prepare(
+        `UPDATE triage_rules
+            SET name = ?,
+                enabled = ?,
+                conditions = ?,
+                actions = ?,
+                updated_at = ${ISO_NOW_SQL}
+          WHERE id = ?`,
+      )
+      .run(
+        normalized.name,
+        normalized.enabled ? 1 : 0,
+        JSON.stringify(normalized.conditions),
+        JSON.stringify(normalized.actions),
+        id,
+      );
+
+    const updated = this.getById(id);
+    if (!updated) throw new Error(`Triage rule ${id} not found`);
+    return updated;
+  }
+
+  delete(id: string): boolean {
+    const existing = this.getById(id);
+    if (!existing) return false;
+
+    return transaction(this.db, () => {
+      const result = this.db.prepare('DELETE FROM triage_rules WHERE id = ?').run(id);
+      this.compactOrder(existing.projectId);
+      return Number(result.changes) > 0;
+    });
+  }
+
+  replaceForProject(projectId: string, drafts: TriageRuleDraft[]): TriageRule[] {
+    if (drafts.length > TRIAGE_RULE_LIMIT) {
+      throw new Error(`A project can have at most ${TRIAGE_RULE_LIMIT} triage rules`);
+    }
+
+    return transaction(this.db, () => {
+      this.db.prepare('DELETE FROM triage_rules WHERE project_id = ?').run(projectId);
+
+      drafts.forEach((draft, index) => {
+        const normalized = normalizeTriageRuleDraft(draft);
+        this.insert(projectId, normalized.id ?? nanoid(), index, normalized);
+      });
+
+      return this.list(projectId);
+    });
+  }
+
+  private countForProject(projectId: string): number {
+    const row = this.db
+      .prepare('SELECT COUNT(*) AS count FROM triage_rules WHERE project_id = ?')
+      .get(projectId) as { count: number } | undefined;
+    return row?.count ?? 0;
+  }
+
+  private insert(projectId: string, id: string, orderIndex: number, draft: TriageRuleDraft): void {
+    this.db
+      .prepare(
+        `INSERT INTO triage_rules (
+           id, project_id, order_index, name, enabled, conditions, actions
+         ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+      )
+      .run(
+        id,
+        projectId,
+        orderIndex,
+        draft.name,
+        draft.enabled ? 1 : 0,
+        JSON.stringify(draft.conditions),
+        JSON.stringify(draft.actions),
+      );
+  }
+
+  private compactOrder(projectId: string): void {
+    const rules = this.list(projectId);
+    rules.forEach((rule, index) => {
+      this.db
+        .prepare(
+          `UPDATE triage_rules SET order_index = ?, updated_at = ${ISO_NOW_SQL} WHERE id = ?`,
+        )
+        .run(index, rule.id);
+    });
+  }
+}
+
+function mapTriageRule(row: TriageRuleRow): TriageRule {
+  return {
+    id: row.id,
+    projectId: row.project_id,
+    orderIndex: row.order_index,
+    name: row.name,
+    enabled: row.enabled === 1,
+    conditions: JSON.parse(
+      row.conditions || '{"operator":"all","items":[]}',
+    ) as TriageRuleConditions,
+    actions: JSON.parse(row.actions || '{"addLabels":[],"removeLabels":[]}') as TriageRuleActions,
+    createdAt: toIsoUtc(row.created_at) ?? row.created_at,
+    updatedAt: toIsoUtc(row.updated_at) ?? row.updated_at,
+  };
+}

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -1608,3 +1608,44 @@ export function migrateV53(db: DatabaseSync): void {
     db.exec(`INSERT OR REPLACE INTO schema_version (version) VALUES (53)`);
   });
 }
+
+export function migrateV54(db: DatabaseSync): void {
+  const row = db
+    .prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1')
+    .get() as { version: number } | undefined;
+  if (row && row.version >= 54) return;
+
+  transaction(db, () => {
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS triage_rules (
+        id          TEXT PRIMARY KEY,
+        project_id  TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        order_index INTEGER NOT NULL,
+        name        TEXT NOT NULL,
+        enabled     INTEGER NOT NULL DEFAULT 1,
+        conditions  TEXT NOT NULL,
+        actions     TEXT NOT NULL,
+        created_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        updated_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_triage_rules_project_order
+        ON triage_rules(project_id, order_index ASC);
+      CREATE INDEX IF NOT EXISTS idx_triage_rules_project_enabled_order
+        ON triage_rules(project_id, enabled, order_index ASC);
+    `);
+
+    execAlterTablesIfMissing(db, [
+      'ALTER TABLE github_issue_cache ADD COLUMN rules_applied_at TEXT',
+      'ALTER TABLE github_issue_cache ADD COLUMN triage_failure_reason TEXT',
+    ]);
+
+    db.exec(`
+      UPDATE github_issue_cache
+         SET rules_applied_at = COALESCE(rules_applied_at, ${ISO_NOW_SQL})
+       WHERE rules_applied_at IS NULL;
+    `);
+
+    db.exec(`INSERT OR REPLACE INTO schema_version (version) VALUES (54)`);
+  });
+}

--- a/packages/db/src/test-helpers.ts
+++ b/packages/db/src/test-helpers.ts
@@ -53,6 +53,7 @@ import {
   migrateV51,
   migrateV52,
   migrateV53,
+  migrateV54,
 } from './schema';
 
 export function createTestDb(): DatabaseSync {
@@ -110,5 +111,6 @@ export function createTestDb(): DatabaseSync {
   migrateV51(db);
   migrateV52(db);
   migrateV53(db);
+  migrateV54(db);
   return db;
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -34,6 +34,7 @@ export * from './sqlite-time';
 export * from './staleness';
 export * from './task-graph';
 export * from './tokens';
+export * from './triage-rules';
 export * from './types';
 export * from './unified-diff';
 // worktree-path uses node:path — import directly from '@shipcode/shared/worktree-path'

--- a/packages/shared/src/ipc-channels.ts
+++ b/packages/shared/src/ipc-channels.ts
@@ -1,5 +1,6 @@
 import type { PrdBlastRadius, PrdEstimatedComplexity } from './prd-issue-metadata';
 import type { TaskGraphWithNodes } from './task-graph';
+import type { TriageRule, TriageRuleDraft } from './triage-rules';
 import type {
   ActivePipelineSummary,
   ActivityEntry,
@@ -168,6 +169,11 @@ export interface IpcInvokeChannels {
   'project:set-notify-github-user': {
     args: { projectId: string; handle: string | null };
     result: Project;
+  };
+  'project:list-triage-rules': { args: { projectId: string }; result: TriageRule[] };
+  'project:replace-triage-rules': {
+    args: { projectId: string; rules: TriageRuleDraft[] };
+    result: TriageRule[];
   };
 
   'thread:list': { args: { projectId: string }; result: Thread[] };

--- a/packages/shared/src/triage-rules.ts
+++ b/packages/shared/src/triage-rules.ts
@@ -1,0 +1,120 @@
+export const TRIAGE_RULE_LIMIT = 50;
+
+export type TriageRuleConditionOperator = 'all' | 'any';
+export type TriageRuleConditionKind = 'label_includes' | 'label_excludes' | 'title_contains';
+
+export interface TriageRuleCondition {
+  kind: TriageRuleConditionKind;
+  value: string;
+}
+
+export interface TriageRuleConditions {
+  operator: TriageRuleConditionOperator;
+  items: TriageRuleCondition[];
+}
+
+export interface TriageRuleActions {
+  addLabels: string[];
+  removeLabels: string[];
+}
+
+export interface TriageRuleDraft {
+  id?: string;
+  name: string;
+  enabled: boolean;
+  conditions: TriageRuleConditions;
+  actions: TriageRuleActions;
+}
+
+export interface TriageRule extends TriageRuleDraft {
+  id: string;
+  projectId: string;
+  orderIndex: number;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface TriageRuleIssue {
+  title: string;
+  labels: readonly string[];
+}
+
+export function normalizeTriageRuleDraft(draft: TriageRuleDraft): TriageRuleDraft {
+  const id = draft.id?.trim();
+  return {
+    ...(id ? { id } : {}),
+    name: draft.name.trim(),
+    enabled: draft.enabled,
+    conditions: {
+      operator: draft.conditions.operator === 'any' ? 'any' : 'all',
+      items: uniqueConditions(
+        draft.conditions.items
+          .map((condition) => ({
+            kind: condition.kind,
+            value: condition.value.trim(),
+          }))
+          .filter((condition) => condition.value.length > 0),
+      ),
+    },
+    actions: {
+      addLabels: uniqueTrimmed(draft.actions.addLabels),
+      removeLabels: uniqueTrimmed(draft.actions.removeLabels),
+    },
+  };
+}
+
+export function evaluateTriageRules(
+  issue: TriageRuleIssue,
+  rules: readonly TriageRule[],
+): TriageRule | null {
+  for (const rule of rules) {
+    if (rule.enabled && matchesConditions(issue, rule.conditions)) {
+      return rule;
+    }
+  }
+  return null;
+}
+
+function matchesConditions(issue: TriageRuleIssue, conditions: TriageRuleConditions): boolean {
+  if (conditions.items.length === 0) return false;
+  const matcher = (condition: TriageRuleCondition) => matchesCondition(issue, condition);
+  return conditions.operator === 'any'
+    ? conditions.items.some(matcher)
+    : conditions.items.every(matcher);
+}
+
+function matchesCondition(issue: TriageRuleIssue, condition: TriageRuleCondition): boolean {
+  const labels = new Set(issue.labels);
+  switch (condition.kind) {
+    case 'label_includes':
+      return labels.has(condition.value);
+    case 'label_excludes':
+      return !labels.has(condition.value);
+    case 'title_contains':
+      return issue.title.toLowerCase().includes(condition.value.toLowerCase());
+  }
+}
+
+function uniqueTrimmed(values: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const value of values) {
+    const trimmed = value.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+function uniqueConditions(conditions: readonly TriageRuleCondition[]): TriageRuleCondition[] {
+  const seen = new Set<string>();
+  const result: TriageRuleCondition[] = [];
+  for (const condition of conditions) {
+    const key = `${condition.kind}\0${condition.value}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    result.push(condition);
+  }
+  return result;
+}

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1407,6 +1407,8 @@ export interface GitHubIssueCacheRecord {
   priorityRank: 'p0' | 'p1' | 'p2' | 'p3' | null;
   priorityRaw: string | null;
   priorityFetchedAt: string | null;
+  rulesAppliedAt?: string | null;
+  triageFailureReason?: string | null;
   // Quick mode: synthetic local-only task with negative sentinel `issueNumber`
   // and no real GitHub issue. Pipeline runs against raw text; PR/comment paths
   // must skip these rows.


### PR DESCRIPTION
## Summary
- Add triage rules engine: define rules that auto-label, auto-prioritize, or auto-assign incoming GitHub issues
- New DB schema + queries for triage rule persistence (`packages/db`)
- Shared types and validation for triage rule contracts (`packages/shared`)
- IPC handlers for CRUD operations on triage rules (`apps/desktop`)
- Issue poller integration to apply matching rules on new issues (`packages/agents`)
- Full UI: TriageRulesTab in project settings modal with create/edit/delete/reorder

## Test plan
- [ ] `bun run test packages/db` passes (new triage-rules queries)
- [ ] `bun run test packages/shared` passes (triage-rules types)
- [ ] Desktop app: Project Settings → Triage Rules tab renders
- [ ] Create a triage rule, verify it persists after app restart
- [ ] New issue matching a rule gets auto-labeled/prioritized

Closes #86