### PR TITLE
[codex] Refactor CLI issue pipeline startup

### DIFF
--- a/apps/cli/src/commands/issue-pipeline.ts
+++ b/apps/cli/src/commands/issue-pipeline.ts
@@ -1,0 +1,40 @@
+import { routeFromLabels } from '@shipcode/agents';
+import { createPipeline } from '@shipcode/pipeline';
+import type { CliContext } from '../context';
+import { createCliContext } from '../context';
+import { parseIssueNumber } from './issue-helpers';
+
+type PipelineIssue = Awaited<ReturnType<CliContext['ghCli']['getIssue']>>;
+
+export async function loadIssuePipelineInput(issueNumber: string) {
+  const num = parseIssueNumber(issueNumber);
+  const ctx = createCliContext(process.cwd());
+
+  console.log(`Fetching issue #${num}...`);
+  const issue = await ctx.ghCli.getIssue(num);
+
+  return { ctx, issue, num };
+}
+
+export function resolveIssuePipelineRoute(labels: string[]) {
+  const route = routeFromLabels(labels);
+
+  return {
+    executorModel: 'error' in route ? 'codex' : route.executorModel,
+    executorModelOverride: 'error' in route ? null : (route.modelOverride ?? null),
+  };
+}
+
+export async function startIssuePipeline(
+  ctx: CliContext,
+  issue: PipelineIssue,
+  route = resolveIssuePipelineRoute(issue.labels),
+) {
+  return createPipeline(ctx.pipelineDeps).startFromGitHubIssue(
+    ctx.project.id,
+    ctx.project.path,
+    issue,
+    route.executorModel,
+    { baseBranch: ctx.project.defaultBranch, executorModelOverride: route.executorModelOverride },
+  );
+}

--- a/apps/cli/src/commands/plan.ts
+++ b/apps/cli/src/commands/plan.ts
@@ -1,9 +1,6 @@
-import { routeFromLabels } from '@shipcode/agents';
-import { createPipeline } from '@shipcode/pipeline';
 import { sanitizeCliText } from '../adapters/cli-emitter';
-import { createCliContext } from '../context';
 import { requireOnboarding } from './guard';
