### PR TITLE
feat(pipeline): split PipelineContext into OrchestratorState + PhasePayload (#136)

### DIFF
--- a/packages/pipeline/src/pipeline/context.test.ts
+++ b/packages/pipeline/src/pipeline/context.test.ts
@@ -1,7 +1,8 @@
 import { DEFAULT_SETTINGS, PIPELINE_PHASE } from '@shipcode/shared';
 import { describe, expect, it, vi } from 'vitest';
-import type { PipelineContext } from '../types';
+import type { OrchestratorState, PipelineContext } from '../types';
 import {
+  buildPhasePayload,
   createPipelineContextHelpers,
   resetPhaseState,
   snapshotPhaseInput,
@@ -157,6 +158,138 @@ describe('snapshotProviderPhaseInput', () => {
     // Phase-local context must not bleed into the provider snapshot.
     expect('stabilizationFeedback' in snapshot).toBe(false);
     expect(Object.isFrozen(snapshot)).toBe(true);
+  });
+});
+
+describe('buildPhasePayload', () => {
+  function makeContext(abort = new AbortController()): PipelineContext {
+    return {
+      threadId: 'thread-1',
+      projectPath: '/repo',
+      projectId: 'project-1',
+      worktreePath: '/worktree',
+      baseBranch: 'main',
+      forkPointSha: 'abc123',
+      githubIssueNumber: 42,
+      githubIssueTitle: 'Issue title',
+      githubRepo: 'shipshitdev/shipcode',
+      autonomous: true,
+      runId: 'run-1',
+      isAutomationRun: true,
+      abort,
+      plannerModel: 'codex',
+      reviewerModel: 'openrouter',
+      verifierModel: 'openrouter',
+      executorModel: 'claude',
+      plannerModelIdOverride: 'claude-opus',
+      reviewerModelIdOverride: 'or-review',
+      verifierModelIdOverride: 'or-verify',
+      executorModelIdOverride: 'claude-exec-id',
+      executorModelOverride: 'openrouter/auto',
+      phaseReasoningEfforts: {
+        plan: 'high',
+        review: 'medium',
+        revision: 'low',
+        verify: 'medium',
+        execute: 'low',
+      },
+      repoContext: 'repo context',
+      repoPromptMaterials: [{ kind: 'repoContextFile' }],
+      promptMaterialSummaries: {
+        plan: { totalMaterials: 3 },
+        execute: { totalMaterials: 7 },
+      },
+      // Phase-local fields that must never appear in the payload.
+      stabilizationFeedback: 'must not leak',
+      testOutput: 'must not leak',
+    } as unknown as PipelineContext;
+  }
+
+  it('snapshots identity, materials, and the plan-phase model/effort', () => {
+    const abort = new AbortController();
+    const payload = buildPhasePayload(makeContext(abort), 'plan');
+
+    expect(payload.threadId).toBe('thread-1');
+    expect(payload.worktreePath).toBe('/worktree');
+    expect(payload.runId).toBe('run-1');
+    expect(payload.isAutomationRun).toBe(true);
+    expect(payload.phase).toBe('plan');
+    expect(payload.repoContext).toBe('repo context');
+    // plan resolves to plannerModel; its id override applies (not the executor's).
+    expect(payload.model).toBe('codex');
+    expect(payload.modelIdOverride).toBe('claude-opus');
+    expect(payload.reasoningEffort).toBe('high');
+    // The live signal is captured, not the controller.
+    expect(payload.abort).toBe(abort.signal);
+    // Only the requested phase's summary is carried.
+    expect(payload.promptMaterialSummary).toEqual({ totalMaterials: 3 });
+    expect(Object.isFrozen(payload)).toBe(true);
+  });
+
+  it('resolves the executor model + run-level override for the execute phase', () => {
+    const payload = buildPhasePayload(makeContext(), 'execute');
+
+    expect(payload.model).toBe('claude');
+    // execute resolves to executorModel, so the run-level override wins.
+    expect(payload.modelIdOverride).toBe('openrouter/auto');
+    expect(payload.reasoningEffort).toBe('low');
+    expect(payload.promptMaterialSummary).toEqual({ totalMaterials: 7 });
+  });
+
+  it('resolves per-phase model/override for verify (no executor-override bleed)', () => {
+    const payload = buildPhasePayload(makeContext(), 'verify');
+
+    expect(payload.model).toBe('openrouter');
+    expect(payload.modelIdOverride).toBe('or-verify');
+    expect(payload.reasoningEffort).toBe('medium');
+    // verify has no material summary in this context.
+    expect(payload.promptMaterialSummary).toBeUndefined();
+  });
+
+  it('falls back to an empty materials array when none are loaded', () => {
+    const context = makeContext();
+    context.repoPromptMaterials = null;
+    const payload = buildPhasePayload(context, 'plan');
+
+    expect(payload.repoPromptMaterials).toEqual([]);
+  });
+
+  it('excludes phase-local carry fields from the payload', () => {
+    const payload = buildPhasePayload(makeContext(), 'plan');
+
+    expect('stabilizationFeedback' in payload).toBe(false);
+    expect('testOutput' in payload).toBe(false);
+    expect('executionResumeContext' in payload).toBe(false);
+    expect('previousPlanRawOutput' in payload).toBe(false);
+  });
+
+  it('resolves per-phase model/override for review and revision', () => {
+    const review = buildPhasePayload(makeContext(), 'review');
+    expect(review.model).toBe('openrouter');
+    expect(review.modelIdOverride).toBe('or-review');
+    expect(review.reasoningEffort).toBe('medium');
+
+    // revision shares the planner model with the plan phase.
+    const revision = buildPhasePayload(makeContext(), 'revision');
+    expect(revision.model).toBe('codex');
+    expect(revision.modelIdOverride).toBe('claude-opus');
+    expect(revision.reasoningEffort).toBe('low');
+  });
+
+  it('uses the executor id override when no run-level override is set', () => {
+    const context = makeContext();
+    context.executorModelOverride = null;
+    const payload = buildPhasePayload(context, 'execute');
+
+    expect(payload.model).toBe('claude');
+    expect(payload.modelIdOverride).toBe('claude-exec-id');
+  });
+
+  it('PipelineContext is assignable to OrchestratorState (type-level)', () => {
+    const context = makeContext();
+    // Compiles only if `PipelineContext extends OrchestratorState` holds.
+    const state: OrchestratorState = context;
+    expect(state.threadId).toBe(context.threadId);
   });
 });
 

