### PR TITLE
fix(cli): handle fast terminal process exits

### DIFF
--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: millionco/react-doctor@main
+      - uses: millionco/react-doctor/actions/inspect@main
         with:
           diff: ${{ github.event.pull_request.base.ref }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/apps/cli/src/commands/terminal.test.ts
+++ b/apps/cli/src/commands/terminal.test.ts
@@ -1,0 +1,132 @@
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { terminalCommand } from './terminal';
+
+const { createCliContextMock } = vi.hoisted(() => ({
+  createCliContextMock: vi.fn(),
+}));
+
+vi.mock('../context', () => ({
+  createCliContext: createCliContextMock,
+}));
+
+vi.mock('../adapters/cli-emitter', () => ({
+  sanitizeCliText: (value: string) => value,
+}));
+
+vi.mock('@shipcode/git', () => ({
+  WorktreeManager: vi.fn(),
+}));
+
+vi.mock('@shipcode/shared', () => ({
+  PIPELINE_PHASE: {
+    completed: 'completed',
+    executing: 'executing',
+    failed: 'failed',
+  },
+  resolveProviderReasoningEffort: () => ({ effective: 'medium' }),
+  THREAD_KIND: {
+    pipeline: 'pipeline',
+  },
+}));
+
+describe('terminalCommand', () => {
+  let tmpDir: string;
+  let stdinDescriptors: Record<string, PropertyDescriptor | undefined>;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'shipcode-cli-terminal-'));
+    stdinDescriptors = {
+      isTTY: Object.getOwnPropertyDescriptor(process.stdin, 'isTTY'),
+      isRaw: Object.getOwnPropertyDescriptor(process.stdin, 'isRaw'),
+      setRawMode: Object.getOwnPropertyDescriptor(process.stdin, 'setRawMode'),
+      resume: Object.getOwnPropertyDescriptor(process.stdin, 'resume'),
+    };
+  });
+
+  afterEach(async () => {
+    for (const [key, descriptor] of Object.entries(stdinDescriptors)) {
+      if (descriptor) {
+        Object.defineProperty(process.stdin, key, descriptor);
+      } else {
+        Reflect.deleteProperty(process.stdin, key);
+      }
+    }
+    await fs.rm(tmpDir, { force: true, recursive: true });
+  });
+
+  it('settles and restores stdin when the managed process exits during spawn', async () => {
+    const processManager = new EventEmitter() as EventEmitter & {
+      spawn: ReturnType<typeof vi.fn>;
+      write: ReturnType<typeof vi.fn>;
+    };
+    processManager.spawn = vi.fn(() => {
+      processManager.emit('output', 'proc-1', 'fast failure\n');
+      processManager.emit('exit', 'proc-1', 2);
+      return { id: 'proc-1' };
+    });
+    processManager.write = vi.fn();
+    const setRawMode = vi.fn();
+    const resume = vi.fn();
+    Object.defineProperty(process.stdin, 'isTTY', { configurable: true, value: true });
+    Object.defineProperty(process.stdin, 'isRaw', { configurable: true, value: false });
+    Object.defineProperty(process.stdin, 'setRawMode', { configurable: true, value: setRawMode });
+    Object.defineProperty(process.stdin, 'resume', { configurable: true, value: resume });
+
+    const thread = {
+      id: 'thread-1',
+      worktreeBranch: 'shipcode/issue-123',
+      worktreePath: tmpDir,
+    };
+    const issue = {
+      body: 'Fix it',
+      id: 'issue-1',
+      issueNumber: 123,
+      title: 'Fast failure',
+    };
+    const agentConversationInsert = vi.fn();
+    const updateStatus = vi.fn();
+    const stdoutWrite = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    createCliContextMock.mockReturnValue({
+      agentConversations: { insert: agentConversationInsert },
+      githubIssues: { getByNumber: vi.fn(() => issue), linkThread: vi.fn() },
+      processManager,
+      project: { defaultBranch: 'develop', gitRemote: 'origin', id: 'project-1', path: tmpDir },
+      settings: { get: vi.fn(() => ({ worktreeBranchFormat: null, worktreeRoot: null })) },
+      terminalEvents: { create: vi.fn() },
+      threads: {
+        create: vi.fn(),
+        getById: vi.fn(() => thread),
+        getByProjectAndGithubIssue: vi.fn(() => thread),
+        setGithubIssue: vi.fn(),
+        setWorktree: vi.fn(),
+        updateIssueContent: vi.fn(),
+        updateStatus,
+      },
+    });
+
+    await expect(terminalCommand('123', { provider: 'claude' })).resolves.toBeUndefined();
+
+    expect(resume).not.toHaveBeenCalled();
+    expect(setRawMode).not.toHaveBeenCalled();
+    expect(processManager.listenerCount('output')).toBe(0);
+    expect(processManager.listenerCount('exit')).toBe(0);
+    expect(stdoutWrite).toHaveBeenCalledWith('fast failure\n');
+    expect(agentConversationInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        content: expect.stringContaining('Interactive claude session exited with code 2'),
+        phase: 'interactive_terminal',
+        role: 'response',
+      }),
+    );
+    expect(updateStatus).toHaveBeenLastCalledWith(
+      'thread-1',
+      'failed',
+      'Interactive claude exited with code 2',
+    );
+  });
+});

