### PR TITLE
Promote 0.1.1 release prep

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -218,7 +218,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   update-homebrew-cask:
-    if: ${{ github.event_name == 'release' || (inputs.build_macos && inputs.update_homebrew) }}
+    if: ${{ (github.event_name == 'release' && vars.HOMEBREW_PUBLISH_ENABLED == 'true') || (inputs.build_macos && inputs.update_homebrew) }}
     needs:
       - validate-release
       - build-desktop-macos

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -162,6 +162,8 @@ jobs:
       - name: Install native build dependencies
         run: sudo apt-get update && sudo apt-get install -y build-essential python3
       - run: bun install
+      - name: Build desktop dependencies
+        run: bun run turbo run build --filter=@shipcode/desktop^...
       - name: Build desktop app
         run: cd apps/desktop && bun run build:code
       - name: Package Linux installers
@@ -198,6 +200,8 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
       - run: bun install
+      - name: Build desktop dependencies
+        run: bun run turbo run build --filter=@shipcode/desktop^...
       - name: Build desktop app
         run: cd apps/desktop && bun run build:code
       - name: Package macOS installers
@@ -299,7 +303,7 @@ jobs:
           git push
 
   publish-cli:
-    if: ${{ github.event_name == 'release' || inputs.publish_cli }}
+    if: ${{ (github.event_name == 'release' && vars.NPM_PUBLISH_ENABLED == 'true') || inputs.publish_cli }}
     needs:
       - validate-release
       - release-quality

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipshitdev/shipcode",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Autonomous AI coding pipeline. GitHub issues in, pull requests out.",
   "type": "module",
   "repository": {
@@ -10,7 +10,7 @@
   },
   "main": "./dist/index.js",
   "bin": {
-    "shipcode": "./dist/index.js"
+    "shipcode": "dist/index.js"
   },
   "files": [
     "dist"

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -35,6 +35,7 @@
     "nanoid": "5.1.11",
     "node-pty": "1.1.0",
     "simple-git": "3.36.0",
+    "yaml": "2.9.0",
     "zod": "4.4.3"
   },
   "devDependencies": {

--- a/apps/cli/tsup.config.ts
+++ b/apps/cli/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
   outDir: 'dist',
   clean: true,
   banner: { js: '#!/usr/bin/env node' },
+  external: ['yaml'],
   noExternal: [
     '@shipcode/shared',
     '@shipcode/db',

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -21,3 +21,4 @@ linux:
     - AppImage
     - deb
   category: Development
+  maintainer: shipshit.dev <hello@shipshit.dev>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,5 +1,9 @@
 {
-  "author": "shipshit.dev",
+  "author": {
+    "email": "hello@shipshit.dev",
+    "name": "shipshit.dev",
+    "url": "https://shipshit.dev"
+  },
   "dependencies": {
     "@fontsource/dm-sans": "5.2.8",
     "@sentry/electron": "7.13.0",
@@ -51,6 +55,7 @@
   },
   "main": "./dist/main/index.js",
   "name": "@shipcode/desktop",
+  "homepage": "https://shipcode.shipshit.dev",
   "private": true,
   "productName": "ShipCode",
   "scripts": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -70,5 +70,5 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
-  "version": "0.1.0"
+  "version": "0.1.1"
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -20,5 +20,5 @@
     "coverage": "vitest run --coverage",
     "start": "next start"
   },
-  "version": "0.1.0"
+  "version": "0.1.1"
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/web",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3000",

--- a/bun.lock
+++ b/bun.lock
@@ -17,7 +17,7 @@
     },
     "apps/cli": {
       "name": "@shipshitdev/shipcode",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "bin": {
         "shipcode": "./dist/index.js",
       },
@@ -26,6 +26,7 @@
         "nanoid": "5.1.11",
         "node-pty": "1.1.0",
         "simple-git": "3.36.0",
+        "yaml": "2.9.0",
         "zod": "4.4.3",
       },
       "devDependencies": {
@@ -41,7 +42,7 @@
     },
     "apps/desktop": {
       "name": "@shipcode/desktop",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@fontsource/dm-sans": "5.2.8",
         "@sentry/electron": "7.13.0",
@@ -93,7 +94,7 @@
     },
     "apps/docs": {
       "name": "@shipcode/docs",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@shipcode/ui": "workspace:*",
         "next": "16.2.6",
@@ -109,7 +110,7 @@
     },
     "apps/web": {
       "name": "@shipcode/web",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@shipcode/shared": "workspace:*",
         "@shipcode/ui": "workspace:*",
@@ -129,7 +130,7 @@
     },
     "packages/agents": {
       "name": "@shipcode/agents",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@shipcode/shared": "workspace:*",
         "nanoid": "5.1.11",
@@ -142,7 +143,7 @@
     },
     "packages/db": {
       "name": "@shipcode/db",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@shipcode/shared": "workspace:*",
         "nanoid": "5.1.11",
@@ -153,7 +154,7 @@
     },
     "packages/git": {
       "name": "@shipcode/git",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@shipcode/shared": "workspace:*",
         "simple-git": "3.36.0",
@@ -164,7 +165,7 @@
     },
     "packages/pipeline": {
       "name": "@shipcode/pipeline",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@shipcode/agents": "workspace:*",
         "@shipcode/db": "workspace:*",
@@ -181,7 +182,7 @@
     },
     "packages/shared": {
       "name": "@shipcode/shared",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "zod": "4.4.3",
       },
@@ -191,7 +192,7 @@
     },
     "packages/ui": {
       "name": "@shipcode/ui",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "dependencies": {
         "@dnd-kit/core": "6.3.1",
         "@radix-ui/react-dropdown-menu": "2.1.16",

--- a/docs/coverage-leftovers.md
+++ b/docs/coverage-leftovers.md
@@ -1,150 +1,45 @@
 # Coverage Leftovers
 
-Last updated: 2026-05-10
+Last updated: 2026-05-24
 
-Goal: 100% lines, statements, functions, and branches for every covered package surface.
+Goal: keep the repo above the release-hardening floor. Do not chase 100% coverage for its own sake.
 
-Current gate: `scripts/coverage-summary.mjs` defaults to `COVERAGE_MIN=95`.
+Current gate:
+
+- Lines, statements, functions: 95%
+- Branches: 90%
+- `COVERAGE_MIN=<n>` overrides every metric for stricter one-off runs.
+- `COVERAGE_BRANCH_MIN=<n>` overrides only branch coverage when `COVERAGE_MIN` is unset.
 
 Verification snapshot:
 
 ```text
-bun run coverage:summary
+node scripts/coverage-summary.mjs
 
-apps/cli: lines 83.88%, statements 82.97%, functions 69.04%, branches 73.83%
-apps/desktop: lines 95.43%, statements 94.32%, functions 94.59%, branches 88.15%
-apps/docs: lines 100.00%, statements 100.00%, functions 100.00%, branches 100.00%
-apps/web: lines 97.77%, statements 95.91%, functions 92.30%, branches 100.00%
-packages/agents: lines 96.00%, statements 95.81%, functions 95.16%, branches 95.27%
-packages/db: lines 97.04%, statements 96.87%, functions 96.30%, branches 95.48%
-packages/git: lines 100.00%, statements 100.00%, functions 100.00%, branches 100.00%
-packages/pipeline: lines 99.23%, statements 99.08%, functions 99.58%, branches 95.17%
-packages/shared: lines 96.10%, statements 96.10%, functions 93.99%, branches 96.87%
-packages/ui: lines 95.40%, statements 94.37%, functions 94.36%, branches 96.28%
+Overall coverage
+lines: 95.91% (20055/20911)
+statements: 95.19% (22206/23327)
+functions: 95.08% (5156/5423)
+branches: 91.52% (17607/19239)
 
-overall: lines 95.83%, statements 95.14%, functions 94.90%, branches 91.73%
+Coverage threshold passed at lines/statements/functions 95.00%, branches 90.00%.
 ```
 
-At the 95 gate, the current aggregate gaps are functions and branches.
+## Accepted
 
-## Already Clean
+- `packages/pipeline` is done under the current release contract: lines 97.09%, statements 96.65%, functions 99.20%, branches 91.63%.
 
-- `apps/docs`
-- `packages/db`
-- `packages/git`
+## Package Gaps
 
-## Packages Pipeline
+These packages are below the current package-level floor, though the aggregate release gate passes:
 
-Remaining files below 100:
+- `apps/desktop`: statements 94.24%, functions 94.53%, branches 87.92%
+- `apps/web`: functions 92.30%
+- `packages/shared`: functions 93.99%
+- `packages/ui`: statements 94.32%, functions 94.40%
 
-```text
-packages/pipeline/src/pipeline/execution-phases.ts: lines 97.33, statements 96.22, functions 96.82, branches 86.09
-packages/pipeline/src/pipeline/planning-phases.ts: lines 100, statements 100, functions 100, branches 89.44
-packages/pipeline/src/pipeline/runtime.ts: lines 100, statements 100, functions 100, branches 96.78
-```
+## Next Pass
 
-Notes:
-- Work mostly belongs in `packages/pipeline/src/pipeline/*.test.ts`.
-- Prefer covering real retry/cancel/failure paths.
-- Do not preserve impossible state combinations just to satisfy branch coverage; delete dry if the state cannot occur.
-
-## Apps Desktop
-
-Remaining files below 100:
-
-```text
-apps/desktop/src/main/index.ts: lines 98.38, statements 95.52, functions 96.87, branches 68.11
-apps/desktop/src/renderer/App.tsx: lines 86.36, statements 87.03, functions 89.13, branches 77.57
-apps/desktop/src/renderer/components/IssuesPanel.tsx: lines 99.16, statements 97.61, functions 97.18, branches 79.60
-apps/desktop/src/main/git-workflows.ts: lines 98.43, statements 98.57, functions 100, branches 79.62
-apps/desktop/src/main/ipc/register-pr-handlers.ts: lines 100, statements 96.15, functions 100, branches 80
-apps/desktop/src/main/ipc/register-quick-task-handlers.ts: lines 92, statements 92.85, functions 80, branches 87.50
-apps/desktop/src/renderer/components/TerminalView.tsx: lines 97.50, statements 97.82, functions 94.11, branches 80
-apps/desktop/src/renderer/components/SkillsView.tsx: lines 96.03, statements 95.48, functions 97.50, branches 81.81
-apps/desktop/src/renderer/features/automations/create-automation-modal.tsx: lines 92.10, statements 89.68, functions 82.05, branches 85.36
-apps/desktop/src/renderer/components/issue-detail/PipelineTab.tsx: lines 98.93, statements 96.96, functions 97.56, branches 82.25
-apps/desktop/src/renderer/features/automations/automations-view.tsx: lines 97.82, statements 96.15, functions 96.55, branches 82.85
-apps/desktop/src/main/ipc/register-automation-handlers.ts: lines 100, statements 100, functions 100, branches 83.33
-apps/desktop/src/renderer/components/ThreadPanelArchiveDialog.tsx: lines 100, statements 100, functions 100, branches 83.33
-apps/desktop/src/renderer/components/issue-detail/IssueDetailDialogs.tsx: lines 100, statements 100, functions 100, branches 83.33
-apps/desktop/src/renderer/components/CleanupModal.tsx: lines 99.03, statements 98.30, functions 100, branches 84.24
-apps/desktop/src/renderer/components/onboarding/OnboardingWizard.tsx: lines 87.87, statements 87.87, functions 84.61, branches 92
-apps/desktop/src/renderer/features/automations/automation-detail.tsx: lines 100, statements 88.88, functions 100, branches 85.45
-apps/desktop/src/renderer/components/AssistantPanel.tsx: lines 98.03, statements 94.70, functions 94.82, branches 85.71
-apps/desktop/src/renderer/components/ProjectProviderWarningPopover.tsx: lines 100, statements 100, functions 100, branches 85.71
-apps/desktop/src/renderer/components/issue-detail/IssueDetailTabs.tsx: lines 100, statements 100, functions 100, branches 85.71
-apps/desktop/src/renderer/components/AutomationRunDetail.tsx: lines 100, statements 94.30, functions 100, branches 85.88
-apps/desktop/src/renderer/components/project-settings-modal/ProjectPhaseSettingsRow.tsx: lines 100, statements 100, functions 100, branches 86.02
-apps/desktop/src/renderer/components/InboxView.tsx: lines 93.80, statements 92.91, functions 89.13, branches 86.27
-apps/desktop/src/renderer/components/terminal-drawer/useTerminalDrawer.ts: lines 100, statements 98.14, functions 100, branches 86.74
-apps/desktop/src/renderer/components/pull-requests/PullRequestDetailPanel.tsx: lines 92.85, statements 93.33, functions 100, branches 86.84
-apps/desktop/src/renderer/components/Titlebar.tsx: lines 96.62, statements 93.69, functions 100, branches 87.07
-apps/desktop/src/renderer/components/SettingsPanel.tsx: lines 100, statements 97.82, functions 95.45, branches 87.09
-apps/desktop/src/renderer/components/project-settings-modal/ProjectSettingsGeneralTab.tsx: lines 100, statements 100, functions 100, branches 87.27
-apps/desktop/src/renderer/components/ProjectSettingsModal.tsx: lines 97.20, statements 94.20, functions 97.34, branches 87.35
-apps/desktop/src/renderer/components/NotificationToaster.tsx: lines 100, statements 100, functions 91.66, branches 87.50
-apps/desktop/src/renderer/components/issue-detail/PlanWaiting.tsx: lines 100, statements 100, functions 100, branches 87.50
-apps/desktop/src/renderer/components/project-settings-modal/ProjectSettingsPipelineTab.tsx: lines 100, statements 100, functions 100, branches 87.50
-apps/desktop/src/renderer/components/terminal-drawer/render-terminal-event.ts: lines 96.77, statements 96.96, functions 100, branches 87.50
-apps/desktop/src/renderer/features/project/code-browser.tsx: lines 91.37, statements 90.32, functions 88.46, branches 87.50
-apps/desktop/src/main/ipc/register-pipeline-handlers.ts: lines 99.78, statements 99.79, functions 100, branches 87.52
-apps/desktop/src/renderer/components/terminal-panes/useTerminalPane.ts: lines 100, statements 96, functions 100, branches 88
-apps/desktop/src/renderer/components/terminal-transcript/TerminalTranscript.tsx: lines 100, statements 99.24, functions 96.42, branches 88.10
-apps/desktop/src/renderer/hooks/useIpc.ts: lines 99.41, statements 96.98, functions 95.65, branches 88.18
-apps/desktop/src/renderer/components/costs/PhaseDurationsChart.tsx: lines 100, statements 100, functions 100, branches 88.23
-apps/desktop/src/renderer/components/costs/TokensByPhaseChart.tsx: lines 100, statements 100, functions 100, branches 88.88
-apps/desktop/src/renderer/components/issue-detail/PlanHistoryTab.tsx: lines 90, statements 90, functions 88.88, branches 98.50
-apps/desktop/src/renderer/components/issue-detail/CommentsTab.tsx: lines 100, statements 96.29, functions 100, branches 89.47
-apps/desktop/src/main/resource-monitor.ts: lines 97.36, statements 97.56, functions 90, branches 96.29
-apps/desktop/src/renderer/components/onboarding/StepAuthCheck.tsx: lines 100, statements 100, functions 100, branches 90.90
-apps/desktop/src/main/ipc/helpers.ts: lines 100, statements 100, functions 100, branches 91.07
-apps/desktop/src/main/splash-screen.ts: lines 100, statements 100, functions 91.66, branches 100
-apps/desktop/src/renderer/components/issue-detail/ApprovalSection.tsx: lines 100, statements 91.66, functions 100, branches 94.44
-apps/desktop/src/main/logger.service.ts: lines 92, statements 92.59, functions 100, branches 100
-apps/desktop/src/renderer/telemetry.ts: lines 100, statements 100, functions 100, branches 92.85
-apps/desktop/src/main/ipc/register-support-handlers.ts: lines 100, statements 97.03, functions 95.65, branches 94.05
-apps/desktop/src/renderer/components/issue-detail/helpers.ts: lines 100, statements 100, functions 100, branches 93.33
-apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx: lines 100, statements 100, functions 100, branches 93.43
-apps/desktop/src/renderer/components/project-settings-modal/ProjectSettingsModelsTab.tsx: lines 100, statements 100, functions 100, branches 93.75
-apps/desktop/src/main/notification-service.ts: lines 100, statements 100, functions 100, branches 94
-apps/desktop/src/renderer/hooks/useGlobalKeyboard.ts: lines 100, statements 100, functions 100, branches 94.11
-apps/desktop/src/main/ipc/register-github-handlers.ts: lines 99.64, statements 99.68, functions 98.52, branches 94.16
-apps/desktop/src/main/ipc/retry-phase.ts: lines 100, statements 100, functions 100, branches 94.44
-apps/desktop/src/main/ipc/register-project-handlers.ts: lines 100, statements 100, functions 100, branches 94.67
-apps/desktop/src/renderer/components/IssueDetail.tsx: lines 99.77, statements 98.15, functions 99.21, branches 95.01
-apps/desktop/src/renderer/components/terminal-panes/TerminalPane.tsx: lines 100, statements 100, functions 100, branches 95.16
-apps/desktop/src/renderer/components/pull-requests/PullRequestsPanel.tsx: lines 100, statements 95.23, functions 100, branches 96
-apps/desktop/src/renderer/components/project-settings-modal/ProjectSettingsSetupTab.tsx: lines 100, statements 100, functions 100, branches 95.83
-apps/desktop/src/main/update-service.ts: lines 100, statements 100, functions 100, branches 96.15
-apps/desktop/src/renderer/components/settings-panel/GeneralSettingsSection.tsx: lines 100, statements 100, functions 100, branches 96.15
-apps/desktop/src/main/telemetry.ts: lines 100, statements 100, functions 100, branches 96.29
-apps/desktop/src/main/ipc/prd-attachments.ts: lines 98.76, statements 98.86, functions 100, branches 96.87
-apps/desktop/src/renderer/components/CreateIssueModal.tsx: lines 97.85, statements 98.12, functions 97.01, branches 96.96
-apps/desktop/src/renderer/components/ProjectSidebar.tsx: lines 98.21, statements 98.44, functions 98.79, branches 96.96
-apps/desktop/src/renderer/components/CommandPalette.tsx: lines 100, statements 100, functions 100, branches 97.29
-apps/desktop/src/renderer/components/settings-panel/IntegrationsSettingsSection.tsx: lines 100, statements 100, functions 100, branches 97.29
-apps/desktop/src/renderer/components/TerminalDrawer.tsx: lines 100, statements 100, functions 100, branches 97.50
-apps/desktop/src/main/ipc/register-instant-handlers.ts: lines 100, statements 99.38, functions 100, branches 99.32
-```
-
-Notes:
-- Desktop is the main remaining surface.
-- Full desktop verification at this snapshot: `140` files passed, `1347` tests passed.
-- Best next order: attack the lowest-branch files first, then the low-line/function files.
-- Several renderer branch gaps are likely optional empty/error states. Prefer behavior tests in the nearest existing `*.test.tsx`.
-- For main-process IPC gaps, keep IPC error clamping rules: renderer-facing errors stay first-line and short; full stacks only in main-process logs.
-
-## Recommended Next Pass
-
-1. Bring `packages/pipeline` to 100 while staying aligned with retry/cancel invariants.
-2. Split desktop into focused batches:
-   - branch-only renderer tabs/settings sections,
-   - low-line renderer components,
-   - main-process IPC handlers,
-   - app bootstrap/index paths.
-
-Before updating this doc, refresh artifacts with:
-
-```bash
-bun run coverage
-```
+1. Raise `apps/desktop` branches to 90%, then close its small statement/function gaps.
+2. Cover the low-function paths in `apps/web`, `packages/shared`, and `packages/ui`.
+3. Keep new package work at or above the release contract before merging.

--- a/docs/coverage-leftovers.md
+++ b/docs/coverage-leftovers.md
@@ -8,8 +8,8 @@ Current gate:
 
 - Lines, statements, functions: 95%
 - Branches: 90%
-- `COVERAGE_MIN=<n>` overrides every metric for stricter one-off runs.
-- `COVERAGE_BRANCH_MIN=<n>` overrides only branch coverage when `COVERAGE_MIN` is unset.
+- `COVERAGE_MIN=<n>` overrides the base floor for every metric.
+- `COVERAGE_BRANCH_MIN=<n>` overrides branch coverage independently, including when `COVERAGE_MIN` is set.
 
 Verification snapshot:
 

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/agents",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/db",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/git",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/pipeline",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/shared",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/ui",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "ShipCode-specific UI components for the ShipCode monorepo.",
   "type": "module",

--- a/scripts/coverage-summary.mjs
+++ b/scripts/coverage-summary.mjs
@@ -4,8 +4,33 @@ import path from 'node:path';
 const ROOT = process.cwd();
 const SEARCH_ROOTS = ['apps', 'packages'];
 const METRIC_KEYS = ['lines', 'statements', 'functions', 'branches'];
-const DEFAULT_MIN_COVERAGE = 85;
-const MIN_COVERAGE = Number(process.env.COVERAGE_MIN ?? DEFAULT_MIN_COVERAGE);
+const DEFAULT_MIN_COVERAGE = 95;
+const DEFAULT_BRANCH_MIN_COVERAGE = 90;
+
+function readCoverageMin(envName, fallback) {
+  const raw = process.env[envName];
+  if (raw === undefined || raw === '') return fallback;
+
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 0 || value > 100) {
+    console.error(`${envName} must be a number between 0 and 100.`);
+    process.exit(1);
+  }
+
+  return value;
+}
+
+const MIN_COVERAGE = readCoverageMin('COVERAGE_MIN', DEFAULT_MIN_COVERAGE);
+const BRANCH_MIN_COVERAGE =
+  process.env.COVERAGE_MIN !== undefined && process.env.COVERAGE_BRANCH_MIN === undefined
+    ? MIN_COVERAGE
+    : readCoverageMin('COVERAGE_BRANCH_MIN', DEFAULT_BRANCH_MIN_COVERAGE);
+const METRIC_THRESHOLDS = {
+  lines: MIN_COVERAGE,
+  statements: MIN_COVERAGE,
+  functions: MIN_COVERAGE,
+  branches: BRANCH_MIN_COVERAGE,
+};
 
 function findCoverageSummaries() {
   const found = [];
@@ -92,13 +117,16 @@ for (const key of METRIC_KEYS) {
   );
 }
 
-const belowThreshold = METRIC_KEYS.filter((key) => aggregate[key].pct < MIN_COVERAGE);
+const belowThreshold = METRIC_KEYS.filter((key) => aggregate[key].pct < METRIC_THRESHOLDS[key]);
 
 if (belowThreshold.length > 0) {
-  console.error(
-    `\nCoverage threshold failed. Minimum ${formatPct(MIN_COVERAGE)} required for: ${belowThreshold.join(', ')}`,
+  const failures = belowThreshold.map(
+    (key) => `${key} ${formatPct(aggregate[key].pct)} < ${formatPct(METRIC_THRESHOLDS[key])}`,
   );
+  console.error(`\nCoverage threshold failed: ${failures.join(', ')}`);
   process.exit(1);
 }
 
-console.log(`\nCoverage threshold passed at ${formatPct(MIN_COVERAGE)}.`);
+console.log(
+  `\nCoverage threshold passed at lines/statements/functions ${formatPct(MIN_COVERAGE)}, branches ${formatPct(BRANCH_MIN_COVERAGE)}.`,
+);

--- a/scripts/coverage-summary.mjs
+++ b/scripts/coverage-summary.mjs
@@ -21,10 +21,14 @@ function readCoverageMin(envName, fallback) {
 }
 
 const MIN_COVERAGE = readCoverageMin('COVERAGE_MIN', DEFAULT_MIN_COVERAGE);
-const BRANCH_MIN_COVERAGE =
-  process.env.COVERAGE_MIN !== undefined && process.env.COVERAGE_BRANCH_MIN === undefined
+const hasCoverageMin = process.env.COVERAGE_MIN !== undefined && process.env.COVERAGE_MIN !== '';
+const hasBranchMin =
+  process.env.COVERAGE_BRANCH_MIN !== undefined && process.env.COVERAGE_BRANCH_MIN !== '';
+const BRANCH_MIN_COVERAGE = hasBranchMin
+  ? readCoverageMin('COVERAGE_BRANCH_MIN', DEFAULT_BRANCH_MIN_COVERAGE)
+  : hasCoverageMin
     ? MIN_COVERAGE
-    : readCoverageMin('COVERAGE_BRANCH_MIN', DEFAULT_BRANCH_MIN_COVERAGE);
+    : DEFAULT_BRANCH_MIN_COVERAGE;
 const METRIC_THRESHOLDS = {
   lines: MIN_COVERAGE,
   statements: MIN_COVERAGE,


### PR DESCRIPTION
## Summary
- promote 0.1.1 package metadata to master
- keep CLI and desktop versions aligned for the next release tag
- normalize CLI bin path for npm global install

## Verification
- develop -> staging PR #177 passed quality and react-doctor
- bun install --frozen-lockfile
- bun run turbo run build --filter=@shipshitdev/shipcode
- node apps/cli/dist/index.js --version
- npm publish --dry-run --access public --provenance
- bun run format:check apps/cli/package.json apps/desktop/package.json apps/docs/package.json apps/web/package.json packages/agents/package.json packages/db/package.json packages/git/package.json packages/pipeline/package.json packages/shared/package.json packages/ui/package.json bun.lock
- git diff --check

Refs #172