### PR TITLE
feat(pipeline): isolate runProviderPhase behind a frozen snapshot (#135)

### DIFF
--- a/packages/pipeline/src/pipeline/context.test.ts
+++ b/packages/pipeline/src/pipeline/context.test.ts
@@ -1,7 +1,12 @@
 import { DEFAULT_SETTINGS, PIPELINE_PHASE } from '@shipcode/shared';
 import { describe, expect, it, vi } from 'vitest';
 import type { PipelineContext } from '../types';
-import { createPipelineContextHelpers, resetPhaseState, snapshotPhaseInput } from './context';
+import {
+  createPipelineContextHelpers,
+  resetPhaseState,
+  snapshotPhaseInput,
+  snapshotProviderPhaseInput,
+} from './context';
 
 describe('resetPhaseState', () => {
   it('clears phase-local context fields', () => {
@@ -100,6 +105,57 @@ describe('snapshotPhaseInput', () => {
       githubRepo: 'shipshitdev/shipcode',
       autonomous: true,
     });
+    expect(Object.isFrozen(snapshot)).toBe(true);
+  });
+});
+
+describe('snapshotProviderPhaseInput', () => {
+  it('captures execution-context fields, slices the phase summary, and excludes phase-local state', () => {
+    const abort = new AbortController();
+    const context = {
+      threadId: 'thread-1',
+      projectPath: '/repo',
+      projectId: 'project-1',
+      worktreePath: '/worktree',
+      baseBranch: 'main',
+      forkPointSha: 'abc123',
+      githubIssueNumber: 42,
+      githubIssueTitle: 'Issue title',
+      githubRepo: 'shipshitdev/shipcode',
+      autonomous: true,
+      runId: 'run-1',
+      abort,
+      promptTelemetry: [{}],
+      promptMaterialSummaries: {
+        plan: { totalMaterials: 3 },
+        review: { totalMaterials: 9 },
+      },
+      executorModel: 'claude',
+      plannerModel: 'codex',
+      reviewerModel: 'openrouter',
+      verifierModel: 'claude',
+      executorModelOverride: 'openrouter/auto',
+      plannerModelIdOverride: 'claude-opus',
+      reviewerModelIdOverride: null,
+      executorModelIdOverride: null,
+      verifierModelIdOverride: null,
+      stabilizationFeedback: 'must not leak',
+    } as unknown as PipelineContext;
+
+    const snapshot = snapshotProviderPhaseInput(context, 'plan');
+
+    expect(snapshot.threadId).toBe('thread-1');
+    expect(snapshot.runId).toBe('run-1');
+    // The live signal is captured, not the controller.
+    expect(snapshot.abort).toBe(abort.signal);
+    // Counter is the length at snapshot time (next attempt is this + 1).
+    expect(snapshot.promptTelemetryCount).toBe(1);
+    // Only the requested phase's summary is carried, not the whole record.
+    expect(snapshot.promptMaterialSummary).toEqual({ totalMaterials: 3 });
+    expect(snapshot.plannerModel).toBe('codex');
+    expect(snapshot.executorModelOverride).toBe('openrouter/auto');
+    // Phase-local context must not bleed into the provider snapshot.
+    expect('stabilizationFeedback' in snapshot).toBe(false);
     expect(Object.isFrozen(snapshot)).toBe(true);
   });
 });

--- a/packages/pipeline/src/pipeline/context.ts
+++ b/packages/pipeline/src/pipeline/context.ts
@@ -1,4 +1,5 @@
 import {
+  type ProviderPhase,
   type ResolveResult,
   resolvePhaseReasoningEffort,
   type SkillValidationError,
@@ -19,6 +20,7 @@ import {
   type PipelineContext,
   type PipelineDeps,
   type PipelineExecutorModel,
+  type ProviderPhaseInput,
 } from '../types';
 import { loadWorkflowPolicy } from '../workflow-loader';
 import type { PipelineContextHelpers } from './shared';
@@ -39,6 +41,48 @@ export function snapshotPhaseInput(context: PipelineContext): PhaseInput {
     githubIssueTitle: context.githubIssueTitle,
     githubRepo: context.githubRepo,
     autonomous: context.autonomous,
+  });
+}
+
+/**
+ * Create a frozen `ProviderPhaseInput` for a single `runProviderPhaseCore`
+ * call. Extends the identity snapshot with the execution-context fields the
+ * provider call reads: models, run id, the live abort signal, the phase's
+ * prompt-material summary, and the prompt-telemetry counter.
+ *
+ * `promptTelemetryCount` captures `promptTelemetry.length` at this instant.
+ * The caller must apply the returned telemetry delta to context with no
+ * intervening `await` that could push to `promptTelemetry`, or the count
+ * goes stale (the `runProviderPhase` wrapper upholds this).
+ */
+export function snapshotProviderPhaseInput(
+  context: PipelineContext,
+  phase: ProviderPhase,
+): ProviderPhaseInput {
+  return Object.freeze({
+    threadId: context.threadId,
+    projectPath: context.projectPath,
+    projectId: context.projectId,
+    worktreePath: context.worktreePath,
+    baseBranch: context.baseBranch,
+    forkPointSha: context.forkPointSha,
+    githubIssueNumber: context.githubIssueNumber,
+    githubIssueTitle: context.githubIssueTitle,
+    githubRepo: context.githubRepo,
+    autonomous: context.autonomous,
+    runId: context.runId,
+    abort: context.abort.signal,
+    promptTelemetryCount: context.promptTelemetry.length,
+    promptMaterialSummary: context.promptMaterialSummaries[phase],
+    executorModel: context.executorModel,
+    plannerModel: context.plannerModel,
+    reviewerModel: context.reviewerModel,
+    verifierModel: context.verifierModel,
+    executorModelOverride: context.executorModelOverride,
+    plannerModelIdOverride: context.plannerModelIdOverride,
+    reviewerModelIdOverride: context.reviewerModelIdOverride,
+    executorModelIdOverride: context.executorModelIdOverride,
+    verifierModelIdOverride: context.verifierModelIdOverride,
   });
 }
 