--- a/apps/cli/src/commands/terminal.ts
+++ b/apps/cli/src/commands/terminal.ts
@@ -12,6 +12,9 @@ import { createCliContext } from '../context';
 import { parseIssueNumber } from './issue-helpers';
 
 type Provider = 'claude' | 'codex';
+type ManagedTerminalProcess = ReturnType<
+  ReturnType<typeof createCliContext>['processManager']['spawn']
+>;
 
 function parseProvider(raw: unknown): Provider {
   if (raw === 'claude' || raw === 'codex') return raw;
@@ -89,17 +92,18 @@ export async function terminalCommand(
   const ctx = createCliContext(process.cwd());
   const thread = await ensureThreadAndWorktree(ctx, issueNumber);
   if (!thread.worktreePath) throw new Error(`Thread ${thread.id} has no worktree path`);
+  const worktreePath = thread.worktreePath;
 
   const issue = ctx.githubIssues.getByNumber(ctx.project.id, issueNumber);
   if (!issue) throw new Error(`Issue #${issueNumber} is not cached`);
-  const runDir = path.join(thread.worktreePath, '.shipcode', 'runs', thread.id);
+  const runDir = path.join(worktreePath, '.shipcode', 'runs', thread.id);
   const promptArtifactPath = path.join(runDir, 'terminal-prompt.md');
   const summaryPath = path.join(runDir, 'session-summary.md');
   await fs.mkdir(runDir, { recursive: true });
   const prompt = `# ShipCode Issue Terminal Session
 
 Issue: #${issue.issueNumber} ${issue.title}
-Worktree: ${thread.worktreePath}
+Worktree: ${worktreePath}
 Branch: ${thread.worktreeBranch ?? ''}
 Summary artifact: ${summaryPath}
 
@@ -121,36 +125,35 @@ Before exiting, write files changed, commands run, blockers, and a suggested Git
   });
   ctx.threads.updateStatus(thread.id, PIPELINE_PHASE.executing);
 
-  const managed = ctx.processManager.spawn(
-    provider,
-    provider,
-    buildArgs(provider, promptArtifactPath, options.model),
-    thread.worktreePath,
-    thread.id,
-    { outputMode: 'raw' },
-  );
-
   const wasRaw = process.stdin.isTTY ? process.stdin.isRaw : false;
-  if (process.stdin.isTTY) process.stdin.setRawMode(true);
-  process.stdin.resume();
-  const onInput = (chunk: Buffer) => ctx.processManager.write(managed.id, chunk.toString());
-  process.stdin.on('data', onInput);
+  let managed: ManagedTerminalProcess | null = null;
+  let inputAttached = false;
+  let rawModeSet = false;
+  const pendingOutput: Array<{ processId: string; chunk: string }> = [];
+  let pendingExit: { processId: string; exitCode: number } | null = null;
 
-  await new Promise<void>((resolve) => {
-    const onOutput = (processId: string, chunk: string) => {
-      if (processId !== managed.id) return;
-      process.stdout.write(sanitizeCliText(chunk));
-      ctx.terminalEvents.create(thread.id, { kind: 'raw', content: chunk });
-    };
-    const onExit = (processId: string, exitCode: number) => {
-      if (processId !== managed.id) return;
+  await new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => {
       ctx.processManager.off('output', onOutput);
       ctx.processManager.off('exit', onExit);
-      process.stdin.off('data', onInput);
-      if (process.stdin.isTTY) process.stdin.setRawMode(wasRaw);
+      if (inputAttached) {
+        process.stdin.off('data', onInput);
+        inputAttached = false;
+      }
+      if (rawModeSet && process.stdin.isTTY) {
+        process.stdin.setRawMode(wasRaw);
+        rawModeSet = false;
+      }
+    };
+
+    const settle = (exitCode: number) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
       const fallback = `Interactive ${provider} session exited with code ${exitCode}.
 Prompt artifact: ${promptArtifactPath}
-Worktree: ${thread.worktreePath}
+Worktree: ${worktreePath}
 Terminal output is available in the session transcript.`;
       fs.readFile(summaryPath, 'utf8')
         .then((content) => content.trim() || fallback)
@@ -173,8 +176,59 @@ Terminal output is available in the session transcript.`;
           resolve();
         });
     };
