### PR TITLE
Promote release packaging fixes

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -162,6 +162,8 @@ jobs:
       - name: Install native build dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential python3
       - run: bun install
+      - name: Build desktop dependencies
+        run: bun run turbo run build --filter=@shipcode/desktop^...
       - name: Build desktop app
         run: cd apps/desktop && bun run build:code
       - name: Package Linux installers
@@ -198,6 +200,8 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - run: bun install
+      - name: Build desktop dependencies
+        run: bun run turbo run build --filter=@shipcode/desktop^...
       - name: Build desktop app
         run: cd apps/desktop && bun run build:code
       - name: Package macOS installers
@@ -299,7 +303,7 @@ jobs:
           git push
 
   publish-cli:
-    if: ${{ github.event_name == 'release' || inputs.publish_cli }}
+    if: ${{ (github.event_name == 'release' && vars.NPM_PUBLISH_ENABLED == 'true') || inputs.publish_cli }}
     needs:
       - validate-release
       - release-quality

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -35,6 +35,7 @@
     "nanoid": "5.1.11",
     "node-pty": "1.1.0",
     "simple-git": "3.36.0",
+    "yaml": "2.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   outDir: 'dist',
   clean: true,
   banner: { js: '#!/usr/bin/env node' },
+  external: ['yaml'],
   noExternal: [
     '@shipcode/shared',
     '@shipcode/db',


### PR DESCRIPTION
## Summary
- promote the release workflow packaging fix from staging to master
- desktop Linux/macOS packaging now builds workspace dependencies first
- automatic npm publishing is skipped unless NPM_PUBLISH_ENABLED=true, leaving manual publish_cli=true available

## Verification
- develop -> staging checks passed on #166: quality, react-doctor, Socket report

## Notes
- this is needed before recreating v0.1.0 so the release run packages desktop artifacts instead of failing during desktop build.