-import { parseIssueNumber } from './issue-helpers';
+import { loadIssuePipelineInput, startIssuePipeline } from './issue-pipeline';
 
 /**
  * `shipcode plan <issue-number>`
@@ -14,28 +11,12 @@ import { parseIssueNumber } from './issue-helpers';
 export async function planCommand(issueNumber: string) {
   if (!requireOnboarding()) return;
 
-  const num = parseIssueNumber(issueNumber);
-  const ctx = createCliContext(process.cwd());
-
-  console.log(`Fetching issue #${num}...`);
-  const issue = await ctx.ghCli.getIssue(num);
-
-  const route = routeFromLabels(issue.labels);
-  const executorModel = 'error' in route ? 'codex' : route.executorModel;
-  const executorModelOverride = 'error' in route ? null : (route.modelOverride ?? null);
+  const { ctx, issue, num } = await loadIssuePipelineInput(issueNumber);
 
   console.log(`Issue: ${sanitizeCliText(issue.title)}`);
   console.log('Running plan generation...\n');
 
-  const pipeline = createPipeline(ctx.pipelineDeps);
-
-  await pipeline.startFromGitHubIssue(
-    ctx.project.id,
-    ctx.project.path,
-    { number: issue.number, title: issue.title, body: issue.body, labels: issue.labels },
-    executorModel,
-    { baseBranch: ctx.project.defaultBranch, executorModelOverride },
-  );
+  await startIssuePipeline(ctx, issue);
 
   // Retrieve the generated plan from DB
   const thread = ctx.threads.getByProjectAndGithubIssue(ctx.project.id, num);

--- a/apps/cli/src/commands/review.ts
+++ b/apps/cli/src/commands/review.ts
@@ -1,9 +1,6 @@
-import { routeFromLabels } from '@shipcode/agents';
-import { createPipeline } from '@shipcode/pipeline';
 import { sanitizeCliText } from '../adapters/cli-emitter';
-import { createCliContext } from '../context';
 import { requireOnboarding } from './guard';
-import { parseIssueNumber } from './issue-helpers';
+import { loadIssuePipelineInput, startIssuePipeline } from './issue-pipeline';
 
 /**
  * `shipcode review <issue-number>`
@@ -13,28 +10,12 @@ import { parseIssueNumber } from './issue-helpers';
 export async function reviewCommand(issueNumber: string) {
   if (!requireOnboarding()) return;
 
-  const num = parseIssueNumber(issueNumber);
-  const ctx = createCliContext(process.cwd());
-
-  console.log(`Fetching issue #${num}...`);
-  const issue = await ctx.ghCli.getIssue(num);
-
-  const route = routeFromLabels(issue.labels);
-  const executorModel = 'error' in route ? 'codex' : route.executorModel;
-  const executorModelOverride = 'error' in route ? null : (route.modelOverride ?? null);
+  const { ctx, issue, num } = await loadIssuePipelineInput(issueNumber);
 
   console.log(`Issue: ${sanitizeCliText(issue.title)}`);
   console.log('Running plan + review...\n');
 
-  const pipeline = createPipeline(ctx.pipelineDeps);
-
-  await pipeline.startFromGitHubIssue(
-    ctx.project.id,
-    ctx.project.path,
-    { number: issue.number, title: issue.title, body: issue.body, labels: issue.labels },
-    executorModel,
-    { baseBranch: ctx.project.defaultBranch, executorModelOverride },
-  );
+  await startIssuePipeline(ctx, issue);
 
   // Retrieve review from DB — reviews are keyed by planId
   const thread = ctx.threads.getByProjectAndGithubIssue(ctx.project.id, num);

--- a/apps/cli/src/commands/run.ts
+++ b/apps/cli/src/commands/run.ts
@@ -1,38 +1,24 @@
-import { routeFromLabels } from '@shipcode/agents';
-import { createPipeline } from '@shipcode/pipeline';
 import { sanitizeCliText } from '../adapters/cli-emitter';
-import { createCliContext } from '../context';
 import { requireOnboarding } from './guard';
-import { parseIssueNumber } from './issue-helpers';
+import {
+  loadIssuePipelineInput,
+  resolveIssuePipelineRoute,
+  startIssuePipeline,
+} from './issue-pipeline';
 
 export async function runCommand(issueNumber: string) {
   if (!requireOnboarding()) return;
 
-  const num = parseIssueNumber(issueNumber);
-  const ctx = createCliContext(process.cwd());
-
-  console.log(`Fetching issue #${num}...`);
-  const issue = await ctx.ghCli.getIssue(num);
-
-  const route = routeFromLabels(issue.labels);
-  const executorModel = 'error' in route ? 'codex' : route.executorModel;
-  const executorModelOverride = 'error' in route ? null : (route.modelOverride ?? null);
+  const { ctx, issue } = await loadIssuePipelineInput(issueNumber);
+  const route = resolveIssuePipelineRoute(issue.labels);
 
   console.log(`Issue: ${sanitizeCliText(issue.title)}`);
   console.log(
-    `Model: ${executorModel}${executorModelOverride ? ` (${executorModelOverride})` : ''}`,
+    `Model: ${route.executorModel}${route.executorModelOverride ? ` (${route.executorModelOverride})` : ''}`,
   );
   console.log(`Starting pipeline...\n`);
 
-  const pipeline = createPipeline(ctx.pipelineDeps);
-
-  await pipeline.startFromGitHubIssue(
-    ctx.project.id,
-    ctx.project.path,
-    { number: issue.number, title: issue.title, body: issue.body, labels: issue.labels },
-    executorModel,
-    { baseBranch: ctx.project.defaultBranch, executorModelOverride },
-  );
+  await startIssuePipeline(ctx, issue, route);
 
   console.log('\nPipeline started. Watching for completion...');
 }


### PR DESCRIPTION
## Summary
- Extract shared CLI GitHub issue pipeline startup into `issue-pipeline.ts`.
- Remove duplicated parse/fetch/route/start logic from `run`, `plan`, and `review` commands.
- Net code reduction: 55 insertions / 67 deletions (-12 LOC).

## Validation
- `biome check apps/cli/src/commands/issue-pipeline.ts apps/cli/src/commands/run.ts apps/cli/src/commands/plan.ts apps/cli/src/commands/review.ts`
- `git diff --check origin/develop..HEAD`

## Notes
- Targeted Vitest and typecheck were blocked earlier by missing local dependencies while the sandbox was offline.
- Repo labels `codex` and `codex-automation` were not present, so no labels were applied.