+
+    const onOutput = (processId: string, chunk: string) => {
+      if (!managed) {
+        pendingOutput.push({ processId, chunk });
+        return;
+      }
+      if (processId !== managed.id) return;
+      process.stdout.write(sanitizeCliText(chunk));
+      ctx.terminalEvents.create(thread.id, { kind: 'raw', content: chunk });
+    };
+    const onExit = (processId: string, exitCode: number) => {
+      if (!managed) {
+        pendingExit = { processId, exitCode };
+        return;
+      }
+      if (processId !== managed.id) return;
+      settle(exitCode);
+    };
+    const onInput = (chunk: Buffer) => {
+      if (managed) ctx.processManager.write(managed.id, chunk.toString());
+    };
+
     ctx.processManager.on('output', onOutput);
     ctx.processManager.on('exit', onExit);
+
+    try {
+      managed = ctx.processManager.spawn(
+        provider,
+        provider,
+        buildArgs(provider, promptArtifactPath, options.model),
+        worktreePath,
+        thread.id,
+        { outputMode: 'raw' },
+      );
+    } catch (error) {
+      cleanup();
+      reject(error);
+      return;
+    }
+
+    for (const event of pendingOutput) onOutput(event.processId, event.chunk);
+    if (pendingExit) {
+      onExit(pendingExit.processId, pendingExit.exitCode);
+      return;
+    }
+
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(true);
+      rawModeSet = true;
+    }
+    process.stdin.resume();
+    process.stdin.on('data', onInput);
+    inputAttached = true;
   });
 }
 


### PR DESCRIPTION
## Summary
- register terminal output/exit listeners before spawning the managed CLI process
- buffer synchronous output/exit events emitted during spawn
- avoid attaching stdin/raw mode when the process has already exited
- add a regression test for synchronous fast-exit behavior

## Verification
- bun --filter @shipshitdev/shipcode test src/commands/terminal.test.ts
- bunx biome check apps/cli/src/commands/terminal.ts apps/cli/src/commands/terminal.test.ts --files-ignore-unknown=true
- bun scripts/verify-affected-workspaces.ts

Clawpatch finding addressed: fnd_sig-feat-cli-command-8c1a6ec86c-_e76151cd7f.
Skipped the node-pty optional dependency finding because the safe fix spans package/runtime boundaries and is not a small reviewable patch.