--- a/packages/pipeline/src/pipeline/context.ts
+++ b/packages/pipeline/src/pipeline/context.ts
@@ -14,12 +14,15 @@ import {
   type SkillResolutionSource,
 } from '@shipcode/shared';
 import {
+  type OrchestratorState,
   PHASE_LOCAL_FIELDS,
   type PhaseInput,
   type PhaseLocalField,
+  type PhasePayload,
   type PipelineContext,
   type PipelineDeps,
   type PipelineExecutorModel,
+  type PipelinePromptPhase,
   type ProviderPhaseInput,
 } from '../types';
 import { loadWorkflowPolicy } from '../workflow-loader';
@@ -83,6 +86,109 @@ export function snapshotProviderPhaseInput(
     reviewerModelIdOverride: context.reviewerModelIdOverride,
     executorModelIdOverride: context.executorModelIdOverride,
     verifierModelIdOverride: context.verifierModelIdOverride,
+  });
+}
+
+/** Fields `buildPhasePayload` needs that live on `PipelineContext`, not `OrchestratorState`. */
+type PhasePayloadSource = OrchestratorState &
+  Pick<PipelineContext, 'repoContext' | 'repoPromptMaterials' | 'promptMaterialSummaries'>;
+
+/**
+ * Resolve the executor model for a phase. Mirrors `resolveAgentForPhase` in
+ * runtime.ts so `PhasePayload.model` matches what the provider call will use.
+ */
+function resolveModelForPhase(
+  state: Pick<
+    OrchestratorState,
+    'plannerModel' | 'reviewerModel' | 'verifierModel' | 'executorModel'
+  >,
+  phase: PipelinePromptPhase,
+): PipelineExecutorModel {
+  switch (phase) {
+    case 'plan':
+    case 'revision':
+      return state.plannerModel;
+    case 'review':
+      return state.reviewerModel;
+    case 'verify':
+      return state.verifierModel;
+    case 'execute':
+      return state.executorModel || 'claude';
+  }
+}
+
+/**
+ * Resolve the model-id override for a phase. Mirrors the `modelHint` logic in
+ * `runProviderPhaseCore`: the executor override wins when the phase resolves to
+ * the executor model, otherwise the phase's own id override applies.
+ */
+function resolveModelIdOverrideForPhase(
+  state: Pick<
+    OrchestratorState,
+    | 'plannerModel'
+    | 'reviewerModel'
+    | 'verifierModel'
+    | 'executorModel'
+    | 'executorModelOverride'
+    | 'plannerModelIdOverride'
+    | 'reviewerModelIdOverride'
+    | 'executorModelIdOverride'
+    | 'verifierModelIdOverride'
+  >,
+  phase: PipelinePromptPhase,
+): string | null {
+  const model = resolveModelForPhase(state, phase);
+  if (model === state.executorModel && state.executorModelOverride) {
+    return state.executorModelOverride;
+  }
+  switch (phase) {
+    case 'plan':
+    case 'revision':
+      return state.plannerModelIdOverride;
+    case 'review':
+      return state.reviewerModelIdOverride;
+    case 'execute':
+      return state.executorModelIdOverride;
+    case 'verify':
+      return state.verifierModelIdOverride;
+  }
+}
+
+/**
+ * Build a frozen `PhasePayload` for a single phase from orchestrator state.
+ * Mirrors `snapshotProviderPhaseInput`: identity + the phase-resolved model,
+ * model-id override, and reasoning effort + the phase's prompt materials. The
+ * phase reads this scoped view; it never mutates orchestrator state.
+ *
+ * Dormant in #136 — defined and unit-tested but not yet wired into a phase
+ * handler. The #138 dispatch loop will call this once per phase invocation,
+ * passing the live `PipelineContext` (which satisfies the parameter type).
+ */
+export function buildPhasePayload(
+  state: PhasePayloadSource,
+  phase: PipelinePromptPhase,
+): PhasePayload {
+  return Object.freeze({
+    threadId: state.threadId,
+    projectPath: state.projectPath,
+    projectId: state.projectId,
+    worktreePath: state.worktreePath,
+    baseBranch: state.baseBranch,
+    forkPointSha: state.forkPointSha,
+    githubIssueNumber: state.githubIssueNumber,
+    githubIssueTitle: state.githubIssueTitle,
+    githubRepo: state.githubRepo,
+    autonomous: state.autonomous,
+    runId: state.runId,
+    isAutomationRun: state.isAutomationRun,
+    abort: state.abort.signal,
+    phase,
+    model: resolveModelForPhase(state, phase),
+    modelIdOverride: resolveModelIdOverrideForPhase(state, phase),
+    reasoningEffort: state.phaseReasoningEfforts[phase],
+    repoContext: state.repoContext,
+    repoPromptMaterials: state.repoPromptMaterials ?? [],
+    promptMaterialSummary: state.promptMaterialSummaries[phase],
   });
 }
 

