### PR TITLE
Fix Vercel docs build dependencies

### DIFF
--- a/scripts/sync-docs-to-web.sh
+++ b/scripts/sync-docs-to-web.sh
@@ -7,8 +7,8 @@ WEB_DIR="$ROOT_DIR/apps/web"
 
 echo "Building docs export with /docs base path..."
 (
-  cd "$DOCS_DIR"
-  DOCS_BASE_PATH=/docs bun run build
+  cd "$ROOT_DIR"
+  DOCS_BASE_PATH=/docs bun run turbo run build --filter=@shipcode/docs
 )
 
 echo "Syncing exported docs into apps/web/public/docs..."


### PR DESCRIPTION
## Summary
- Build docs through Turbo during web docs sync so workspace dependencies are built first
- Keeps the exported docs under /docs for the Vercel web deployment

## Verification
- rm -rf packages/ui/dist packages/shared/dist apps/docs/out apps/web/public/docs && bun run sync:docs
- bun run --filter @shipcode/web build