--- a/packages/pipeline/src/pipeline/runtime.test.ts
+++ b/packages/pipeline/src/pipeline/runtime.test.ts
@@ -5,6 +5,7 @@ import { type AgentProvider, GhCli } from '@shipcode/agents/source';
 import { DEFAULT_SETTINGS } from '@shipcode/shared';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PipelineContext, PipelineDeps } from '../types';
+import { snapshotProviderPhaseInput } from './context';
 import { buildFrozenInstallFallback, createPipelineRuntime, resolveSetupShell } from './runtime';
 
 const { mockExecFile, mockLoadRepoSetupContract, mockGhCli } = vi.hoisted(() => ({
@@ -1333,6 +1334,93 @@ describe('createPipelineRuntime', () => {
       message: 'telemetry string failure',
       nonFatal: true,
     });
+  });
+
+  it('runProviderPhaseCore does not mutate context and returns telemetry deltas', async () => {
+    const provider: AgentProvider = {
+      id: 'claude-cli',
+      supports: new Set(['plan']),
+      generate: vi.fn(async () => ({ rawOutput: 'done', exitCode: 0 })),
+      healthCheck: vi.fn(async () => ({ ok: true })),
+    };
+    const { deps } = makeDeps(provider);
+    const runtime = createPipelineRuntime(deps, {} as never);
+    const context = makeContext();
+    const input = snapshotProviderPhaseInput(context, 'plan');
+
+    const result = await runtime.runProviderPhaseCore(input, 'plan', 'prompt', [], {});
+
+    // The pure core leaves the mutable context untouched...
+    expect(context.promptTelemetry).toHaveLength(0);
+    expect(context.promptTelemetryDiagnostics).toHaveLength(0);
+    // ...and surfaces the mutation it would have made as deltas instead.
+    expect(result.deltas.promptTelemetry).toBeDefined();
+    expect(result.deltas.diagnosticEntry).toBeNull();
+  });
+
+  it('runProviderPhase wrapper applies the telemetry delta to context', async () => {
+    const provider: AgentProvider = {
+      id: 'claude-cli',
+      supports: new Set(['plan']),
+      generate: vi.fn(async () => ({ rawOutput: 'done', exitCode: 0 })),
+      healthCheck: vi.fn(async () => ({ ok: true })),
+    };
+    const { deps } = makeDeps(provider);
+    const runtime = createPipelineRuntime(deps, {} as never);
+    const context = makeContext();
+
+    await runtime.runProviderPhase(context, 'plan', 'prompt', [], {});
+
+    expect(context.promptTelemetry).toHaveLength(1);
+  });
+
+  it('threads the post-push telemetry counter into invocationId and attempt', async () => {
+    const provider: AgentProvider = {
+      id: 'claude-cli',
+      supports: new Set(['plan']),
+      generate: vi.fn(async () => ({ rawOutput: 'done', exitCode: 0 })),
+      healthCheck: vi.fn(async () => ({ ok: true })),
+    };
+    const { deps } = makeDeps(provider);
+    const runtime = createPipelineRuntime(deps, {} as never);
+    const context = makeContext();
+    // One prior telemetry entry → this invocation is attempt 2.
+    context.promptTelemetry.push({} as never);
+
+    await runtime.runProviderPhase(context, 'plan', 'prompt', [], {});
+
+    expect(deps.promptTelemetry?.create).toHaveBeenCalledWith(
+      expect.objectContaining({ invocationId: 'thread-1:plan:2', attempt: 2 }),
+    );
+    // Wrapper appended this invocation's entry on top of the pre-seeded one.
+    expect(context.promptTelemetry).toHaveLength(2);
+  });
+
+  it('runProviderPhaseCore returns a diagnostic delta without mutating context', async () => {
+    const provider: AgentProvider = {
+      id: 'claude-cli',
+      supports: new Set(['plan']),
+      generate: vi.fn(async () => ({ rawOutput: 'done', exitCode: 0 })),
+      healthCheck: vi.fn(async () => ({ ok: true })),
+    };
+    const { deps } = makeDeps(provider);
+    deps.promptTelemetry = {
+      create: vi.fn(() => {
+        throw new Error('telemetry offline');
+      }),
+    } as never;
+    const runtime = createPipelineRuntime(deps, {} as never);
+    const context = makeContext();
+    const input = snapshotProviderPhaseInput(context, 'plan');
+
+    const result = await runtime.runProviderPhaseCore(input, 'plan', 'prompt', [], {});
+
+    expect(result.deltas.diagnosticEntry).toEqual({
+      phase: 'plan',
+      message: 'telemetry offline',
+      nonFatal: true,
+    });
+    expect(context.promptTelemetryDiagnostics).toHaveLength(0);
   });
 
   it('keeps provider exception handling nonfatal when error logging fails', async () => {

--- a/packages/pipeline/src/pipeline/runtime.ts
+++ b/packages/pipeline/src/pipeline/runtime.ts
@@ -26,7 +26,14 @@ import {
 } from '@shipcode/shared/source';
 import { GhSyncQueue, type GhSyncWriteOpts } from '../gh-sync-queue';
 import { syncThreadAndIssuePhase } from '../phase-sync';
-import type { PipelineContext, PipelineDeps, PipelineExecutorModel } from '../types';
+import type {
+  PipelineContext,
+  PipelineDeps,
+  PipelineExecutorModel,
+  ProviderPhaseDeltas,
+  ProviderPhaseInput,
+} from '../types';
+import { snapshotProviderPhaseInput } from './context';
 import type { PipelineContextHelpers, PipelineRuntime } from './shared';
 
 const execFileAsync = promisify(execFile);
@@ -531,25 +538,35 @@ export function createPipelineRuntime(
   }
 
   function resolveAgentForPhase(
-    context: PipelineContext,
+    input: Pick<
+      ProviderPhaseInput,
+      'plannerModel' | 'reviewerModel' | 'verifierModel' | 'executorModel'
+    >,
     phase: ProviderPhase,
   ): PipelineExecutorModel {
     switch (phase) {
       case 'plan':
       case 'revision':
-        return context.plannerModel;
+        return input.plannerModel;
       case 'review':
-        return context.reviewerModel;
+        return input.reviewerModel;
       case 'verify':
-        return context.verifierModel;
+        return input.verifierModel;
       case 'execute':
-        if (context.executorModel) return context.executorModel;
+        if (input.executorModel) return input.executorModel;
         return 'claude';
     }
   }
 
-  async function runProviderPhase(
-    context: PipelineContext,
+  /**
+   * Pure provider-phase execution. Reads only the frozen `ProviderPhaseInput`
+   * snapshot — never the mutable `PipelineContext` — and returns the context
+   * mutations it would have made (`deltas`) for the orchestrator to apply.
+   * The `runProviderPhase` wrapper (and, later, the #137 dispatch loop) owns
+   * snapshotting and delta application.
+   */
+  async function runProviderPhaseCore(
+    input: ProviderPhaseInput,
     phase: ProviderPhase,
     prompt: string,
     promptMaterials: PromptMaterial[],
@@ -560,27 +577,28 @@ export function createPipelineRuntime(
     resolvedModel?: string;
     promptTelemetry?: import('@shipcode/agents/source').PhasePromptTelemetry;
     clarificationRequest?: import('@shipcode/shared').ClarificationRequest;
+    deltas: ProviderPhaseDeltas;
   }> {
-    const agent = resolveAgentForPhase(context, phase);
+    const agent = resolveAgentForPhase(input, phase);
     const provider = deps.providers.for(agent, phase);
     // When a GitHub issue is resumed, planning/review should inspect the same
     // worktree that already contains in-progress changes instead of the clean
     // project root.
-    const cwd = context.worktreePath ?? context.projectPath;
+    const cwd = input.worktreePath ?? input.projectPath;
     const modelHint = (() => {
-      if (agent === context.executorModel && context.executorModelOverride) {
-        return context.executorModelOverride;
+      if (agent === input.executorModel && input.executorModelOverride) {
+        return input.executorModelOverride;
       }
       switch (phase) {
         case 'plan':
         case 'revision':
-          return context.plannerModelIdOverride;
+          return input.plannerModelIdOverride;
         case 'review':
-          return context.reviewerModelIdOverride;
+          return input.reviewerModelIdOverride;
         case 'execute':
-          return context.executorModelIdOverride;
+          return input.executorModelIdOverride;
         case 'verify':
-          return context.verifierModelIdOverride;
+          return input.verifierModelIdOverride;
       }
     })();
 
@@ -600,10 +618,10 @@ export function createPipelineRuntime(
       try {
         return (
           deps.pipelineSteps?.start({
-            threadId: context.threadId,
-            runId: context.runId,
+            threadId: input.threadId,
+            runId: input.runId,
             phase,
-            attempt: context.promptTelemetry.length + 1,
+            attempt: input.promptTelemetryCount + 1,
             provider: provider.id,
             requestedModel: modelHint ?? agent,
           }) ?? null
@@ -620,10 +638,10 @@ export function createPipelineRuntime(
       try {
         return (
           deps.agentConversations?.insert({
-            threadId: context.threadId,
-            runId: context.runId,
+            threadId: input.threadId,
+            runId: input.runId,
             phase,
-            round: context.promptTelemetry.length,
+            round: input.promptTelemetryCount,
             speaker: 'pipeline',
             role: 'prompt',
             provider: provider.id,
@@ -642,17 +660,17 @@ export function createPipelineRuntime(
       // Defense in depth: only assert workspace shape when running inside a
       // worktree. Plan/review for issues that haven't materialized a
       // worktree yet still spawn at the project root and skip the check.
-      const workspaceRoot = context.worktreePath ? deps.settings.get().worktreeRoot : undefined;
+      const workspaceRoot = input.worktreePath ? deps.settings.get().worktreeRoot : undefined;
       response = await provider.generate({
         phase,
         prompt,
         cwd,
-        projectPath: context.projectPath,
-        signal: context.abort.signal,
+        projectPath: input.projectPath,
+        signal: input.abort,
         phaseHints: mergedHints,
-        promptMaterialSummary: context.promptMaterialSummaries[phase],
+        promptMaterialSummary: input.promptMaterialSummary,
         modelHint: modelHint ?? undefined,
-        threadId: context.threadId,
+        threadId: input.threadId,
         ...(workspaceRoot !== undefined ? { workspaceRoot } : {}),
         githubGraphql: {
           // Token read happens at tool-call time, not now — captures
@@ -660,7 +678,7 @@ export function createPipelineRuntime(
           getToken: () => readGhAuthToken(),
           getDefaultRepo: async () => {
             try {
-              const { githubRepoFullName } = await new GhCli(context.projectPath).getRepoMetadata();
+              const { githubRepoFullName } = await new GhCli(input.projectPath).getRepoMetadata();
               const [owner, repo] = githubRepoFullName.split('/');
               if (!owner || !repo) return null;
               return { owner, repo };
@@ -672,22 +690,22 @@ export function createPipelineRuntime(
         onTerminalEvent: (event) =>
           deps.emitter.emit({
             type: 'terminal:event',
-            threadId: context.threadId,
-            ...(context.runId ? { runId: context.runId } : {}),
+            threadId: input.threadId,
+            ...(input.runId ? { runId: input.runId } : {}),
             event,
           }),
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      const aborted = context.abort.signal.aborted || /abort/i.test(message);
+      const aborted = input.abort.aborted || /abort/i.test(message);
 
       // Conversation log: write synthetic error response row.
       try {
         deps.agentConversations?.insert({
-          threadId: context.threadId,
-          runId: context.runId,
+          threadId: input.threadId,
+          runId: input.runId,
           phase,
-          round: context.promptTelemetry.length,
+          round: input.promptTelemetryCount,
           speaker: 'pipeline',
           role: 'response',
           parentId: promptConvRow?.id ?? null,
@@ -715,10 +733,10 @@ export function createPipelineRuntime(
     // Conversation log: write the provider response row.
     try {
       deps.agentConversations?.insert({
-        threadId: context.threadId,
-        runId: context.runId,
+        threadId: input.threadId,
+        runId: input.runId,
         phase,
-        round: context.promptTelemetry.length,
+        round: input.promptTelemetryCount,
         speaker: provider.id,
         role: 'response',
         parentId: promptConvRow?.id ?? null,
@@ -768,14 +786,18 @@ export function createPipelineRuntime(
       prompt,
       materials: promptMaterials,
     });
-    context.promptTelemetry.push(promptTelemetry);
+    // Mutation delta, applied to context by the caller. The "+ 1" reproduces
+    // the old post-push `promptTelemetry.length` (count at snapshot time, plus
+    // this very entry) used for invocationId/attempt.
+    const deltas: ProviderPhaseDeltas = { promptTelemetry, diagnosticEntry: null };
+    const nextAttempt = input.promptTelemetryCount + 1;
     try {
       deps.promptTelemetry?.create({
-        threadId: context.threadId,
-        runId: context.runId,
+        threadId: input.threadId,
+        runId: input.runId,
         phase,
-        invocationId: `${context.threadId}:${phase}:${context.promptTelemetry.length}`,
-        attempt: context.promptTelemetry.length,
+        invocationId: `${input.threadId}:${phase}:${nextAttempt}`,
+        attempt: nextAttempt,
         provider: provider.id,
         model: response.resolvedModel ?? modelHint ?? agent,
         promptCharacters: promptTelemetry.promptSize.characters,
@@ -790,21 +812,21 @@ export function createPipelineRuntime(
       });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      context.promptTelemetryDiagnostics.push({ phase, message, nonFatal: true });
+      deltas.diagnosticEntry = { phase, message, nonFatal: true };
       console.error('[pipeline] prompt telemetry persistence failed:', error);
     }
 
     if (response.resolvedModel) {
       const requestedModel = modelHint ?? agent;
       try {
-        deps.threads.setResolvedModel(context.threadId, phase, response.resolvedModel);
+        deps.threads.setResolvedModel(input.threadId, phase, response.resolvedModel);
       } catch (error) {
         console.error('[pipeline] setResolvedModel failed:', error);
       }
       if (response.tokensUsed) {
         try {
           deps.threads.addTokenUsage(
-            context.threadId,
+            input.threadId,
             response.tokensUsed.prompt,
             response.tokensUsed.completion,
             response.costUsd ?? 0,
@@ -815,8 +837,8 @@ export function createPipelineRuntime(
       }
       deps.emitter.emit({
         type: 'pipeline:model-resolved',
-        threadId: context.threadId,
-        ...(context.runId ? { runId: context.runId } : {}),
+        threadId: input.threadId,
+        ...(input.runId ? { runId: input.runId } : {}),
         phase,
         requestedModel,
         resolvedModel: response.resolvedModel,
@@ -831,7 +853,43 @@ export function createPipelineRuntime(
       resolvedModel: response.resolvedModel,
       promptTelemetry,
       clarificationRequest: response.clarificationRequest,
+      deltas,
     };
+  }
+
+  /**
+   * Orchestrator seam: snapshot the mutable context into a frozen
+   * `ProviderPhaseInput`, run the pure core, then apply the returned mutation
+   * deltas back to context. No `await` sits between snapshot and apply, so the
+   * `promptTelemetryCount` captured in the snapshot stays consistent with the
+   * push below.
+   */
+  async function runProviderPhase(
+    context: PipelineContext,
+    phase: ProviderPhase,
+    prompt: string,
+    promptMaterials: PromptMaterial[],
+    phaseHints: ProviderRequest['phaseHints'],
+  ): Promise<{
+    rawOutput: string;
+    exitCode: number;
+    resolvedModel?: string;
+    promptTelemetry?: import('@shipcode/agents/source').PhasePromptTelemetry;
+    clarificationRequest?: import('@shipcode/shared').ClarificationRequest;
+  }> {
+    const input = snapshotProviderPhaseInput(context, phase);
+    const { deltas, ...response } = await runProviderPhaseCore(
+      input,
+      phase,
+      prompt,
+      promptMaterials,
+      phaseHints,
+    );
+    context.promptTelemetry.push(deltas.promptTelemetry);
+    if (deltas.diagnosticEntry !== null) {
+      context.promptTelemetryDiagnostics.push(deltas.diagnosticEntry);
+    }
+    return response;
   }
 
   /** Perform the actual GH write for a single state snapshot. */
@@ -1147,6 +1205,7 @@ export function createPipelineRuntime(
     formatTestFixFeedback,
     resolveAgentForPhase,
     runProviderPhase,
+    runProviderPhaseCore,
     emitPhase,
     postPlanComment,
     postTaskGraphComment,

--- a/packages/pipeline/src/pipeline/shared.ts
+++ b/packages/pipeline/src/pipeline/shared.ts
@@ -18,6 +18,8 @@ import type {
   PipelineContext,
   PipelineDeps,
   PipelineExecutorModel,
+  ProviderPhaseDeltas,
+  ProviderPhaseInput,
 } from '../types';
 
 export interface PipelineContextHelpers {
@@ -79,6 +81,27 @@ export interface PipelineRuntime {
     exitCode: number;
     resolvedModel?: string;
     clarificationRequest?: ClarificationRequest;
+  }>;
+  /**
+   * Pure variant of `runProviderPhase`: reads a frozen `ProviderPhaseInput`
+   * snapshot and returns the context mutations as `deltas` for the caller to
+   * apply. The orchestrator dispatch loop (#137) drives this directly.
+   */
+  runProviderPhaseCore: (
+    input: ProviderPhaseInput,
+    phase: ProviderPhase,
+    prompt: string,
+    promptMaterials: PromptMaterial[],
+    phaseHints: {
+      maxTurns?: number;
+      reasoningEffort?: PipelineContext['plannerReasoningEffort'];
+    },
+  ) => Promise<{
+    rawOutput: string;
+    exitCode: number;
+    resolvedModel?: string;
+    clarificationRequest?: ClarificationRequest;
+    deltas: ProviderPhaseDeltas;
   }>;
   emitPhase: (
     threadId: string,

--- a/packages/pipeline/src/types.ts
+++ b/packages/pipeline/src/types.ts
@@ -361,6 +361,45 @@ export interface PhaseInput {
 }
 
 /**
+ * Frozen input for a single `runProviderPhaseCore` call. Extends the identity
+ * snapshot (`PhaseInput`) with the execution-context fields the provider call
+ * needs — models, run id, abort signal, the phase's prompt-material summary,
+ * and the prompt-telemetry counter captured at call time. The core reads only
+ * this; it never touches the mutable `PipelineContext`. Mutations flow back out
+ * via `ProviderPhaseDeltas`, which the orchestrator (the `runProviderPhase`
+ * wrapper, and later the #137 dispatch loop) applies to context.
+ */
+export interface ProviderPhaseInput extends PhaseInput {
+  readonly runId: string | null;
+  /** The live signal (not the controller) so the core can read `.aborted`. */
+  readonly abort: AbortSignal;
+  /** `promptTelemetry.length` at snapshot time; the next attempt is this + 1. */
+  readonly promptTelemetryCount: number;
+  /** Pre-sliced summary for this phase from `promptMaterialSummaries[phase]`. */
+  readonly promptMaterialSummary: PromptMaterialSummary | undefined;
+  readonly executorModel: PipelineExecutorModel;
+  readonly plannerModel: PipelineExecutorModel;
+  readonly reviewerModel: PipelineExecutorModel;
+  readonly verifierModel: PipelineExecutorModel;
+  readonly executorModelOverride: string | null;
+  readonly plannerModelIdOverride: string | null;
+  readonly reviewerModelIdOverride: string | null;
+  readonly executorModelIdOverride: string | null;
+  readonly verifierModelIdOverride: string | null;
+}
+
+/**
+ * Context mutations produced by a `runProviderPhaseCore` call, returned instead
+ * of being applied directly. The orchestrator appends `promptTelemetry` to
+ * `context.promptTelemetry`, and — only when telemetry persistence failed —
+ * appends `diagnosticEntry` to `context.promptTelemetryDiagnostics`.
+ */
+export interface ProviderPhaseDeltas {
+  promptTelemetry: PhasePromptTelemetry;
+  diagnosticEntry: PromptTelemetryPersistenceDiagnostic | null;
+}
+
+/**
  * Fields on PipelineContext that are scoped to a single phase and should be
  * cleared between transitions. `resetPhaseState` nulls these before handing
  * control to the next phase handler.


### PR DESCRIPTION
## What

Splits `runProviderPhase` into a **pure core** (`runProviderPhaseCore`) plus a thin **orchestrator seam** (the `runProviderPhase` wrapper) so provider-phase execution reads a frozen, scoped snapshot instead of mutating the shared `PipelineContext`. Mutations flow back out as return-value deltas the wrapper applies.

First concrete step of the subagent-architecture epic #126 → sub-issue #135.

## Why

`PipelineContext` is a single mutable object threaded through every phase. For context isolation (clean retries, cheaper orchestration, future cloud/multi-pipeline runtimes) the provider call must not mutate orchestrator state directly. This lands that boundary and produces the independently-callable pure core that the next step (#137, orchestrator dispatch loop) will drive directly.

> Note: issue #135 estimated "~30 lines, low risk." Inspection showed `runProviderPhase` actually **mutates** context twice (`promptTelemetry` / `promptTelemetryDiagnostics` pushes) and **reads ~14 fields absent from the existing `PhaseInput`** (models, runId, abort, summaries, telemetry counter). This is the honest version of that change.

## Changes

- **`types.ts`** — `ProviderPhaseInput` (frozen: identity fields + models/overrides, `runId`, `AbortSignal`, phase-sliced `promptMaterialSummary`, `promptTelemetryCount`) and `ProviderPhaseDeltas` (`promptTelemetry` + optional `diagnosticEntry`). `PhaseInput` untouched.
- **`context.ts`** — `snapshotProviderPhaseInput(context, phase)`; captures `abort.signal` (the live signal, not the controller) and `promptTelemetry.length` at call time.
- **`runtime.ts`** — body becomes pure `runProviderPhaseCore(input, …)`: every `context.X` read → `input.X`; the two array pushes → returned `deltas`; post-push telemetry counter made explicit as `promptTelemetryCount + 1`. Public `runProviderPhase(context, …)` is now an 8-line wrapper (snapshot → core → apply deltas). `resolveAgentForPhase` retyped to a structural `Pick` (assignment-safe both directions). `runProviderPhaseCore` exposed on the runtime object.
- **`shared.ts`** — `PipelineRuntime` gains `runProviderPhaseCore`; `runProviderPhase` signature unchanged.

## Reviewer notes

- **Zero churn at the 6 production callers** (planning-phases / execution-phases) and their tests — the public wrapper still takes `context`.
- **Telemetry counter is the subtle bit:** the old code read `promptTelemetry.length` *after* the push for `invocationId`/`attempt`. The core reproduces this as `promptTelemetryCount + 1` — guarded by a new test asserting `invocationId: 'thread-1:plan:2'`, `attempt: 2`.
- TOCTOU on the counter is a pre-existing property: no `await` sits between snapshot and delta-apply in the wrapper.

## Tests / verification

- New: core no-mutation + returns deltas; wrapper applies delta; counter threading; diagnostic-delta path (`runtime.test.ts`); `snapshotProviderPhaseInput` shape/freeze/phase-local-exclusion (`context.test.ts`).
- `tsc --noEmit` clean; full pipeline package **468 pass / 7 skipped**; coverage gate passed — lines 97.11 / statements 96.67 / functions 99.21 / branches 91.64 (gate 95/95/95/90); biome clean.

## Scope

Out of scope: #136 (context split), #137 (dispatch loop), model-resolution restructuring. This lands the pure core + isolation seam only.