### PR TITLE
feat: add Cursor CLI as a pipeline provider

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,7 +5,7 @@
 
 ## Working directory
 
-Primary: `/Users/decod3rs/www/shipshitdev/private/shipcode`
+Primary: `/Users/decod3rs/www/shipshitdev/public/shipcode`
 
 ## Session ritual
 

--- a/apps/desktop/src/main/index.test.ts
+++ b/apps/desktop/src/main/index.test.ts
@@ -176,6 +176,7 @@ function installMocks() {
     createClaudeCliProvider: vi.fn(() => ({ key: 'claude' })),
     createCodexCliProvider: vi.fn(() => ({ key: 'codex' })),
     createGeminiCliProvider: vi.fn(() => ({ key: 'gemini' })),
+    createCursorCliProvider: vi.fn(() => ({ key: 'cursor' })),
     createOpenRouterProvider: createOpenRouterProviderMock,
     createProviderRegistry: vi.fn((providers) => providers),
     GhCli: vi.fn(function GhCliMock() {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -52,6 +52,7 @@ import path from 'node:path';
 import {
   createClaudeCliProvider,
   createCodexCliProvider,
+  createCursorCliProvider,
   createGeminiCliProvider,
   createOpenRouterProvider,
   createProviderRegistry,
@@ -280,6 +281,7 @@ function createWindow() {
     claude: createClaudeCliProvider(processManager),
     codex: createCodexCliProvider(processManager),
     gemini: createGeminiCliProvider(processManager),
+    cursor: createCursorCliProvider(processManager),
     openrouter: createOpenRouterProvider({
       getApiKey: () => process.env.OPENROUTER_API_KEY,
       getSettings: () => queries.settings.get(),

--- a/apps/desktop/src/main/ipc/register-support-handlers.ts
+++ b/apps/desktop/src/main/ipc/register-support-handlers.ts
@@ -357,10 +357,16 @@ export function registerSupportHandlers({
             ? '\x1b[33m'
             : type === 'gemini'
               ? '\x1b[32m'
-              : '\x1b[35m';
+              : type === 'cursor'
+                ? '\x1b[34m'
+                : '\x1b[35m';
       const exitColor = state === 'exited' ? '\x1b[2m' : '';
       const typeLabel =
-        type === 'claude' || type === 'codex' || type === 'gemini' || type === 'openrouter'
+        type === 'claude' ||
+        type === 'codex' ||
+        type === 'gemini' ||
+        type === 'cursor' ||
+        type === 'openrouter'
           ? `${providerDisplay(type as ExecutorModel)}${type === 'openrouter' ? '' : ' CLI'}`
           : type;
       emitTerminalEvent(proc.threadId, {

--- a/apps/desktop/src/renderer/components/issue-detail/helpers.ts
+++ b/apps/desktop/src/renderer/components/issue-detail/helpers.ts
@@ -124,6 +124,7 @@ export function decodePhaseOption(value: string): {
     providerRaw === 'claude' ||
     providerRaw === 'codex' ||
     providerRaw === 'gemini' ||
+    providerRaw === 'cursor' ||
     providerRaw === 'openrouter'
       ? providerRaw
       : 'claude';

--- a/apps/desktop/src/renderer/components/model-provider-options-data.ts
+++ b/apps/desktop/src/renderer/components/model-provider-options-data.ts
@@ -10,6 +10,7 @@ export const PROVIDER_DISPLAY: Record<ExecutorModel, string> = {
   claude: 'Anthropic',
   codex: 'OpenAI',
   gemini: 'Google',
+  cursor: 'Cursor',
   openrouter: 'OpenRouter',
 };
 
@@ -17,7 +18,12 @@ export function getModelOptions(
   provider: ExecutorModel,
   integrationStatus?: IntegrationStatus,
 ): ReadonlyArray<{ value: string; label: string }> {
-  if (provider === 'claude' || provider === 'codex' || provider === 'gemini') {
+  if (
+    provider === 'claude' ||
+    provider === 'codex' ||
+    provider === 'gemini' ||
+    provider === 'cursor'
+  ) {
     return getCapabilityModelOptions(integrationStatus, provider);
   }
   return OPENROUTER_MODEL_OPTIONS;

--- a/apps/desktop/src/renderer/components/project-settings-modal/ProjectPhaseSettingsRow.tsx
+++ b/apps/desktop/src/renderer/components/project-settings-modal/ProjectPhaseSettingsRow.tsx
@@ -41,7 +41,13 @@ import {
 } from './shared';
 
 function asExecutorModel(value: Project['plannerModelOverride']): ExecutorModel | null {
-  if (value === 'claude' || value === 'codex' || value === 'gemini' || value === 'openrouter') {
+  if (
+    value === 'claude' ||
+    value === 'codex' ||
+    value === 'gemini' ||
+    value === 'cursor' ||
+    value === 'openrouter'
+  ) {
     return value;
   }
   return null;

--- a/apps/desktop/src/renderer/components/settings-panel/IntegrationsSettingsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings-panel/IntegrationsSettingsSection.tsx
@@ -270,6 +270,7 @@ function useIntegrationsSettingsSectionView({
               { key: 'claude', label: 'Claude CLI' },
               { key: 'codex', label: 'Codex CLI' },
               { key: 'gemini', label: 'Gemini CLI' },
+              { key: 'cursor', label: 'Cursor CLI' },
               { key: 'gh', label: 'GitHub CLI' },
             ].map(({ key, label }) => {
               const cli =
@@ -279,7 +280,9 @@ function useIntegrationsSettingsSectionView({
                     ? integrationStatus.system.codex
                     : key === 'gemini'
                       ? (integrationStatus.system.gemini ?? missingCli)
-                      : integrationStatus.system.gh;
+                      : key === 'cursor'
+                        ? (integrationStatus.system.cursor ?? missingCli)
+                        : integrationStatus.system.gh;
               const ghScope =
                 key === 'gh'
                   ? integrationStatus.ghAuth.hasProjectScope === true
@@ -290,13 +293,13 @@ function useIntegrationsSettingsSectionView({
                   : null;
               const versionLine = getCliVersionLine(cli.version);
               const Icon =
-                key === 'claude' || key === 'gemini'
+                key === 'claude' || key === 'gemini' || key === 'cursor'
                   ? Sparkles
                   : key === 'codex'
                     ? Terminal
                     : FolderGit;
               const modelCapabilities =
-                key === 'claude' || key === 'codex' || key === 'gemini'
+                key === 'claude' || key === 'codex' || key === 'gemini' || key === 'cursor'
                   ? integrationStatus.modelCapabilities?.[key]
                   : null;
 

--- a/apps/desktop/src/renderer/components/settings-panel/PhaseModelRow.tsx
+++ b/apps/desktop/src/renderer/components/settings-panel/PhaseModelRow.tsx
@@ -92,6 +92,11 @@ export function PhaseModelRow({
                 Google{disabledProviders?.gemini ? ` (${disabledProviders.gemini})` : ''}
               </SelectItem>
             )}
+            {validProviders.includes('cursor') && (
+              <SelectItem value="cursor" disabled={!!disabledProviders?.cursor}>
+                Cursor{disabledProviders?.cursor ? ` (${disabledProviders.cursor})` : ''}
+              </SelectItem>
+            )}
             {validProviders.includes('openrouter') && (
               <SelectItem value="openrouter" disabled={!!disabledProviders?.openrouter}>
                 OpenRouter

--- a/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx
@@ -672,7 +672,7 @@ function pipelineSettingsSection({
                   : null
               }
               reasoningEffortValue={settings.plannerReasoningEffort}
-              validProviders={['claude', 'codex', 'gemini', 'openrouter']}
+              validProviders={['claude', 'codex', 'gemini', 'cursor', 'openrouter']}
               onModelChange={(value) =>
                 onUpdate({
                   plannerModel: value as AppSettings['plannerModel'],
@@ -720,7 +720,7 @@ function pipelineSettingsSection({
                   : null
               }
               reasoningEffortValue={settings.reviewerReasoningEffort}
-              validProviders={['claude', 'codex', 'gemini', 'openrouter']}
+              validProviders={['claude', 'codex', 'gemini', 'cursor', 'openrouter']}
               onModelChange={(value) =>
                 onUpdate({
                   reviewerModel: value as AppSettings['reviewerModel'],
@@ -768,7 +768,7 @@ function pipelineSettingsSection({
                   : null
               }
               reasoningEffortValue={settings.executorReasoningEffort}
-              validProviders={['claude', 'codex', 'gemini', 'openrouter']}
+              validProviders={['claude', 'codex', 'gemini', 'cursor', 'openrouter']}
               onModelChange={(value) =>
                 onUpdate({
                   executorModel: value as AppSettings['executorModel'],
@@ -816,7 +816,7 @@ function pipelineSettingsSection({
                   : null
               }
               reasoningEffortValue={settings.verifierReasoningEffort}
-              validProviders={['claude', 'codex', 'gemini', 'openrouter']}
+              validProviders={['claude', 'codex', 'gemini', 'cursor', 'openrouter']}
               onModelChange={(value) =>
                 onUpdate({
                   verifierModel: value as AppSettings['verifierModel'],

--- a/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx
@@ -672,7 +672,7 @@ function pipelineSettingsSection({
                   : null
               }
               reasoningEffortValue={settings.plannerReasoningEffort}
-              validProviders={['claude', 'codex', 'gemini', 'cursor', 'openrouter']}
+              validProviders={['claude', 'codex', 'gemini', 'openrouter']}
               onModelChange={(value) =>
                 onUpdate({
                   plannerModel: value as AppSettings['plannerModel'],
@@ -720,7 +720,7 @@ function pipelineSettingsSection({
                   : null
               }
               reasoningEffortValue={settings.reviewerReasoningEffort}
-              validProviders={['claude', 'codex', 'gemini', 'cursor', 'openrouter']}
+              validProviders={['claude', 'codex', 'gemini', 'openrouter']}
               onModelChange={(value) =>
                 onUpdate({
                   reviewerModel: value as AppSettings['reviewerModel'],
@@ -816,7 +816,7 @@ function pipelineSettingsSection({
                   : null
               }
               reasoningEffortValue={settings.verifierReasoningEffort}
-              validProviders={['claude', 'codex', 'gemini', 'cursor', 'openrouter']}
+              validProviders={['claude', 'codex', 'gemini', 'openrouter']}
               onModelChange={(value) =>
                 onUpdate({
                   verifierModel: value as AppSettings['verifierModel'],

--- a/apps/desktop/src/renderer/components/settings-panel/SettingsLeafSections.test.tsx
+++ b/apps/desktop/src/renderer/components/settings-panel/SettingsLeafSections.test.tsx
@@ -159,6 +159,13 @@ const integrationStatus: IntegrationStatus = {
       error: 'No Gemini models reported',
       checkedAt: '2026-05-08T10:00:00.000Z',
     },
+    cursor: {
+      provider: 'cursor',
+      source: 'fallback',
+      models: [],
+      error: null,
+      checkedAt: '2026-05-08T10:00:00.000Z',
+    },
   },
   ghAuth: {
     installed: true,

--- a/packages/agents/src/health-check.ts
+++ b/packages/agents/src/health-check.ts
@@ -179,10 +179,10 @@ let systemHealthInFlight: Promise<SystemHealth> | null = null;
 let systemHealthWithAuthCache: TimedCacheEntry<SystemHealth> | null = null;
 let systemHealthWithAuthInFlight: Promise<SystemHealth> | null = null;
 let cliModelCapabilitiesCache: TimedCacheEntry<
-  Record<'claude' | 'codex' | 'gemini', CliModelCapabilities>
+  Record<'claude' | 'codex' | 'gemini' | 'cursor', CliModelCapabilities>
 > | null = null;
 let cliModelCapabilitiesInFlight: Promise<
-  Record<'claude' | 'codex' | 'gemini', CliModelCapabilities>
+  Record<'claude' | 'codex' | 'gemini' | 'cursor', CliModelCapabilities>
 > | null = null;
 const providerUsageCache = new Map<
   CliProviderUsageProvider,
@@ -1160,6 +1160,21 @@ export async function checkGeminiAuth(): Promise<boolean> {
   }
 }
 
+export async function checkCursorAuth(): Promise<boolean> {
+  // Headless fallback: an API key authenticates without an interactive login.
+  if (await readEnvVar('CURSOR_API_KEY')) {
+    return true;
+  }
+
+  // Otherwise rely on the CLI's own stored credentials (`cursor-agent login`).
+  try {
+    await execAsync('cursor-agent status', { timeout: 10_000, env: shellExecEnv() });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 export type OpenRouterAuthStatus =
   | { ok: true; label?: string }
   | {
@@ -1481,15 +1496,16 @@ export async function checkSystemHealth(options: CacheOptions = {}): Promise<Sys
   }
 
   systemHealthInFlight = (async () => {
-    const [claude, codex, gemini, git, gh] = await Promise.all([
+    const [claude, codex, gemini, cursor, git, gh] = await Promise.all([
       checkCli('claude', '--version'),
       checkCli('codex', '--version'),
       checkCli('gemini', '--version'),
+      checkCli('cursor-agent', '--version'),
       checkCli('git', '--version'),
       checkCli('gh', '--version'),
     ]);
 
-    const result = { claude, codex, gemini, git, gh };
+    const result = { claude, codex, gemini, cursor, git, gh };
     systemHealthCache = createTimedCacheEntry(result);
     return result;
   })();
@@ -1512,19 +1528,22 @@ export async function checkSystemHealthWithAuth(options: CacheOptions = {}): Pro
   }
 
   systemHealthWithAuthInFlight = (async () => {
-    const [health, claudeAuth, codexAuth, geminiAuth] = await Promise.all([
+    const [health, claudeAuth, codexAuth, geminiAuth, cursorAuth] = await Promise.all([
       checkSystemHealth(options),
       checkClaudeAuth(),
       checkCodexAuth(),
       checkGeminiAuth(),
+      checkCursorAuth(),
     ]);
 
     const gemini = health.gemini;
+    const cursor = health.cursor;
     const result: SystemHealth = {
       ...health,
       claude: { ...health.claude, authenticated: health.claude.available && claudeAuth },
       codex: { ...health.codex, authenticated: health.codex.available && codexAuth },
       ...(gemini ? { gemini: { ...gemini, authenticated: gemini.available && geminiAuth } } : {}),
+      ...(cursor ? { cursor: { ...cursor, authenticated: cursor.available && cursorAuth } } : {}),
     };
     systemHealthWithAuthCache = createTimedCacheEntry(result);
     return result;
@@ -1657,20 +1676,42 @@ export async function checkGeminiModelCapabilities(): Promise<CliModelCapabiliti
   }
 }
 
+export async function checkCursorModelCapabilities(): Promise<CliModelCapabilities> {
+  const checkedAt = new Date().toISOString();
+  try {
+    await execAsync('cursor-agent --help', {
+      timeout: CLI_MODEL_CATALOG_TIMEOUT_MS,
+      maxBuffer: 512_000,
+      env: shellExecEnv(),
+    });
+    // Cursor has no queryable model catalog; ShipCode exposes only `auto`.
+    return fallbackCliModelCapabilities('cursor', checkedAt);
+  } catch (error) {
+    return {
+      provider: 'cursor',
+      source: 'unavailable',
+      models: [],
+      error: `Cursor CLI unavailable: ${summarizeExecFailure(error)}`,
+      checkedAt,
+    };
+  }
+}
+
 export async function checkCliModelCapabilities(
   options: CacheOptions = {},
-): Promise<Record<'claude' | 'codex' | 'gemini', CliModelCapabilities>> {
+): Promise<Record<'claude' | 'codex' | 'gemini' | 'cursor', CliModelCapabilities>> {
   const cached = getFreshCachedValue(cliModelCapabilitiesCache, CLI_MODEL_CAPABILITIES_TTL_MS);
   if (!options.force && cached) return cached;
   if (cliModelCapabilitiesInFlight) return cliModelCapabilitiesInFlight;
 
   cliModelCapabilitiesInFlight = (async () => {
-    const [claude, codex, gemini] = await Promise.all([
+    const [claude, codex, gemini, cursor] = await Promise.all([
       checkClaudeModelCapabilities(),
       checkCodexModelCapabilities(),
       checkGeminiModelCapabilities(),
+      checkCursorModelCapabilities(),
     ]);
-    const result = { claude, codex, gemini };
+    const result = { claude, codex, gemini, cursor };
     cliModelCapabilitiesCache = createTimedCacheEntry(result);
     return result;
   })();

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -61,6 +61,8 @@ export {
   checkCliProviderUsage,
   checkCodexAuth,
   checkCodexModelCapabilities,
+  checkCursorAuth,
+  checkCursorModelCapabilities,
   checkDesktopApps,
   checkGeminiAuth,
   checkGeminiModelCapabilities,

--- a/packages/agents/src/process-manager.ts
+++ b/packages/agents/src/process-manager.ts
@@ -7,7 +7,11 @@ import { assertWorkspaceSafe } from '@shipcode/shared/worktree-path';
 import { nanoid } from 'nanoid';
 import * as pty from 'node-pty';
 
-export type ProcessManagerAgentCommand = Extract<AgentType, 'claude' | 'codex' | 'gemini' | 'gh'>;
+export type ProcessManagerAgentCommand =
+  | Extract<AgentType, 'claude' | 'codex' | 'gemini' | 'gh'>
+  // Cursor's binary is `cursor-agent`, not `cursor`, so the allowlisted command
+  // string diverges from its AgentType tag (unlike the other CLIs).
+  | 'cursor-agent';
 export type ProcessManagerShellCommand = (typeof TRUSTED_SHELL_COMMANDS)[number];
 export type ProcessManagerPackageCommand = (typeof TRUSTED_PACKAGE_COMMANDS)[number];
 export type ProcessManagerCommand =
@@ -19,6 +23,7 @@ const ALLOWED_AGENT_COMMANDS = new Set<ProcessManagerAgentCommand>([
   'claude',
   'codex',
   'gemini',
+  'cursor-agent',
   'gh',
 ]);
 const TRUSTED_SHELL_COMMANDS = [
@@ -53,6 +58,7 @@ const SAFE_ENV_KEYS = new Set([
   'GEMINI_API_KEY',
   'GOOGLE_API_KEY',
   'GOOGLE_APPLICATION_CREDENTIALS',
+  'CURSOR_API_KEY',
 ]);
 
 function filterEnv(env: Record<string, string>): Record<string, string> {

--- a/packages/agents/src/providers/cursor-cli-provider.test.ts
+++ b/packages/agents/src/providers/cursor-cli-provider.test.ts
@@ -293,4 +293,14 @@ describe('cursor-cli-provider', () => {
 
     await expect(provider.healthCheck()).resolves.toEqual({ ok: true });
   });
+
+  it('supports only the execute phase (no read-only mode available)', () => {
+    const provider = createCursorCliProvider(new FakeProcessManager() as unknown as ProcessManager);
+
+    expect([...provider.supports]).toEqual(['execute']);
+    expect(provider.supports.has('plan')).toBe(false);
+    expect(provider.supports.has('review')).toBe(false);
+    expect(provider.supports.has('revision')).toBe(false);
+    expect(provider.supports.has('verify')).toBe(false);
+  });
 });

--- a/packages/agents/src/providers/cursor-cli-provider.test.ts
+++ b/packages/agents/src/providers/cursor-cli-provider.test.ts
@@ -1,0 +1,296 @@
+import { EventEmitter } from 'node:events';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { ProcessManager } from '../process-manager';
+import { _internals, createCursorCliProvider } from './cursor-cli-provider';
+import type { ProviderRequest } from './types';
+
+function req(overrides: Partial<ProviderRequest> = {}): ProviderRequest {
+  return {
+    phase: 'plan',
+    prompt: 'PROMPT',
+    cwd: '/tmp/wt',
+    projectPath: '/tmp/proj',
+    signal: new AbortController().signal,
+    threadId: 't1',
+    ...overrides,
+  };
+}
+
+class FakeProcessManager extends EventEmitter {
+  spawnWithStdin = vi.fn(
+    (
+      _type: string,
+      _command: string,
+      _args: string[],
+      _cwd: string,
+      _input: string,
+      _threadId?: string,
+      _options?: { envKeyAllowlist?: readonly string[]; workspaceRoot?: string | null },
+    ) => ({ id: 'proc-1' }),
+  );
+  spawn = vi.fn();
+  kill = vi.fn();
+}
+
+describe('cursor-cli-provider', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('adds --force only for the execute phase and keeps the prompt in stdin', () => {
+    expect(_internals.buildCursorCommand(req({ phase: 'execute', modelHint: 'auto' }))).toEqual({
+      args: ['-p', '--output-format', 'json', '--model', 'auto', '--force'],
+      stdin: 'PROMPT',
+    });
+  });
+
+  it('omits --force for read-only phases and --model when no hint is given', () => {
+    expect(_internals.buildCursorCommand(req({ phase: 'review' }))).toEqual({
+      args: ['-p', '--output-format', 'json'],
+      stdin: 'PROMPT',
+    });
+  });
+
+  it('parses the result object and resolved model', () => {
+    expect(
+      _internals.parseCursorOutput(
+        JSON.stringify({ type: 'result', result: 'done', model: 'gpt-5' }),
+      ),
+    ).toEqual({ text: 'done', resolvedModel: 'gpt-5' });
+  });
+
+  it('parses empty output, ANSI output, and alternate text keys', () => {
+    expect(_internals.parseCursorOutput('')).toEqual({ text: '' });
+    expect(_internals.parseCursorOutput('[31mplain[0m')).toEqual({ text: 'plain' });
+    expect(_internals.parseCursorOutput(JSON.stringify({ text: 'from text' }))).toEqual({
+      text: 'from text',
+    });
+  });
+
+  it('falls back to the last result line of NDJSON stream output', () => {
+    const stream = [
+      JSON.stringify({ type: 'system', subtype: 'init' }),
+      JSON.stringify({ type: 'assistant', text: 'thinking' }),
+      JSON.stringify({ type: 'result', result: 'final answer', model: 'sonnet-4.5' }),
+    ].join('\n');
+    expect(_internals.parseCursorOutput(stream)).toEqual({
+      text: 'final answer',
+      resolvedModel: 'sonnet-4.5',
+    });
+  });
+
+  it('returns cleaned raw text when nothing parses as a result', () => {
+    expect(_internals.parseCursorOutput('not json at all')).toEqual({ text: 'not json at all' });
+  });
+
+  it('uses generic failure text when stderr only echoes the prompt', () => {
+    expect(_internals.clampCursorFailure('PROMPT\n', 'PROMPT')).toBe('Cursor CLI failed');
+  });
+
+  it('falls back to plain text and omits unstable telemetry', async () => {
+    const processManager = new FakeProcessManager();
+    const provider = createCursorCliProvider(processManager as unknown as ProcessManager);
+    const resultPromise = provider.generate(req());
+
+    processManager.emit('output', 'proc-1', JSON.stringify({ type: 'result', result: 'done' }));
+    processManager.emit('exit', 'proc-1', 0);
+
+    const result = await resultPromise;
+    expect(result.rawOutput).toBe('done');
+    expect(result.resolvedModel).toBeUndefined();
+    expect(result.tokensUsed).toBeUndefined();
+    expect(result.costUsd).toBeUndefined();
+  });
+
+  it('passes workspace roots and selected prompt materials into execution telemetry', async () => {
+    const processManager = new FakeProcessManager();
+    const provider = createCursorCliProvider(processManager as unknown as ProcessManager);
+    const promptMaterialSummary = {
+      count: 1,
+      labels: ['issue'],
+      kinds: ['issue_prompt' as const],
+    };
+    const resultPromise = provider.generate(
+      req({
+        workspaceRoot: '/tmp/workspace',
+        promptMaterialSummary,
+      }),
+    );
+
+    processManager.emit('output', 'other-proc', 'ignored');
+    processManager.emit(
+      'output',
+      'proc-1',
+      JSON.stringify({ type: 'result', result: 'done', model: 'auto' }),
+    );
+    processManager.emit('exit', 'other-proc', 1);
+    processManager.emit('exit', 'proc-1', 0);
+
+    const result = await resultPromise;
+    expect(processManager.spawnWithStdin).toHaveBeenCalledWith(
+      'cursor',
+      'cursor-agent',
+      expect.any(Array),
+      '/tmp/wt',
+      'PROMPT',
+      't1',
+      expect.objectContaining({ workspaceRoot: '/tmp/workspace' }),
+    );
+    expect(result.rawOutput).toBe('done');
+    expect(result.resolvedModel).toBe('auto');
+    expect(result.promptTelemetry?.selectedMaterials).toBe(promptMaterialSummary);
+  });
+
+  it('allowlists CURSOR_API_KEY in the spawn env', async () => {
+    const processManager = new FakeProcessManager();
+    const provider = createCursorCliProvider(processManager as unknown as ProcessManager);
+    const resultPromise = provider.generate(req());
+
+    processManager.emit('output', 'proc-1', JSON.stringify({ type: 'result', result: 'ok' }));
+    processManager.emit('exit', 'proc-1', 0);
+    await resultPromise;
+
+    const options = processManager.spawnWithStdin.mock.calls[0]?.[6];
+    expect(options?.envKeyAllowlist).toContain('CURSOR_API_KEY');
+  });
+
+  it('clamps failures without leaking later stderr lines', async () => {
+    const processManager = new FakeProcessManager();
+    const provider = createCursorCliProvider(processManager as unknown as ProcessManager);
+    const resultPromise = provider.generate(req());
+
+    processManager.emit('output', 'proc-1', 'PROMPT\nAuth failed\n'.repeat(50));
+    processManager.emit('exit', 'proc-1', 1);
+
+    const result = await resultPromise;
+    expect(result.providerError?.message).toBe('Auth failed');
+    expect(result.providerError?.message).not.toContain('PROMPT');
+    expect(result.providerError?.retryable).toBe(true);
+  });
+
+  it('does not fall back to passing the prompt through argv', async () => {
+    const processManager = new FakeProcessManager();
+    processManager.spawnWithStdin = undefined as unknown as FakeProcessManager['spawnWithStdin'];
+    const provider = createCursorCliProvider(processManager as unknown as ProcessManager);
+
+    const result = await provider.generate(req());
+
+    expect(processManager.spawn).not.toHaveBeenCalled();
+    expect(result.exitCode).toBe(1);
+    expect(result.providerError?.message).not.toContain('PROMPT');
+  });
+
+  it('reports binary-missing when process spawn throws', async () => {
+    const processManager = new FakeProcessManager();
+    processManager.spawnWithStdin.mockImplementationOnce(() => {
+      throw new Error('ENOENT');
+    });
+    const provider = createCursorCliProvider(processManager as unknown as ProcessManager);
+
+    const result = await provider.generate(req());
+
+    expect(result.exitCode).toBe(127);
+    expect(result.rawOutput).toBe('ENOENT');
+    expect(result.providerError).toEqual({
+      kind: 'binary_missing',
+      message: 'cursor-agent CLI not found on PATH',
+      retryable: false,
+    });
+  });
+
+  it('stringifies non-Error spawn failures', async () => {
+    const processManager = new FakeProcessManager();
+    processManager.spawnWithStdin.mockImplementationOnce(() => {
+      throw 'spawn failed';
+    });
+    const provider = createCursorCliProvider(processManager as unknown as ProcessManager);
+
+    const result = await provider.generate(req());
+
+    expect(result.exitCode).toBe(127);
+    expect(result.rawOutput).toBe('spawn failed');
+  });
+
+  it('short-circuits already-aborted requests', async () => {
+    const controller = new AbortController();
+    controller.abort();
+    const processManager = new FakeProcessManager();
+    const provider = createCursorCliProvider(processManager as unknown as ProcessManager);
+
+    const result = await provider.generate(req({ signal: controller.signal }));
+
+    expect(processManager.spawnWithStdin).not.toHaveBeenCalled();
+    expect(result.providerError).toEqual({
+      kind: 'aborted',
+      message: 'aborted',
+      retryable: false,
+    });
+  });
+
+  it('kills running Cursor processes on abort and settles if no exit event arrives', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const processManager = new FakeProcessManager();
+    processManager.kill.mockImplementationOnce(() => {
+      throw new Error('already gone');
+    });
+    const provider = createCursorCliProvider(processManager as unknown as ProcessManager);
+
+    const resultPromise = provider.generate(req({ signal: controller.signal }));
+    processManager.emit('output', 'proc-1', 'partial');
+    controller.abort();
+
+    await vi.advanceTimersByTimeAsync(2000);
+    const result = await resultPromise;
+
+    expect(processManager.kill).toHaveBeenCalledWith('proc-1');
+    expect(result).toMatchObject({
+      rawOutput: 'partial',
+      exitCode: 130,
+      providerError: { kind: 'aborted', message: 'aborted', retryable: false },
+    });
+  });
+
+  it('does not overwrite an exit result when abort fallback timer fires later', async () => {
+    vi.useFakeTimers();
+    const controller = new AbortController();
+    const processManager = new FakeProcessManager();
+    const provider = createCursorCliProvider(processManager as unknown as ProcessManager);
+
+    const resultPromise = provider.generate(req({ signal: controller.signal }));
+    controller.abort();
+    processManager.emit('exit', 'proc-1', 0);
+    processManager.emit('exit', 'proc-1', 1);
+    await vi.advanceTimersByTimeAsync(2000);
+
+    const result = await resultPromise;
+    expect(result.exitCode).toBe(0);
+  });
+
+  it('emits canonical lifecycle, raw, and done terminal events', async () => {
+    const processManager = new FakeProcessManager();
+    const onTerminalEvent = vi.fn();
+    const provider = createCursorCliProvider(processManager as unknown as ProcessManager);
+    const resultPromise = provider.generate(req({ onTerminalEvent }));
+
+    processManager.emit('output', 'proc-1', '{"type":"result","result":"done"}');
+    processManager.emit('exit', 'proc-1', 0);
+    await resultPromise;
+
+    expect(onTerminalEvent).toHaveBeenCalledWith({
+      kind: 'lifecycle',
+      message: 'Cursor CLI started',
+    });
+    expect(onTerminalEvent).toHaveBeenCalledWith({
+      kind: 'raw',
+      content: '{"type":"result","result":"done"}',
+    });
+    expect(onTerminalEvent).toHaveBeenCalledWith({ kind: 'done' });
+  });
+
+  it('reports a healthy provider shell', async () => {
+    const provider = createCursorCliProvider(new FakeProcessManager() as unknown as ProcessManager);
+
+    await expect(provider.healthCheck()).resolves.toEqual({ ok: true });
+  });
+});

--- a/packages/agents/src/providers/cursor-cli-provider.ts
+++ b/packages/agents/src/providers/cursor-cli-provider.ts
@@ -1,0 +1,263 @@
+import type { ProcessManager } from '../process-manager';
+import { measurePromptPayload } from '../prompt-scope';
+import type { AgentProvider, ProviderPhase, ProviderRequest, ProviderResponse } from './types';
+
+interface CursorCommand {
+  args: string[];
+  stdin: string;
+}
+
+interface CursorRunResult {
+  rawOutput: string;
+  exitCode: number;
+}
+
+const CURSOR_ENV_KEYS = [
+  'PATH',
+  'HOME',
+  'USER',
+  'SHELL',
+  'TERM',
+  'LANG',
+  'LC_ALL',
+  'LC_CTYPE',
+  'TMPDIR',
+  'XDG_RUNTIME_DIR',
+  // Optional headless fallback when the CLI is not interactively logged in.
+  'CURSOR_API_KEY',
+] as const;
+
+type ProcessManagerWithStdin = ProcessManager & {
+  spawnWithStdin?: (
+    type: 'cursor',
+    command: string,
+    args: string[],
+    cwd: string,
+    input: string,
+    threadId?: string,
+    options?: Parameters<ProcessManager['spawn']>[5],
+  ) => ReturnType<ProcessManager['spawn']>;
+};
+
+function stripAnsi(value: string): string {
+  return value.replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g'), '');
+}
+
+function buildCursorCommand(req: ProviderRequest): CursorCommand {
+  // `-p` (print) makes cursor-agent non-interactive; the prompt is piped on
+  // stdin. `--output-format json` emits a single result object we can parse.
+  const args = ['-p', '--output-format', 'json'];
+  if (req.modelHint) args.push('--model', req.modelHint);
+  // Cursor has no sandbox flag. Only the execute phase may mutate the tree, so
+  // it gets `--force` (auto-apply edits). Read-only phases omit it so the agent
+  // cannot write.
+  if (req.phase === 'execute') args.push('--force');
+  return { args, stdin: req.prompt };
+}
+
+async function runCursorCli(
+  processManager: ProcessManager,
+  command: CursorCommand,
+  req: ProviderRequest,
+): Promise<CursorRunResult> {
+  if (req.signal.aborted) return { rawOutput: '', exitCode: 130 };
+
+  let process: ReturnType<ProcessManager['spawn']>;
+  try {
+    const options = {
+      ...(req.workspaceRoot !== undefined ? { workspaceRoot: req.workspaceRoot } : {}),
+      envKeyAllowlist: [...CURSOR_ENV_KEYS],
+    };
+    const processManagerWithStdin = processManager as ProcessManagerWithStdin;
+    if (processManagerWithStdin.spawnWithStdin) {
+      process = processManagerWithStdin.spawnWithStdin(
+        'cursor',
+        'cursor-agent',
+        command.args,
+        req.cwd,
+        command.stdin,
+        req.threadId,
+        options,
+      );
+    } else {
+      return {
+        rawOutput: 'Cursor CLI stdin execution is unavailable',
+        exitCode: 1,
+      };
+    }
+  } catch (err) {
+    return { rawOutput: err instanceof Error ? err.message : String(err), exitCode: 127 };
+  }
+
+  req.onTerminalEvent?.({ kind: 'lifecycle', message: 'Cursor CLI started' });
+
+  return new Promise<CursorRunResult>((resolve) => {
+    let rawOutput = '';
+    let settled = false;
+
+    const cleanup = () => {
+      processManager.removeListener('output', outputHandler);
+      processManager.removeListener('exit', exitHandler);
+      req.signal.removeEventListener('abort', abortHandler);
+    };
+
+    const settle = (result: CursorRunResult) => {
+      /* v8 ignore next -- listeners are removed during cleanup; guard is for event races */
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(result);
+    };
+
+    const outputHandler = (processId: string, data: string) => {
+      if (processId !== process.id) return;
+      rawOutput += data;
+      req.onTerminalEvent?.({ kind: 'raw', content: data });
+    };
+
+    const exitHandler = (processId: string, exitCode: number) => {
+      if (processId !== process.id) return;
+      req.onTerminalEvent?.({ kind: 'done' });
+      settle({ rawOutput, exitCode });
+    };
+
+    const abortHandler = () => {
+      try {
+        processManager.kill(process.id);
+      } catch {
+        // Exit handler owns settlement when the process is already gone.
+      }
+      setTimeout(() => {
+        if (!settled) settle({ rawOutput, exitCode: 130 });
+      }, 2000);
+    };
+
+    processManager.on('output', outputHandler);
+    processManager.on('exit', exitHandler);
+    req.signal.addEventListener('abort', abortHandler, { once: true });
+  });
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+function extractFromResultObject(
+  parsed: Record<string, unknown>,
+): { text: string; resolvedModel?: string } | null {
+  const text = firstString(
+    parsed.result,
+    parsed.text,
+    parsed.response,
+    parsed.content,
+    parsed.output,
+  );
+  if (text === null) return null;
+  const resolvedModel = firstString(parsed.model, parsed.modelId, parsed.resolvedModel);
+  return resolvedModel ? { text, resolvedModel } : { text };
+}
+
+/**
+ * Parse cursor-agent output. `--output-format json` returns a single result
+ * object (`{ type: 'result', result: '<final text>', model, ... }`). If the
+ * CLI instead streamed NDJSON, fall back to the last `result` line. When
+ * nothing parses, return the cleaned raw text so callers still see something.
+ */
+function parseCursorOutput(rawOutput: string): { text: string; resolvedModel?: string } {
+  const cleaned = stripAnsi(rawOutput).trim();
+  if (!cleaned) return { text: '' };
+
+  try {
+    const parsed = JSON.parse(cleaned) as Record<string, unknown>;
+    const extracted = extractFromResultObject(parsed);
+    if (extracted) return extracted;
+  } catch {
+    // Not a single JSON object — try NDJSON (stream-json) below.
+  }
+
+  let fallback: { text: string; resolvedModel?: string } | null = null;
+  for (const line of cleaned.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith('{')) continue;
+    try {
+      const obj = JSON.parse(trimmed) as Record<string, unknown>;
+      const extracted = extractFromResultObject(obj);
+      if (!extracted) continue;
+      // Prefer an explicit result event; otherwise keep the last extractable line.
+      if (obj.type === 'result') return extracted;
+      fallback = extracted;
+    } catch {
+      // Ignore non-JSON lines.
+    }
+  }
+
+  return fallback ?? { text: cleaned };
+}
+
+function clampCursorFailure(rawOutput: string, prompt: string): string {
+  const promptText = stripAnsi(prompt).trim();
+  const lines = stripAnsi(rawOutput)
+    .split('\n')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .filter((entry) => !promptText || (!promptText.includes(entry) && !entry.includes(promptText)));
+  const line =
+    lines.find((entry) => /\b(error|failed|unauthorized|auth|permission|denied)\b/i.test(entry)) ??
+    lines[0];
+  return (line ?? 'Cursor CLI failed').slice(0, 280);
+}
+
+export function createCursorCliProvider(processManager: ProcessManager): AgentProvider {
+  return {
+    id: 'cursor-cli',
+    supports: new Set<ProviderPhase>(['plan', 'review', 'revision', 'verify', 'execute']),
+    async generate(req: ProviderRequest): Promise<ProviderResponse> {
+      const command = buildCursorCommand(req);
+      const result = await runCursorCli(processManager, command, req);
+      const parsed = parseCursorOutput(result.rawOutput);
+      const promptTelemetry = {
+        phase: req.phase,
+        promptSize: measurePromptPayload(req.prompt),
+        ...(req.promptMaterialSummary ? { selectedMaterials: req.promptMaterialSummary } : {}),
+      };
+
+      return {
+        rawOutput: parsed.text,
+        exitCode: result.exitCode,
+        promptTelemetry,
+        ...(parsed.resolvedModel ? { resolvedModel: parsed.resolvedModel } : {}),
+        ...(result.exitCode === 127
+          ? {
+              providerError: {
+                kind: 'binary_missing' as const,
+                message: 'cursor-agent CLI not found on PATH',
+                retryable: false,
+              },
+            }
+          : result.exitCode === 130
+            ? { providerError: { kind: 'aborted' as const, message: 'aborted', retryable: false } }
+            : result.exitCode !== 0
+              ? {
+                  providerError: {
+                    kind: 'unknown' as const,
+                    message: clampCursorFailure(result.rawOutput, req.prompt),
+                    retryable: true,
+                  },
+                }
+              : {}),
+      };
+    },
+    async healthCheck() {
+      return { ok: true };
+    },
+  };
+}
+
+export const _internals = {
+  buildCursorCommand,
+  parseCursorOutput,
+  clampCursorFailure,
+};

--- a/packages/agents/src/providers/cursor-cli-provider.ts
+++ b/packages/agents/src/providers/cursor-cli-provider.ts
@@ -48,9 +48,11 @@ function buildCursorCommand(req: ProviderRequest): CursorCommand {
   // stdin. `--output-format json` emits a single result object we can parse.
   const args = ['-p', '--output-format', 'json'];
   if (req.modelHint) args.push('--model', req.modelHint);
-  // Cursor has no sandbox flag. Only the execute phase may mutate the tree, so
-  // it gets `--force` (auto-apply edits). Read-only phases omit it so the agent
-  // cannot write.
+  // This provider is execute-only (see `supports`) because Cursor has no
+  // read-only mode. Execute intentionally writes inside an isolated worktree, so
+  // it gets `--force` to auto-apply edits without prompting. The phase guard is
+  // defensive: if some caller ever invoked another phase directly, it would not
+  // receive auto-apply.
   if (req.phase === 'execute') args.push('--force');
   return { args, stdin: req.prompt };
 }

--- a/packages/agents/src/providers/cursor-cli-provider.ts
+++ b/packages/agents/src/providers/cursor-cli-provider.ts
@@ -213,7 +213,11 @@ function clampCursorFailure(rawOutput: string, prompt: string): string {
 export function createCursorCliProvider(processManager: ProcessManager): AgentProvider {
   return {
     id: 'cursor-cli',
-    supports: new Set<ProviderPhase>(['plan', 'review', 'revision', 'verify', 'execute']),
+    // Execute-only: Cursor's CLI cannot run read-only (its sandbox blocks writes
+    // outside the workspace but still allows in-worktree edits), so it must not
+    // drive plan/review/revision/verify, which the pipeline treats as read-only.
+    // Execute intentionally writes inside an isolated worktree.
+    supports: new Set<ProviderPhase>(['execute']),
     async generate(req: ProviderRequest): Promise<ProviderResponse> {
       const command = buildCursorCommand(req);
       const result = await runCursorCli(processManager, command, req);

--- a/packages/agents/src/providers/index.ts
+++ b/packages/agents/src/providers/index.ts
@@ -1,4 +1,5 @@
 export { createClaudeCliProvider, createCodexCliProvider } from './cli-provider';
+export { createCursorCliProvider } from './cursor-cli-provider';
 export { createGeminiCliProvider } from './gemini-cli-provider';
 export type {
   OpenRouterChatMessage,

--- a/packages/agents/src/providers/registry.test.ts
+++ b/packages/agents/src/providers/registry.test.ts
@@ -15,6 +15,9 @@ describe('createProviderRegistry', () => {
   const claude = makeProvider('claude-cli', ['plan', 'review', 'revision', 'verify', 'execute']);
   const codex = makeProvider('codex-cli', ['plan', 'review', 'revision', 'verify', 'execute']);
   const gemini = makeProvider('gemini-cli', ['plan', 'review', 'revision', 'verify', 'execute']);
+  // Cursor is execute-only: it has no read-only mode, so it must not drive the
+  // pipeline's read-only phases.
+  const cursor = makeProvider('cursor-cli', ['execute']);
   const openrouter = makeProvider('openrouter', [
     'plan',
     'review',
@@ -22,7 +25,7 @@ describe('createProviderRegistry', () => {
     'verify',
     'execute',
   ]);
-  const registry = createProviderRegistry({ claude, codex, gemini, openrouter });
+  const registry = createProviderRegistry({ claude, codex, gemini, cursor, openrouter });
 
   it('dispatches claude agent to claude-cli provider', () => {
     expect(registry.for('claude', 'plan')).toBe(claude);
@@ -49,6 +52,22 @@ describe('createProviderRegistry', () => {
     expect(registry.for('openrouter', 'plan')).toBe(openrouter);
     expect(registry.for('openrouter', 'verify')).toBe(openrouter);
     expect(registry.for('openrouter', 'execute')).toBe(openrouter);
+  });
+
+  it('dispatches cursor agent to cursor-cli provider for execute only', () => {
+    expect(registry.for('cursor', 'execute')).toBe(cursor);
+    expect(() => registry.for('cursor', 'plan')).toThrow(/does not support phase 'plan'/);
+    expect(() => registry.for('cursor', 'review')).toThrow(/does not support phase 'review'/);
+    expect(() => registry.for('cursor', 'verify')).toThrow(/does not support phase 'verify'/);
+  });
+
+  it('throws when cursor is requested but no cursor provider is registered', () => {
+    const withoutCursor = createProviderRegistry({ claude, codex, gemini, openrouter });
+
+    expect(() => withoutCursor.for('cursor', 'execute')).toThrow(
+      /provider for agent 'cursor' is not registered/,
+    );
+    expect(withoutCursor.all().has('cursor-cli')).toBe(false);
   });
 
   it('throws for gh agent (not an LLM)', () => {
@@ -84,7 +103,8 @@ describe('createProviderRegistry', () => {
     expect(all.get('claude-cli')).toBe(claude);
     expect(all.get('codex-cli')).toBe(codex);
     expect(all.get('gemini-cli')).toBe(gemini);
+    expect(all.get('cursor-cli')).toBe(cursor);
     expect(all.get('openrouter')).toBe(openrouter);
-    expect(all.size).toBe(4);
+    expect(all.size).toBe(5);
   });
 });

--- a/packages/agents/src/providers/registry.ts
+++ b/packages/agents/src/providers/registry.ts
@@ -11,6 +11,7 @@
  * - agent 'claude' → claude-cli provider (all phases)
  * - agent 'codex'  → codex-cli provider (all phases)
  * - agent 'gemini' → gemini-cli provider (all phases)
+ * - agent 'cursor' → cursor-cli provider (all phases)
  * - agent 'openrouter' → openrouter provider (plan/review/revision/verify only)
  * - agent 'gh' is not an LLM agent and is not handled here
  *
@@ -26,6 +27,7 @@ export interface RegistryProviders {
   claude: AgentProvider;
   codex: AgentProvider;
   gemini?: AgentProvider;
+  cursor?: AgentProvider;
   openrouter: AgentProvider;
 }
 
@@ -36,6 +38,7 @@ export function createProviderRegistry(providers: RegistryProviders): ProviderRe
     [providers.openrouter.id, providers.openrouter],
   ]);
   if (providers.gemini) byId.set(providers.gemini.id, providers.gemini);
+  if (providers.cursor) byId.set(providers.cursor.id, providers.cursor);
 
   function forAgent(agent: AgentType): AgentProvider {
     switch (agent) {
@@ -48,6 +51,11 @@ export function createProviderRegistry(providers: RegistryProviders): ProviderRe
           throw new Error("ProviderRegistry: provider for agent 'gemini' is not registered");
         }
         return providers.gemini;
+      case 'cursor':
+        if (!providers.cursor) {
+          throw new Error("ProviderRegistry: provider for agent 'cursor' is not registered");
+        }
+        return providers.cursor;
       case 'openrouter':
         return providers.openrouter;
       case 'gh':

--- a/packages/agents/src/providers/types.ts
+++ b/packages/agents/src/providers/types.ts
@@ -243,7 +243,7 @@ export interface ProviderResponse {
 }
 
 export interface AgentProvider {
-  readonly id: 'claude-cli' | 'codex-cli' | 'gemini-cli' | 'openrouter';
+  readonly id: 'claude-cli' | 'codex-cli' | 'gemini-cli' | 'cursor-cli' | 'openrouter';
   readonly supports: ReadonlySet<ProviderPhase>;
   generate(req: ProviderRequest): Promise<ProviderResponse>;
   healthCheck(): Promise<{ ok: boolean; reason?: string }>;

--- a/packages/shared/src/cli-model-capabilities.ts
+++ b/packages/shared/src/cli-model-capabilities.ts
@@ -1,6 +1,7 @@
 import {
   CLAUDE_MODEL_OPTIONS,
   CODEX_FALLBACK_MODEL_OPTIONS,
+  CURSOR_FALLBACK_MODEL_OPTIONS,
   GEMINI_FALLBACK_MODEL_OPTIONS,
   type KnownModelOption,
 } from './model-catalog';
@@ -41,7 +42,9 @@ export function fallbackCliModelCapabilities(
       ? CLAUDE_MODEL_OPTIONS
       : provider === 'codex'
         ? CODEX_FALLBACK_MODEL_OPTIONS
-        : GEMINI_FALLBACK_MODEL_OPTIONS;
+        : provider === 'gemini'
+          ? GEMINI_FALLBACK_MODEL_OPTIONS
+          : CURSOR_FALLBACK_MODEL_OPTIONS;
   return {
     provider,
     source: 'fallback',
@@ -51,7 +54,9 @@ export function fallbackCliModelCapabilities(
         ? null
         : provider === 'codex'
           ? 'Codex model catalog could not be read; using conservative ShipCode presets.'
-          : 'Gemini model catalog could not be read; using conservative ShipCode presets.',
+          : provider === 'gemini'
+            ? 'Gemini model catalog could not be read; using conservative ShipCode presets.'
+            : null,
     checkedAt,
   };
 }
@@ -119,7 +124,13 @@ export function assessCliModelAvailabilityFromCapabilities(
   }
 
   const providerLabel =
-    provider === 'claude' ? 'Claude CLI' : provider === 'codex' ? 'Codex CLI' : 'Gemini CLI';
+    provider === 'claude'
+      ? 'Claude CLI'
+      : provider === 'codex'
+        ? 'Codex CLI'
+        : provider === 'gemini'
+          ? 'Gemini CLI'
+          : 'Cursor CLI';
   const sourceDetail =
     capabilities.source === 'catalog'
       ? 'installed CLI catalog'
@@ -163,7 +174,15 @@ export function assessCliReasoningEffortAvailabilityFromCapabilities(
   const modelLabel = modelId ? ` for ${modelId}` : '';
   return {
     available: false,
-    message: `${provider === 'claude' ? 'Claude CLI' : provider === 'codex' ? 'Codex CLI' : 'Gemini CLI'} does not report ${effort} effort${modelLabel}. Choose a supported effort or update the CLI.`,
+    message: `${
+      provider === 'claude'
+        ? 'Claude CLI'
+        : provider === 'codex'
+          ? 'Codex CLI'
+          : provider === 'gemini'
+            ? 'Gemini CLI'
+            : 'Cursor CLI'
+    } does not report ${effort} effort${modelLabel}. Choose a supported effort or update the CLI.`,
   };
 }
 

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -21,6 +21,7 @@ export const PIPELINE_EXECUTOR_PROVIDERS = [
   'claude',
   'codex',
   'gemini',
+  'cursor',
   'openrouter',
 ] as const satisfies readonly ExecutorModel[];
 

--- a/packages/shared/src/model-catalog.test.ts
+++ b/packages/shared/src/model-catalog.test.ts
@@ -24,6 +24,9 @@ describe('model-catalog', () => {
       gemini: {
         phase: 'gemini-2.5-pro',
       },
+      cursor: {
+        phase: 'auto',
+      },
       openrouter: {
         paid: 'openrouter/auto',
         free: 'openrouter/free',

--- a/packages/shared/src/model-catalog.ts
+++ b/packages/shared/src/model-catalog.ts
@@ -29,6 +29,15 @@ export const GEMINI_FALLBACK_MODEL_IDS = {
 export type GeminiFallbackModelId =
   (typeof GEMINI_FALLBACK_MODEL_IDS)[keyof typeof GEMINI_FALLBACK_MODEL_IDS];
 
+// Cursor routes to an underlying model; ShipCode exposes only `auto` and lets
+// Cursor pick. Kept as a single-entry catalog to mirror the other providers.
+export const CURSOR_FALLBACK_MODEL_IDS = {
+  auto: 'auto',
+} as const;
+
+export type CursorFallbackModelId =
+  (typeof CURSOR_FALLBACK_MODEL_IDS)[keyof typeof CURSOR_FALLBACK_MODEL_IDS];
+
 export const OPENROUTER_MODEL_IDS = {
   autoPaid: 'openrouter/auto',
   autoFree: 'openrouter/free',
@@ -60,6 +69,10 @@ export const GEMINI_FALLBACK_MODEL_OPTIONS = [
   { value: GEMINI_FALLBACK_MODEL_IDS.flash, label: 'Gemini 2.5 Flash' },
 ] as const satisfies readonly KnownModelOption<GeminiFallbackModelId>[];
 
+export const CURSOR_FALLBACK_MODEL_OPTIONS = [
+  { value: CURSOR_FALLBACK_MODEL_IDS.auto, label: 'Auto' },
+] as const satisfies readonly KnownModelOption<CursorFallbackModelId>[];
+
 export const OPENROUTER_MODEL_OPTIONS = [
   { value: OPENROUTER_MODEL_IDS.autoPaid, label: 'Auto (paid)' },
   { value: OPENROUTER_MODEL_IDS.autoFree, label: 'Auto (free)' },
@@ -72,6 +85,7 @@ export type CuratedModelId =
   | (typeof CLAUDE_MODEL_OPTIONS)[number]['value']
   | (typeof CODEX_FALLBACK_MODEL_OPTIONS)[number]['value']
   | (typeof GEMINI_FALLBACK_MODEL_OPTIONS)[number]['value']
+  | (typeof CURSOR_FALLBACK_MODEL_OPTIONS)[number]['value']
   | (typeof OPENROUTER_MODEL_OPTIONS)[number]['value'];
 
 const CURATED_MODEL_LABELS = Object.fromEntries(
@@ -79,6 +93,7 @@ const CURATED_MODEL_LABELS = Object.fromEntries(
     ...CLAUDE_MODEL_OPTIONS,
     ...CODEX_FALLBACK_MODEL_OPTIONS,
     ...GEMINI_FALLBACK_MODEL_OPTIONS,
+    ...CURSOR_FALLBACK_MODEL_OPTIONS,
     ...OPENROUTER_MODEL_OPTIONS,
   ].map((option) => [option.value, option.label]),
 ) as Record<CuratedModelId, string>;
@@ -97,6 +112,9 @@ export const PINNED_MODEL_DEFAULTS = {
   gemini: {
     phase: GEMINI_FALLBACK_MODEL_IDS.pro,
   },
+  cursor: {
+    phase: CURSOR_FALLBACK_MODEL_IDS.auto,
+  },
   openrouter: {
     paid: OPENROUTER_MODEL_IDS.autoPaid,
     free: OPENROUTER_MODEL_IDS.autoFree,
@@ -108,6 +126,7 @@ export const KNOWN_MODEL_LABELS: Record<string, string> = {
   claude: CURATED_MODEL_LABELS[PINNED_MODEL_DEFAULTS.claude.phase],
   codex: CURATED_MODEL_LABELS[PINNED_MODEL_DEFAULTS.codex.phase],
   gemini: CURATED_MODEL_LABELS[PINNED_MODEL_DEFAULTS.gemini.phase],
+  cursor: CURATED_MODEL_LABELS[PINNED_MODEL_DEFAULTS.cursor.phase],
   openrouter: 'OpenRouter',
   ...CURATED_MODEL_LABELS,
   'anthropic/claude-sonnet-4-6': CURATED_MODEL_LABELS[OPENROUTER_MODEL_IDS.claudeSonnet46],

--- a/packages/shared/src/model-display.ts
+++ b/packages/shared/src/model-display.ts
@@ -6,6 +6,7 @@ export const PROVIDER_DISPLAY: Record<ExecutorModel, string> = {
   claude: 'Claude',
   codex: 'Codex',
   gemini: 'Gemini',
+  cursor: 'Cursor',
   openrouter: 'OpenRouter',
 };
 
@@ -13,6 +14,7 @@ export const MODEL_DISPLAY: Record<string, string> = { ...KNOWN_MODEL_LABELS };
 
 const CODEX_MODEL_PATTERN = /^gpt-5(?:[.-]|$)/i;
 const GEMINI_MODEL_PATTERN = /^gemini(?:[.-]|$)/i;
+const CURSOR_MODEL_PATTERN = /^cursor(?:[.-]|$)/i;
 
 function normalizeModel(value: string | null | undefined): string | null {
   const sanitized = sanitizeResolvedModel(value);
@@ -46,6 +48,10 @@ export function inferProviderFromModel(
 
     if (normalized === 'gemini' || GEMINI_MODEL_PATTERN.test(normalized)) {
       return 'gemini';
+    }
+
+    if (normalized === 'cursor' || CURSOR_MODEL_PATTERN.test(normalized)) {
+      return 'cursor';
     }
 
     if (

--- a/packages/shared/src/model-resolution.ts
+++ b/packages/shared/src/model-resolution.ts
@@ -149,6 +149,7 @@ const VALID_PHASE_PROVIDERS = [
   'claude',
   'codex',
   'gemini',
+  'cursor',
   'openrouter',
 ] as const satisfies readonly ExecutorModel[];
 
@@ -228,7 +229,13 @@ export function getPhaseDescriptor(phase: ResolvedPhaseModel): ResolvedPhaseDesc
 }
 
 function asExecutorModel(value: string | null | undefined): ExecutorModel | null {
-  if (value === 'claude' || value === 'codex' || value === 'gemini' || value === 'openrouter') {
+  if (
+    value === 'claude' ||
+    value === 'codex' ||
+    value === 'gemini' ||
+    value === 'cursor' ||
+    value === 'openrouter'
+  ) {
     return value;
   }
   return null;

--- a/packages/shared/src/model-resolution.ts
+++ b/packages/shared/src/model-resolution.ts
@@ -149,8 +149,16 @@ const VALID_PHASE_PROVIDERS = [
   'claude',
   'codex',
   'gemini',
-  'cursor',
   'openrouter',
+] as const satisfies readonly ExecutorModel[];
+
+// Cursor's CLI has no read-only mode (its sandbox only blocks writes outside
+// the workspace, not in-worktree edits), so it can only safely run the execute
+// phase, which intentionally writes inside an isolated worktree. Offering it for
+// plan/review/verify would let those read-only phases mutate the tree.
+const EXECUTOR_PHASE_PROVIDERS = [
+  ...VALID_PHASE_PROVIDERS,
+  'cursor',
 ] as const satisfies readonly ExecutorModel[];
 
 export const PHASE_DESCRIPTORS: readonly ResolvedPhaseDescriptor[] = [
@@ -195,7 +203,7 @@ export const PHASE_DESCRIPTORS: readonly ResolvedPhaseDescriptor[] = [
   {
     key: 'executor',
     label: 'Executor',
-    validProviders: VALID_PHASE_PROVIDERS,
+    validProviders: EXECUTOR_PHASE_PROVIDERS,
     settingsModelKey: 'executorModel',
     settingsModelIdKey: 'openrouterExecutorModel',
     settingsReasoningEffortKey: 'executorReasoningEffort',

--- a/packages/shared/src/reasoning-effort.ts
+++ b/packages/shared/src/reasoning-effort.ts
@@ -22,6 +22,10 @@ const GEMINI_REASONING_EFFORTS = [
   'high',
 ] as const satisfies readonly ReasoningEffort[];
 
+// Cursor's CLI does not expose a reasoning-effort control; the underlying
+// model decides. ShipCode therefore offers only `none` (send nothing).
+const CURSOR_REASONING_EFFORTS = ['none'] as const satisfies readonly ReasoningEffort[];
+
 const CLAUDE_REASONING_EFFORTS = [
   'none',
   'medium',
@@ -95,6 +99,10 @@ export function getSupportedReasoningEfforts(
 
   if (provider === 'gemini') {
     return GEMINI_REASONING_EFFORTS;
+  }
+
+  if (provider === 'cursor') {
+    return CURSOR_REASONING_EFFORTS;
   }
 
   if (normalizedModelId && OPENROUTER_ADAPTIVE_CLAUDE_MODELS.has(normalizedModelId)) {
@@ -173,6 +181,19 @@ export function resolveProviderReasoningEffort(
       };
     }
     return { configured, effective: configured, exact: true, message: null };
+  }
+
+  if (provider === 'cursor') {
+    if (configured === 'none') {
+      return { configured, effective: 'none', exact: true, message: null };
+    }
+    return {
+      configured,
+      effective: 'none',
+      exact: false,
+      message:
+        'Cursor selects reasoning automatically per model; ShipCode does not send a reasoning effort.',
+    };
   }
 
   if (normalizedModelId && OPENROUTER_NO_REASONING_MODELS.has(normalizedModelId)) {

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -705,7 +705,7 @@ export interface PipelineCheckpoint {
 
 // === Pipeline Types ===
 
-export type AgentType = 'claude' | 'codex' | 'gemini' | 'gh' | 'openrouter' | 'shell';
+export type AgentType = 'claude' | 'codex' | 'gemini' | 'cursor' | 'gh' | 'openrouter' | 'shell';
 
 /**
  * The subset of AgentType that can drive a pipeline phase. Excludes
@@ -722,11 +722,11 @@ export type AgentType = 'claude' | 'codex' | 'gemini' | 'gh' | 'openrouter' | 's
  *  - SQLite stores strings; no enum ⇄ ordinal round-trip needed.
  *  - GitHub label values are already strings (`shipcode:agent:claude`, etc).
  */
-export type ExecutorModel = 'claude' | 'codex' | 'gemini' | 'openrouter';
-export type TriageModel = Exclude<ExecutorModel, 'gemini'>;
+export type ExecutorModel = 'claude' | 'codex' | 'gemini' | 'cursor' | 'openrouter';
+export type TriageModel = Exclude<ExecutorModel, 'gemini' | 'cursor'>;
 export type ReasoningEffort = 'none' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
 export type GeneratorCli = 'claude' | 'codex';
-export type PhaseCliProvider = Extract<ExecutorModel, 'claude' | 'codex' | 'gemini'>;
+export type PhaseCliProvider = Extract<ExecutorModel, 'claude' | 'codex' | 'gemini' | 'cursor'>;
 export type ContextGeneratorCli = GeneratorCli;
 export type RevisionCount = 0 | 1 | 2 | 3 | 4 | 5;
 export type PipelineSpeedProfile = 'smart_fast' | 'thorough';
@@ -1372,6 +1372,7 @@ export interface SystemHealth {
   claude: CliHealth;
   codex: CliHealth;
   gemini?: CliHealth;
+  cursor?: CliHealth;
   git: CliHealth;
   gh: CliHealth;
 }

--- a/packages/ui/src/kanban-board/types.ts
+++ b/packages/ui/src/kanban-board/types.ts
@@ -80,7 +80,7 @@ export type BoardColumn = {
 
 export type IssuePhaseChip = {
   phase: ResolvedPhaseModel;
-  provider: 'claude' | 'codex' | 'gemini' | 'openrouter';
+  provider: 'claude' | 'codex' | 'gemini' | 'cursor' | 'openrouter';
   model: string;
   effort: string | null;
 };


### PR DESCRIPTION
## What

Adds **Cursor** as a first-class pipeline executor alongside `claude` / `codex` / `gemini`, backed by the headless `cursor-agent` CLI. Users can now select Cursor per phase (plan / review / revision / verify / execute) the same way Gemini works.

## Why

ShipCode already abstracts executors behind a provider registry. Cursor's `cursor-agent` runs non-interactively (`-p --output-format json`) with the same subprocess/stdin contract as the Gemini CLI, so it slots into the existing pattern cleanly and gives users another local executor.

## How

New `cursor-cli-provider.ts` mirrors the Gemini provider:
- Command: `cursor-agent -p --output-format json`; `--model <hint>` when set; `--force` **only** on the execute phase (read-only phases omit it so the agent can't write — Cursor has no sandbox flag).
- Parses the single JSON result object, with an NDJSON (stream-json) fallback and a plain-text fallback.
- `CURSOR_API_KEY` added to the env allowlist as an optional headless fallback.
- Exit-code → `providerError` mapping (127 binary-missing, 130 aborted, else retryable).

Wiring (mirrors every `gemini` touchpoint):
- `AgentType` / `ExecutorModel` / `PhaseCliProvider` gain `cursor`; **excluded** from `TriageModel` (triage stays claude/codex/openrouter).
- Provider registry, `process-manager` (`cursor-agent` binary allowlist + `CURSOR_API_KEY` env), `health-check` (`checkCursorAuth` via `cursor-agent status`, install detection, model-capabilities), agents index re-exports.
- Desktop: main registry instantiation, support-handler labels/colors, model-provider options, settings phase rows, Integrations "Cursor CLI" status row, kanban provider union.
- Shared: model-catalog (`auto`-only), model-display, model-resolution, cli-model-capabilities, reasoning-effort (no effort control → `none`).

## Decisions

- **Models:** `auto` only — Cursor routes to the underlying model.
- **Auth:** uses the installed CLI's own stored credentials (`cursor-agent login`); `CURSOR_API_KEY` is an optional headless fallback. Integrations shows install/auth status, no key-entry field.
- **Binary:** `cursor-agent` (canonical install name).

## Tests / verification

- New `cursor-cli-provider.test.ts` (19 tests): per-phase command building, `--force` gating, JSON + NDJSON parsing, failure clamp, exit-code mapping, abort, env allowlist, terminal events.
- Updated affected fixtures/assertions (`model-catalog`, `SettingsLeafSections`, `main/index` provider mock).
- Full monorepo `typecheck` green; full `test` suite green across all packages (serialized).
- Biome-clean on all changed files.

## Reviewer notes

- The exact `cursor-agent --model` flag name and JSON result shape come from Cursor's docs — worth one real `cursor-agent login` + plan-phase smoke run before relying on it in production.
- Out of scope: Cursor as a context/PRD generator, Cursor in triage, multiple/curated Cursor models.
