### PR TITLE
Promote Homebrew release gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -218,7 +218,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   update-homebrew-cask:
-    if: ${{ github.event_name == 'release' || (inputs.build_macos && inputs.update_homebrew) }}
+    if: ${{ (github.event_name == 'release' && vars.HOMEBREW_PUBLISH_ENABLED == 'true') || (inputs.build_macos && inputs.update_homebrew) }}
     needs:
       - validate-release
       - build-desktop-macos

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -162,6 +162,8 @@ jobs:
       - name: Install native build dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential python3
       - run: bun install
+      - name: Build desktop dependencies
+        run: bun run turbo run build --filter=@shipcode/desktop^...
       - name: Build desktop app
         run: cd apps/desktop && bun run build:code
       - name: Package Linux installers
@@ -198,6 +200,8 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - run: bun install
+      - name: Build desktop dependencies
+        run: bun run turbo run build --filter=@shipcode/desktop^...
       - name: Build desktop app
         run: cd apps/desktop && bun run build:code
       - name: Package macOS installers
@@ -299,7 +303,7 @@ jobs:
           git push
 
   publish-cli:
-    if: ${{ github.event_name == 'release' || inputs.publish_cli }}
+    if: ${{ (github.event_name == 'release' && vars.NPM_PUBLISH_ENABLED == 'true') || inputs.publish_cli }}
     needs:
       - validate-release
       - release-quality

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -35,6 +35,7 @@
     "nanoid": "5.1.11",
     "node-pty": "1.1.0",
     "simple-git": "3.36.0",
+    "yaml": "2.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   outDir: 'dist',
   clean: true,
   banner: { js: '#!/usr/bin/env node' },
+  external: ['yaml'],
   noExternal: [
     '@shipcode/shared',
     '@shipcode/db',

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -21,3 +21,4 @@ linux:
     - AppImage
     - deb
   category: Development
+  maintainer: shipshit.dev <hello@shipshit.dev>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,5 +1,9 @@
 {
-  "author": "shipshit.dev",
+  "author": {
+    "email": "hello@shipshit.dev",
+    "name": "shipshit.dev",
+    "url": "https://shipshit.dev"
+  },
   "dependencies": {
     "@fontsource/dm-sans": "5.2.8",
     "@sentry/electron": "7.13.0",
@@ -51,6 +55,7 @@
   },
   "main": "./dist/main/index.js",
   "name": "@shipcode/desktop",
+  "homepage": "https://shipcode.shipshit.dev",
   "private": true,
   "productName": "ShipCode",
   "scripts": {


### PR DESCRIPTION
## Summary
- promote Homebrew release gate from staging to master
- release events skip Homebrew tap mutation unless HOMEBREW_PUBLISH_ENABLED=true
- manual workflow_dispatch update_homebrew=true still works for explicit Homebrew publishing

## Verification
- develop -> staging checks passed on #170: quality, react-doctor, Socket report

## Release failure fixed
- v0.1.0 update-homebrew-cask failed because HOMEBREW_TAP_TOKEN could not authenticate to shipshitdev/homebrew-tap. The token/repo access issue should not keep web and desktop release lanes red by default.