--- a/packages/pipeline/src/types.ts
+++ b/packages/pipeline/src/types.ts
@@ -224,7 +224,19 @@ export interface PipelineEmitter {
   emit(event: PipelineEvent): void;
 }
 
-export interface PipelineContext {
+/**
+ * Persistent pipeline state owned by the orchestrator for the lifetime of a
+ * single run. Every field here survives across all phases and is never cleared
+ * by `resetPhaseState` (contrast `PHASE_LOCAL_FIELDS`). `PipelineContext`
+ * extends this, so existing context access is unchanged; the #137 dispatch loop
+ * will own an `OrchestratorState` directly and derive a `PhasePayload` per phase
+ * from it via `buildPhasePayload`.
+ *
+ * Intentionally mutable (no `readonly`): external callers write some fields
+ * after `getContext()` (e.g. the desktop IPC handler updates `clarification*`).
+ * The frozen, read-only view is `PhasePayload`, not this.
+ */
+export interface OrchestratorState {
   threadId: string;
   projectPath: string;
   runId: string | null;
@@ -241,7 +253,6 @@ export interface PipelineContext {
   clarificationHistory: AnsweredClarification[];
   verificationRetries: number;
   testRetries: number;
-  testOutput: string | null;
   githubIssueNumber: number | null;
   githubIssueTitle: string | null;
   githubRepo: string | null;
@@ -265,16 +276,9 @@ export interface PipelineContext {
   cancelled: boolean;
   verifiedSha: string | null;
   startedAt: number;
-  /**
-   * Pre-loaded repo context string for injection into phase prompts.
-   * Read once from `<projectPath>/.agents/memory/` at pipeline start.
-   */
-  repoContext: string | null;
-  repoPromptMaterials: PromptMaterial[] | null;
   phasePromptScopes: Record<PipelinePromptPhase, PipelinePromptScope>;
   phaseReasoningOverrides: Partial<Record<PipelinePromptPhase, ReasoningEffort>>;
   phaseReasoningEfforts: Record<PipelinePromptPhase, ReasoningEffort>;
-  promptMaterialSummaries: Partial<Record<PipelinePromptPhase, PromptMaterialSummary>>;
   promptTelemetry: PhasePromptTelemetry[];
   promptTelemetryDiagnostics: PromptTelemetryPersistenceDiagnostic[];
   /**
@@ -291,6 +295,47 @@ export interface PipelineContext {
    * calls abort() in addition to killing any active process.
    */
   abort: AbortController;
+  /** Per-node verification retry counter. Reset to 0 when active node advances. */
+  nodeVerificationRetries: number;
+  /** Git SHA before current node's execution. Used to compute node-scoped diff. */
+  nodeAnchorSha: string | null;
+  /**
+   * Number of full plan→review→execute→verify turns completed so far.
+   * Incremented after each turn; the loop exits when `turnCount >= maxTurns`
+   * or verify passes.
+   */
+  turnCount: number;
+  /**
+   * Feature QA contract extracted from the PRD `## QA State` section.
+   * When present, the verifier evaluates each critical flow and
+   * persists per-flow pass/fail results.
+   */
+  featureQaState: FeatureQaState | null;
+  /**
+   * True when this run was started via startFromAutomation (cron tick).
+   * The executor prompt drops file-restriction language because the
+   * synthesized plan has empty files/steps arrays — the prompt itself
+   * is the source of truth and the executor must discover files itself.
+   */
+  isAutomationRun: boolean;
+}
+
+/**
+ * Live, mutable per-run context. Extends `OrchestratorState` with the
+ * phase-local fields cleared by `resetPhaseState` (see `PHASE_LOCAL_FIELDS`) and
+ * the lazily materialized prompt-material cache. The split is naming-only:
+ * `PipelineContext` still carries every field it always has, so all existing
+ * reads, writes, construction, and persistence are unchanged.
+ */
+export interface PipelineContext extends OrchestratorState {
+  testOutput: string | null;
+  /**
+   * Pre-loaded repo context string for injection into phase prompts.
+   * Read once from `<projectPath>/.agents/memory/` at pipeline start.
+   */
+  repoContext: string | null;
+  repoPromptMaterials: PromptMaterial[] | null;
+  promptMaterialSummaries: Partial<Record<PipelinePromptPhase, PromptMaterialSummary>>;
   /**
    * Optional follow-up inputs from a linked draft PR. When set, the next
    * execute pass appends them to the prompt and then clears the field.
@@ -308,22 +353,6 @@ export interface PipelineContext {
    * Consumed (cleared) after use.
    */
   previousPlanRawOutput: string | null;
-  /** Per-node verification retry counter. Reset to 0 when active node advances. */
-  nodeVerificationRetries: number;
-  /** Git SHA before current node's execution. Used to compute node-scoped diff. */
-  nodeAnchorSha: string | null;
-  /**
-   * Number of full plan→review→execute→verify turns completed so far.
-   * Incremented after each turn; the loop exits when `turnCount >= maxTurns`
-   * or verify passes.
-   */
-  turnCount: number;
-  /**
-   * Feature QA contract extracted from the PRD `## QA State` section.
-   * When present, the verifier evaluates each critical flow and
-   * persists per-flow pass/fail results.
-   */
-  featureQaState: FeatureQaState | null;
   /** Cleanup function for a running runtime QA server. Called on cancel. */
   runtimeQaCleanup: (() => Promise<void>) | null;
   /** Captured output from runtime QA test commands. Fed to verifier. */
@@ -332,13 +361,6 @@ export interface PipelineContext {
   cpuQueueStartedAt: number | null;
   /** Last terminal notice emitted while waiting for a CPU-heavy local command slot. */
   cpuQueueLastNotifiedAt: number | null;
-  /**
-   * True when this run was started via startFromAutomation (cron tick).
-   * The executor prompt drops file-restriction language because the
-   * synthesized plan has empty files/steps arrays — the prompt itself
-   * is the source of truth and the executor must discover files itself.
-   */
-  isAutomationRun: boolean;
 }
 
 /**
@@ -397,6 +419,43 @@ export interface ProviderPhaseInput extends PhaseInput {
 export interface ProviderPhaseDeltas {
   promptTelemetry: PhasePromptTelemetry;
   diagnosticEntry: PromptTelemetryPersistenceDiagnostic | null;
+}
+
+/**
+ * Frozen, per-phase input built by `buildPhasePayload` before a phase runs.
+ * Carries identity, the phase-resolved model + model-id override + reasoning
+ * effort, and the phase's prompt materials — everything a single phase reads,
+ * and nothing the orchestrator mutates across phases. Read-only by design;
+ * phase-local carry (stabilizationFeedback etc.) is deliberately absent.
+ *
+ * Dormant in #136 (defined and unit-tested, no production caller). The #138
+ * dispatch loop will construct one per phase invocation from `OrchestratorState`
+ * and the phase will read it instead of the mutable `PipelineContext`.
+ */
+export interface PhasePayload {
+  readonly threadId: string;
+  readonly projectPath: string;
+  readonly projectId: string | null;
+  readonly worktreePath: string | null;
+  readonly baseBranch: string;
+  readonly forkPointSha: string;
+  readonly githubIssueNumber: number | null;
+  readonly githubIssueTitle: string | null;
+  readonly githubRepo: string | null;
+  readonly autonomous: boolean;
+  readonly runId: string | null;
+  readonly isAutomationRun: boolean;
+  /** The live abort signal (not the controller), mirroring `ProviderPhaseInput`. */
+  readonly abort: AbortSignal;
+  readonly phase: PipelinePromptPhase;
+  /** Model resolved for this phase (mirrors `resolveAgentForPhase`). */
+  readonly model: PipelineExecutorModel;
+  /** Model-id override resolved for this phase, or null. */
+  readonly modelIdOverride: string | null;
+  readonly reasoningEffort: ReasoningEffort;
+  readonly repoContext: string | null;
+  readonly repoPromptMaterials: readonly PromptMaterial[];
+  readonly promptMaterialSummary: PromptMaterialSummary | undefined;
 }
 
 /**


### PR DESCRIPTION
Closes #136. Step 2 of epic #126 (subagent architecture), following #135.

## What

Names the two halves of the per-run pipeline context and adds a frozen per-phase view, so #137 (dispatch loop) and #138 (fresh-per-invocation payload) have concrete types to build on.

- **`OrchestratorState`** — the ~persistent fields owned across all phases (identity, retry/turn counters, clarification state, models + reasoning config, telemetry, abort, workflow/setup/QA flags, github). Intentionally **mutable** (no `readonly`): the desktop IPC handler writes `clarification*` / resume fields after `getContext()`.
- **`PipelineContext extends OrchestratorState`** — declares only the phase-local fields (`PHASE_LOCAL_FIELDS`) + the prompt-material cache. **Naming-only split**: `PipelineContext` still carries every field it always had, so all reads, writes, construction (`ensureContext`), persistence (`rehydrateContext`), and the three phase test files are **unchanged (zero churn)**.
- **`PhasePayload`** — frozen, read-only per-phase view: identity + phase-resolved `model`/`modelIdOverride`/`reasoningEffort` + prompt materials.
- **`buildPhasePayload(state, phase)`** — factory in `context.ts`, mirrors `snapshotProviderPhaseInput`. Per-phase model resolution mirrors `resolveAgentForPhase` (runtime.ts) and the `modelHint` logic in `runProviderPhaseCore`, so the payload's model matches what the provider call will use.

## Dormant seam

`buildPhasePayload` has **no production caller** in this PR — #138 wires it into the dispatch loop. It is fully unit-tested (`context.ts` → 100% stmts/funcs/lines). Tradeoff accepted: a tested, documented, unused factory now vs. pulling #137's 21-callsite conversion forward into this PR.

## Scope notes vs the issue text

- Reasoning/routing config (`phaseReasoningEfforts` etc.) lives in `OrchestratorState` (the issue's "reasoning config"), so the factory's parameter `Pick` only needs the material-cache fields.
- `PhaseCarryOutput` + the `prevOutput` argument are **deferred to #138**, where they are actually consumed — avoids a dead, unused param/type here. `PhasePayload` stays carry-free, keeping the "phase-local fields absent" invariant clean.

## Verification

- `bun run typecheck` — clean (the `extends` is compile-time-validated).
- `bun run coverage` (pipeline) — **476 pass / 7 skip**, zero changes to existing phase tests confirms the split is non-breaking.
- Coverage **96.69 / 91.67 / 99.21 / 97.12** (gate 95/95/95/90); `context.ts` at 100% stmts/funcs/lines.
- `bunx biome check` on changed files — clean.

## Next in the chain

#136 → **#137** (dispatch loop: 21 `handlers.startX()` → return-value `PhaseOutcome`, orchestrator owns `OrchestratorState`) → **#138** (wire `buildPhasePayload`) → **#139** (typed phase results).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved pipeline state management architecture by separating persistent orchestrator state from phase-local context.
  * Enhanced phase execution with immutable payload snapshots to ensure isolation and consistency across pipeline phases.

* **Tests**
  * Added comprehensive unit tests validating phase payload construction, state preservation, and override behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shipshitdev/shipcode/pull/183?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->