### PR TITLE
feat(pipeline): orchestrator dispatch loop with typed PhaseOutcome (#137)

### DIFF
--- a/packages/pipeline/src/pipeline.test.ts
+++ b/packages/pipeline/src/pipeline.test.ts
@@ -4357,6 +4357,7 @@ Custom prompt`,
       });
 
       await pipeline.startTesting('t1');
+      await flush();
 
       expect(mock.deps.threads.recordFailure).toHaveBeenCalledWith(
         't1',
@@ -4427,6 +4428,7 @@ Custom prompt`,
       });
 
       await pipeline.startTesting('t1');
+      await flush();
 
       expect(mock.deps.threads.recordFailure).toHaveBeenCalledWith(
         't1',
@@ -4523,6 +4525,7 @@ Custom prompt`,
       };
 
       await pipeline.startTesting('t1');
+      await flush();
 
       expect(context.retryTimer).not.toBeNull();
       expect(mock.deps.threads.recordFailure).not.toHaveBeenCalledWith(
@@ -4684,6 +4687,7 @@ Custom prompt`,
       };
 
       await pipeline.startTesting('t1');
+      await flush();
 
       expect(mock.deps.processManager.spawnWithStdin).not.toHaveBeenCalledWith(
         'shell',
@@ -4743,6 +4747,7 @@ Custom prompt`,
       };
 
       await pipeline.startTesting('t1');
+      await flush();
 
       expect(mock.deps.threads.recordFailure).toHaveBeenCalledWith(
         't1',

--- a/packages/pipeline/src/pipeline.ts
+++ b/packages/pipeline/src/pipeline.ts
@@ -12,30 +12,125 @@ import { createPipelineContextHelpers } from './pipeline/context';
 import { createExecutionPhaseHandlers } from './pipeline/execution-phases';
 import { createPlanningPhaseHandlers } from './pipeline/planning-phases';
 import { createPipelineRuntime } from './pipeline/runtime';
-import type { PipelinePhaseHandlers } from './pipeline/shared';
+import type { PhaseOutcome } from './pipeline/shared';
 import type { Pipeline, PipelineContext, PipelineDeps, PipelineExecutorModel } from './types';
 
 export function createPipeline(deps: PipelineDeps): Pipeline {
   const activePipelines = new Map<string, PipelineContext>();
   const contextHelpers = createPipelineContextHelpers(deps, activePipelines);
   const runtime = createPipelineRuntime(deps, contextHelpers);
-  const handlers = {} as PipelinePhaseHandlers;
+  const planning = createPlanningPhaseHandlers({ deps, contextHelpers, runtime });
+  const execution = createExecutionPhaseHandlers({ deps, contextHelpers, runtime });
 
-  Object.assign(
-    handlers,
-    createPlanningPhaseHandlers({
-      deps,
-      contextHelpers,
-      runtime,
-      handlers,
-    }),
-    createExecutionPhaseHandlers({
-      deps,
-      contextHelpers,
-      runtime,
-      handlers,
-    }),
-  );
+  /**
+   * Wait `delayMs`, resolving `true` on normal expiry or `false` if the run is
+   * aborted first. The timer handle is stored on `context.retryTimer` and the
+   * wait is tied to `context.abort.signal`, so `cancel()`/`pause()` (which call
+   * `abort.abort()`) unblock a pending retry immediately — exact parity with the
+   * old `if (cancelled || !activePipelines.has) return` guard inside setTimeout.
+   */
+  function cancelableDelay(context: PipelineContext, delayMs: number): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+      if (context.retryTimer) clearTimeout(context.retryTimer);
+      let handle: ReturnType<typeof setTimeout> | undefined;
+      const onAbort = () => {
+        if (handle) clearTimeout(handle);
+        context.retryTimer = null;
+        resolve(false);
+      };
+      handle = setTimeout(() => {
+        context.retryTimer = null;
+        context.abort.signal.removeEventListener('abort', onAbort);
+        resolve(true);
+      }, delayMs);
+      context.retryTimer = handle;
+      if (context.abort.signal.aborted) {
+        onAbort();
+        return;
+      }
+      context.abort.signal.addEventListener('abort', onAbort, { once: true });
+    });
+  }
+
+  /**
+   * Orchestrator dispatch loop. Drives the pipeline as an explicit state machine:
+   * each phase returns a `PhaseOutcome`, and this loop advances to the next phase.
+   * Terminal outcomes (`done`/`paused`/`failed`) — whose `emitPhase` + cleanup the
+   * phase already performed — stop the loop. `retry` waits a cancelable delay then
+   * dispatches its `then` outcome.
+   */
+  async function dispatch(threadId: string, initial: PhaseOutcome): Promise<void> {
+    let outcome = initial;
+    while (true) {
+      switch (outcome.next) {
+        case 'plan':
+          outcome = await planning.startPlanGeneration(
+            threadId,
+            outcome.prompt,
+            outcome.projectPath,
+            outcome.worktreePath,
+          );
+          break;
+        case 'review':
+          outcome = await planning.startReview(threadId, outcome.plan);
+          break;
+        case 'revision':
+          outcome = await planning.startRevision(threadId, outcome.plan, outcome.reviewFeedback);
+          break;
+        case 'execute':
+          outcome = await execution.startExecution(threadId, outcome.plan);
+          break;
+        case 'testing':
+          outcome = await execution.startTesting(threadId);
+          break;
+        case 'verification':
+          outcome = await execution.startVerification(threadId);
+          break;
+        case 'commit':
+          outcome = await execution.startCommitAndPush(threadId);
+          break;
+        case 'shipping':
+          outcome = await execution.startShipping(threadId);
+          break;
+        case 'retry': {
+          const context = activePipelines.get(threadId);
+          if (!context || context.cancelled) return;
+          const proceed = await cancelableDelay(context, outcome.delayMs);
+          if (!proceed || context.cancelled || !activePipelines.has(threadId)) return;
+          outcome = outcome.andThen;
+          break;
+        }
+        case 'done':
+        case 'paused':
+        case 'failed':
+          return;
+      }
+    }
+  }
+
+  /**
+   * Kick off the dispatch loop for a phase WITHOUT blocking the caller. The
+   * phase's synchronous setup (e.g. `emitPhase('planning')`) runs immediately;
+   * the provider calls and subsequent phases advance in the background — exactly
+   * the old fire-and-forget behavior, where public `startX` resolved after setup
+   * and the pipeline progressed on its own. Phase handlers own their own error
+   * handling (emit `failed` + cleanup); this guard only catches the unexpected.
+   */
+  function launch(threadId: string, start: () => Promise<PhaseOutcome>): void {
+    void (async () => {
+      try {
+        await dispatch(threadId, await start());
+      } catch (error) {
+        console.error(`[pipeline] dispatch loop crashed for thread ${threadId}:`, error);
+        runtime.emitPhase(
+          threadId,
+          'failed',
+          error instanceof Error ? error.message : String(error),
+        );
+        activePipelines.delete(threadId);
+      }
+    })();
+  }
 
   function createRun(input: {
     threadId: string;
@@ -228,11 +323,8 @@ export function createPipeline(deps: PipelineDeps): Pipeline {
     const prompt =
       `GitHub Issue #${issue.number}: ${issue.title}\n\n${issue.body ?? ''}` +
       buildWorkpadProtocol({ issueNumber: issue.number });
-    await handlers.startPlanGeneration(
-      threadId,
-      prompt,
-      projectPath,
-      options?.worktreePath ?? null,
+    launch(threadId, () =>
+      planning.startPlanGeneration(threadId, prompt, projectPath, options?.worktreePath ?? null),
     );
   }
 
@@ -394,7 +486,7 @@ export function createPipeline(deps: PipelineDeps): Pipeline {
     deps.plans.updateStatus(planRecord.id, 'approved');
     deps.taskGraphs?.replaceForPlan(threadId, planRecord.id, synthesizedPlan, { speedProfile });
 
-    await handlers.startExecution(threadId, synthesizedPlan);
+    launch(threadId, () => execution.startExecution(threadId, synthesizedPlan));
   }
 
   async function startFromAutomation(
@@ -465,7 +557,7 @@ export function createPipeline(deps: PipelineDeps): Pipeline {
       speedProfile: resolvePipelineSpeedProfile(deps.settings.get(), project),
     });
 
-    await handlers.startExecution(threadId, synthesizedPlan);
+    launch(threadId, () => execution.startExecution(threadId, synthesizedPlan));
   }
 
   function cancel(threadId: string) {
@@ -521,15 +613,39 @@ export function createPipeline(deps: PipelineDeps): Pipeline {
 
   return {
     rehydrateContext: contextHelpers.rehydrateContext,
-    startPlanGeneration: handlers.startPlanGeneration,
-    startReview: handlers.startReview,
-    startRevision: handlers.startRevision,
-    startExecution: handlers.startExecution,
-    startTesting: handlers.startTesting,
-    startVerification: handlers.startVerification,
-    startCommitAndPush: handlers.startCommitAndPush,
-    startShipping: handlers.startShipping,
-    startStabilization: handlers.startStabilization,
+    startPlanGeneration: async (threadId, prompt, projectPath, worktreePath) => {
+      launch(threadId, () =>
+        planning.startPlanGeneration(threadId, prompt, projectPath, worktreePath),
+      );
+    },
+    startReview: async (threadId, plan) => {
+      launch(threadId, () => planning.startReview(threadId, plan));
+    },
+    startRevision: async (threadId, plan, reviewFeedback) => {
+      launch(threadId, () => planning.startRevision(threadId, plan, reviewFeedback));
+    },
+    startExecution: async (threadId, plan) => {
+      launch(threadId, () => execution.startExecution(threadId, plan));
+    },
+    startTesting: async (threadId) => {
+      launch(threadId, () => execution.startTesting(threadId));
+    },
+    startVerification: async (threadId) => {
+      launch(threadId, () => execution.startVerification(threadId));
+    },
+    startCommitAndPush: async (threadId) => {
+      launch(threadId, () => execution.startCommitAndPush(threadId));
+    },
+    startShipping: async (threadId) => {
+      launch(threadId, () => execution.startShipping(threadId));
+    },
+    startStabilization: async (threadId, inputs) => {
+      // Await the synchronous setup so a missing-plan throw reaches the caller
+      // (e.g. the PR-check webhook handler), then dispatch the execute outcome
+      // in the background like every other phase.
+      const outcome = await execution.startStabilization(threadId, inputs);
+      launch(threadId, () => Promise.resolve(outcome));
+    },
     startFromGitHubIssue,
     startFromQuickTask,
     startFromAutomation,

--- a/packages/pipeline/src/pipeline/execution-phases.test.ts
+++ b/packages/pipeline/src/pipeline/execution-phases.test.ts
@@ -15,7 +15,7 @@ import {
   resolveWorktreeDiffBase,
   worktreeHasChanges,
 } from './execution-phases';
-import type { PipelineContextHelpers, PipelinePhaseHandlers, PipelineRuntime } from './shared';
+import type { PipelineContextHelpers, PipelineRuntime } from './shared';
 
 type ExecutionHarnessDeps = {
   plans: { getLatest: ReturnType<typeof vi.fn> };
@@ -242,21 +242,11 @@ function makeExecutionHarness(context = makeContext()) {
     runProviderPhase: vi.fn(async () => ({ rawOutput: 'done', exitCode: 0 })),
     postTaskGraphComment: vi.fn(),
   } as unknown as PipelineRuntime;
-  const handlers = {
-    startExecution: vi.fn(),
-    startTesting: vi.fn(),
-    startVerification: vi.fn(),
-    startPlanGeneration: vi.fn(),
-    startCommitAndPush: vi.fn(),
-    startShipping: vi.fn(),
-  } as unknown as PipelinePhaseHandlers;
-  const phaseHandlers = createExecutionPhaseHandlers({
+  const handlers = createExecutionPhaseHandlers({
     deps: deps as never,
     contextHelpers,
     runtime,
-    handlers,
   });
-  Object.assign(handlers, phaseHandlers);
   return { activePipelines, context, contextHelpers, deps, handlers, runtime };
 }
 
@@ -574,8 +564,7 @@ describe('execution phase handlers', () => {
     }
   });
 
-  it('queues testing when CPU slots are busy and cancellation suppresses the retry callback', async () => {
-    vi.useFakeTimers();
+  it('queues testing as a retry outcome when CPU slots are busy', async () => {
     const context = makeContext();
     const harness = makeExecutionHarness(context);
     vi.mocked(harness.contextHelpers.listActiveInPhases).mockReturnValue([
@@ -588,22 +577,23 @@ describe('execution phase handlers', () => {
     ] as never);
     vi.mocked(harness.runtime.getVerifyCommands).mockReturnValue(['bun test']);
 
-    await harness.handlers.startTesting('thread-1');
+    const outcome = await harness.handlers.startTesting('thread-1');
 
     expect(harness.runtime.emitTerminalLifecycle).toHaveBeenCalledWith(
       'thread-1',
       expect.stringContaining('CPU-heavy task slots are busy'),
     );
-    expect(context.retryTimer).not.toBeNull();
-
-    context.cancelled = true;
-    await vi.runOnlyPendingTimersAsync();
-
-    expect(harness.runtime.emitPhase).not.toHaveBeenCalledWith('thread-1', 'testing');
+    // CPU backpressure is now a retry outcome; the dispatch loop owns the delay,
+    // so the phase no longer arms context.retryTimer.
+    expect(outcome).toEqual({
+      next: 'retry',
+      delayMs: expect.any(Number),
+      andThen: { next: 'testing' },
+    });
+    expect(context.retryTimer).toBeNull();
   });
 
   it('queues testing on CPU gate pressure without repeating recent queue notices', async () => {
-    vi.useFakeTimers();
     const context = makeContext({
       cpuQueueLastNotifiedAt: Date.now(),
     });
@@ -618,22 +608,16 @@ describe('execution phase handlers', () => {
     } as never;
     vi.mocked(harness.runtime.getVerifyCommands).mockReturnValue(['bun test']);
 
-    await harness.handlers.startTesting('thread-1');
+    const outcome = await harness.handlers.startTesting('thread-1');
 
-    expect(context.retryTimer).not.toBeNull();
+    expect(outcome).toEqual({ next: 'retry', delayMs: 123, andThen: { next: 'testing' } });
     expect(harness.runtime.emitTerminalLifecycle).not.toHaveBeenCalledWith(
       'thread-1',
       expect.stringContaining('[cpu-queue]'),
     );
-
-    await vi.advanceTimersByTimeAsync(123);
-
-    expect(gateCheck).toHaveBeenCalledTimes(2);
-    expect(harness.runtime.emitPhase).toHaveBeenCalledWith('thread-1', 'testing');
   });
 
   it('routes selector-readiness feature QA failures through coordinated test-fix retry', async () => {
-    vi.useFakeTimers();
     const context = makeContext({
       featureQaState: {
         featureId: 'feature-1',
@@ -669,16 +653,21 @@ describe('execution phase handlers', () => {
       return context.repoSetupContract;
     });
 
-    await harness.handlers.startTesting('thread-1');
+    const outcome = await harness.handlers.startTesting('thread-1');
 
     expect(context.testRetries).toBe(1);
-    expect(context.testOutput).toContain('Visual QA requires stable selectors');
+    // The accumulated failure output is consumed into the test-fix feedback that
+    // the re-execution will read.
+    expect(context.stabilizationFeedback).toContain('Visual QA requires stable selectors');
     expect(context.stabilizationFeedback).toContain('failed on attempt 1');
-    expect(context.retryTimer).not.toBeNull();
+    expect(outcome).toEqual({
+      next: 'retry',
+      delayMs: expect.any(Number),
+      andThen: { next: 'execute', plan: expect.anything() },
+    });
   });
 
-  it('drops a scheduled test-fix retry when the context disappears before callback entry', async () => {
-    vi.useFakeTimers();
+  it('emits a failure when the test-fix retry cannot find a structured plan', async () => {
     const context = makeContext({
       featureQaState: {
         featureId: 'feature-1',
@@ -713,14 +702,12 @@ describe('execution phase handlers', () => {
       };
       return context.repoSetupContract;
     });
+    // No structured plan available when the test-fix outcome is built.
+    harness.deps.plans.getLatest.mockReturnValue(null);
 
     await harness.handlers.startTesting('thread-1');
-    harness.activePipelines.get = vi.fn(() => undefined) as never;
-    harness.activePipelines.has = vi.fn(() => true) as never;
 
-    await vi.runOnlyPendingTimersAsync();
-
-    expect(harness.runtime.emitPhase).not.toHaveBeenCalledWith(
+    expect(harness.runtime.emitPhase).toHaveBeenCalledWith(
       'thread-1',
       'failed',
       'Test fix cannot start: structured plan missing for this thread.',
@@ -1846,8 +1833,7 @@ describe('execution phase handlers', () => {
     );
   });
 
-  it('schedules execution retry after failed verification and honors cancelled timers', async () => {
-    vi.useFakeTimers();
+  it('returns an execution retry outcome after failed verification', async () => {
     const context = makeContext({ verificationRetries: 0 });
     const harness = makeExecutionHarness(context);
     harness.deps.plans.getLatest.mockReturnValue({
@@ -1871,44 +1857,16 @@ describe('execution phase handlers', () => {
       return '';
     });
 
-    await harness.handlers.startVerification('thread-1');
-    await Promise.resolve();
-    await Promise.resolve();
+    const outcome = await harness.handlers.startVerification('thread-1');
 
     expect(context.verificationRetries).toBe(1);
-    expect(context.retryTimer).not.toBeNull();
-
-    context.cancelled = true;
-    await vi.runOnlyPendingTimersAsync();
-
+    // The phase returns the retry outcome; the dispatch loop owns the delay and
+    // the cancellable timer (no context.retryTimer armed here).
+    expect(outcome).toEqual({
+      next: 'retry',
+      delayMs: expect.any(Number),
+      andThen: { next: 'execute', plan },
+    });
     expect(harness.runtime.runProviderPhase).toHaveBeenCalledTimes(1);
-  });
-
-  it('replaces existing verification retry timers before scheduling continuation', async () => {
-    vi.useFakeTimers();
-    const oldTimerCallback = vi.fn();
-    const context = makeContext({
-      verificationRetries: 0,
-      retryTimer: setTimeout(oldTimerCallback, 1) as unknown as PipelineContext['retryTimer'],
-    });
-    const harness = makeExecutionHarness(context);
-    vi.mocked(harness.runtime.runProviderPhase).mockResolvedValue({
-      rawOutput: verificationFailed,
-      exitCode: 0,
-    });
-    mockExecFileSync.mockImplementation((_command: string, args: string[]) => {
-      if (args[0] === 'status') return '';
-      if (args[0] === 'rev-parse') return 'head-sha\n';
-      if (args[0] === 'diff') return 'diff --git a/src/a.ts b/src/a.ts\n';
-      return '';
-    });
-
-    await harness.handlers.startVerification('thread-1');
-    await Promise.resolve();
-    await Promise.resolve();
-    context.cancelled = true;
-    await vi.runOnlyPendingTimersAsync();
-
-    expect(oldTimerCallback).not.toHaveBeenCalled();
   });
 });

--- a/packages/pipeline/src/pipeline/execution-phases.ts
+++ b/packages/pipeline/src/pipeline/execution-phases.ts
@@ -44,7 +44,7 @@ import type { PipelineContext } from '../types';
 import { renderWorkflowPromptTemplate } from '../workflow-prompt';
 import { resetPhaseState } from './context';
 import { extractQaFlowResults } from './qa-result-parser';
-import type { PipelineHelperEnv } from './shared';
+import type { PhaseOutcome, PipelineHelperEnv } from './shared';
 import {
   collectQaEvidencePaths,
   formatVisualQaFailureFeedback,
@@ -324,12 +324,7 @@ export function resolveWorktreeDiffBase(context: PipelineContext): string | null
   }
 }
 
-export function createExecutionPhaseHandlers({
-  deps,
-  contextHelpers,
-  runtime,
-  handlers,
-}: PipelineHelperEnv) {
+export function createExecutionPhaseHandlers({ deps, contextHelpers, runtime }: PipelineHelperEnv) {
   const { activePipelines, skillCallSite } = contextHelpers;
   const {
     emitPhase,
@@ -432,12 +427,20 @@ export function createExecutionPhaseHandlers({
     );
   }
 
+  /**
+   * Coordinate a test-fix retry after a failed verify/runtime command.
+   * Returns the `PhaseOutcome` the caller should propagate:
+   *   - `{ next: 'retry', then: <re-execute> }` to schedule a fix attempt,
+   *   - `{ next: 'failed' }` when a shared-failure block halts this thread
+   *     (emitPhase + delete already done), or
+   *   - `null` when the retry budget is exhausted (caller emits the failure).
+   */
   function scheduleCoordinatedTestFixRetry(
     threadId: string,
     context: NonNullable<ReturnType<typeof activePipelines.get>>,
     command: string,
     testOutput: string,
-  ): boolean {
+  ): PhaseOutcome | null {
     context.testOutput = context.testOutput?.includes(testOutput)
       ? context.testOutput
       : `${context.testOutput ?? ''}\n${testOutput}`.slice(-16384);
@@ -446,30 +449,53 @@ export function createExecutionPhaseHandlers({
       emitTerminalLifecycle(threadId, `[shared-failure] ${blockMessage}\r\n`);
       emitPhase(threadId, 'failed', blockMessage);
       activePipelines.delete(threadId);
-      return true;
+      return { next: 'failed' };
     }
 
-    if (context.testRetries >= MAX_TEST_RETRIES) return false;
+    if (context.testRetries >= MAX_TEST_RETRIES) return null;
 
     context.testRetries++;
-    context.stabilizationFeedback = formatTestFixFeedback(context.testOutput, context.testRetries);
     const delayMs = computeRetryDelayMs({
       reason: 'continuation',
       attempt: context.testRetries,
     });
-    if (context.retryTimer) clearTimeout(context.retryTimer);
-    context.retryTimer = setTimeout(() => {
-      context.retryTimer = null;
-      if (context.cancelled || !activePipelines.has(threadId)) return;
-      void startTestFix(threadId);
-    }, delayMs);
-    return true;
+    return { next: 'retry', delayMs, andThen: makeTestFixOutcome(threadId) };
+  }
+
+  /**
+   * Build the re-execution outcome for a test-fix retry. Mirrors the old
+   * `startTestFix`: consume accumulated test output, reset phase state, and
+   * inject focused test-fix feedback before re-entering execute.
+   */
+  function makeTestFixOutcome(threadId: string): PhaseOutcome {
+    const context = activePipelines.get(threadId);
+    if (!context) return { next: 'paused' };
+
+    const testOutput = context.testOutput ?? '';
+    context.testOutput = null;
+
+    const latestPlan = deps.plans.getLatest(threadId);
+    const structuredPlan = latestPlan?.structured;
+    if (!structuredPlan) {
+      emitPhase(
+        threadId,
+        'failed',
+        'Test fix cannot start: structured plan missing for this thread.',
+      );
+      activePipelines.delete(threadId);
+      return { next: 'failed' };
+    }
+
+    // Reset phase state, then inject focused test-fix feedback (consumed-once).
+    resetPhaseState(context);
+    context.stabilizationFeedback = formatTestFixFeedback(testOutput, context.testRetries);
+    return { next: 'execute', plan: structuredPlan };
   }
 
   function queueTestingIfCpuBusy(
     threadId: string,
     context: NonNullable<ReturnType<typeof activePipelines.get>>,
-  ): boolean {
+  ): PhaseOutcome | null {
     const settings = deps.settings.get();
     const maxConcurrentCpuTasks = Math.max(1, settings.maxConcurrentCpuTasks ?? 1);
     const runningCpuTasks = contextHelpers
@@ -482,7 +508,7 @@ export function createExecutionPhaseHandlers({
     if (!blockedBySlot && !blockedByCpu) {
       context.cpuQueueStartedAt = null;
       context.cpuQueueLastNotifiedAt = null;
-      return false;
+      return null;
     }
 
     const now = Date.now();
@@ -505,13 +531,7 @@ export function createExecutionPhaseHandlers({
     }
 
     const retryMs = deps.cpuTaskGate?.retryDelayMs ?? DEFAULT_CPU_QUEUE_RETRY_MS;
-    if (context.retryTimer) clearTimeout(context.retryTimer);
-    context.retryTimer = setTimeout(() => {
-      context.retryTimer = null;
-      if (context.cancelled || !activePipelines.has(threadId)) return;
-      void handlers.startTesting(threadId);
-    }, retryMs);
-    return true;
+    return { next: 'retry', delayMs: retryMs, andThen: { next: 'testing' } };
   }
 
   function claimSharedTestFailure(
@@ -721,9 +741,9 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
 
   // ─── End per-node verification helpers ─────────────────────────────────────
 
-  async function startExecution(threadId: string, plan: ShipCodePlan) {
+  async function startExecution(threadId: string, plan: ShipCodePlan): Promise<PhaseOutcome> {
     const context = activePipelines.get(threadId);
-    if (!context) return;
+    if (!context) return { next: 'paused' };
 
     // Defense-in-depth: every direct caller already passes a parsed
     // ShipCodePlan, but the DB record is the source of truth. Halt at the
@@ -733,7 +753,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
     if (!executionGatePlan) {
       emitPhase(threadId, 'failed', 'Refusing to execute: no plan record found for this thread.');
       activePipelines.delete(threadId);
-      return;
+      return { next: 'failed' };
     }
     if (executionGatePlan.structured === null) {
       emitPhase(
@@ -742,7 +762,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
         'Refusing to execute: latest plan has no parsed structured output.',
       );
       activePipelines.delete(threadId);
-      return;
+      return { next: 'failed' };
     }
     if (executionGatePlan.status === 'superseded' || executionGatePlan.status === 'rejected') {
       emitPhase(
@@ -751,7 +771,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
         `Refusing to execute: latest plan is ${executionGatePlan.status}.`,
       );
       activePipelines.delete(threadId);
-      return;
+      return { next: 'failed' };
     }
 
     const settings = deps.settings.get();
@@ -765,7 +785,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
     if (executingCount >= maxConcurrentExecutions) {
       // Project execution slots full — stay in approval until a slot frees.
       emitPhase(threadId, 'approval');
-      return;
+      return { next: 'paused' };
     }
 
     if (
@@ -783,7 +803,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
         lockedIssue.executionRunId !== context.runId
       ) {
         emitPhase(threadId, 'approval');
-        return;
+        return { next: 'paused' };
       }
     }
 
@@ -795,7 +815,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
     } catch (error) {
       emitPhase(threadId, 'failed', error instanceof Error ? error.message : String(error));
       activePipelines.delete(threadId);
-      return;
+      return { next: 'failed' };
     }
 
     if (!context.worktreePath || !existsSync(context.worktreePath)) {
@@ -822,7 +842,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
         console.error(`[pipeline] worktree creation failed for thread ${threadId}:`, error);
         emitPhase(threadId, 'failed', `Worktree creation failed: ${String(error)}`);
         activePipelines.delete(threadId);
-        return;
+        return { next: 'failed' };
       }
     }
 
@@ -830,7 +850,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
     if (!preparation.ok) {
       emitPhase(threadId, 'failed', `Setup failed: ${preparation.error}`);
       activePipelines.delete(threadId);
-      return;
+      return { next: 'failed' };
     }
 
     try {
@@ -870,7 +890,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
       const message = error instanceof Error ? error.message : String(error);
       emitPhase(threadId, 'failed', `Checkpoint creation failed: ${message}`);
       activePipelines.delete(threadId);
-      return;
+      return { next: 'failed' };
     }
 
     const skill = skillCallSite(context);
@@ -910,22 +930,21 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
           void postTaskGraphComment(context, completedGraph);
           if (context.autonomous) {
             resetPhaseState(context);
-            handlers.startTesting(threadId);
-          } else {
-            // Check if any code was actually changed
-            if (!worktreeHasChanges(context)) {
-              emitPhase(
-                threadId,
-                'failed',
-                'All task graph nodes completed but no code changes were produced',
-              );
-              activePipelines.delete(threadId);
-              return;
-            }
-            emitPhase(threadId, 'completed');
-            activePipelines.delete(threadId);
+            return { next: 'testing' };
           }
-          return;
+          // Check if any code was actually changed
+          if (!worktreeHasChanges(context)) {
+            emitPhase(
+              threadId,
+              'failed',
+              'All task graph nodes completed but no code changes were produced',
+            );
+            activePipelines.delete(threadId);
+            return { next: 'failed' };
+          }
+          emitPhase(threadId, 'completed');
+          activePipelines.delete(threadId);
+          return { next: 'done' };
         }
 
         const blockedSummary = incompleteNodes
@@ -933,7 +952,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
           .join(', ');
         emitPhase(threadId, 'failed', `Task graph has no ready node (${blockedSummary}).`);
         activePipelines.delete(threadId);
-        return;
+        return { next: 'failed' };
       }
 
       deps.taskGraphs.updateNodeStatus(activeTaskNode.id, 'running');
@@ -985,7 +1004,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
         `WORKFLOW.md template render error: ${error instanceof Error ? error.message : String(error)}`,
       );
       activePipelines.delete(threadId);
-      return;
+      return { next: 'failed' };
     }
     const executionTaskGraph = usesTaskGraph ? taskGraph : null;
     const baseExecutionPrompt =
@@ -1008,180 +1027,141 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
       context.nodeAnchorSha = captureNodeAnchorSha(context);
     }
 
-    void (async () => {
-      try {
-        const response = await runProviderPhase(
-          context,
-          'execute',
-          executionPrompt,
-          executeMaterials,
-          {
-            reasoningEffort:
-              activeTaskNode?.suggestedReasoningEffort ?? context.phaseReasoningEfforts.execute,
-          },
-        );
+    try {
+      const response = await runProviderPhase(
+        context,
+        'execute',
+        executionPrompt,
+        executeMaterials,
+        {
+          reasoningEffort:
+            activeTaskNode?.suggestedReasoningEffort ?? context.phaseReasoningEfforts.execute,
+        },
+      );
 
-        if (context.cancelled) return;
+      if (context.cancelled) return { next: 'paused' };
 
-        if (response.exitCode === 0) {
-          if (activeTaskNode && deps.taskGraphs) {
-            // ─── Per-node verification gate ───
-            const nodeOutcome = await verifyNodeCompletion(threadId, plan, activeTaskNode);
+      if (response.exitCode === 0) {
+        if (activeTaskNode && deps.taskGraphs) {
+          // ─── Per-node verification gate ───
+          const nodeOutcome = await verifyNodeCompletion(threadId, plan, activeTaskNode);
 
-            if (nodeOutcome === 'passed') {
-              context.nodeVerificationRetries = 0;
-              context.nodeAnchorSha = null;
-              const updatedGraph = deps.taskGraphs.markNodeCompletedAndPromote(activeTaskNode.id);
-              void postTaskGraphComment(context, updatedGraph);
-              resetPhaseState(context);
-              handlers.startExecution(threadId, plan);
-              return;
-            }
-
-            if (nodeOutcome === 'retry') {
-              // Budget check BEFORE scheduling — covers all retry sources (empty diff,
-              // provider error, LLM non-pass). Without this the loop is unbounded.
-              if (context.nodeVerificationRetries >= MAX_NODE_VERIFICATION_RETRIES) {
-                const failedGraph = deps.taskGraphs.markNodeFailed(activeTaskNode.id);
-                void postTaskGraphComment(context, failedGraph);
-                emitPhase(
-                  threadId,
-                  'failed',
-                  `Node "${activeTaskNode.stableKey}" failed verification after ${MAX_NODE_VERIFICATION_RETRIES + 1} attempts.`,
-                );
-                activePipelines.delete(threadId);
-                return;
-              }
-              context.nodeVerificationRetries++;
-              context.stabilizationFeedback = formatNodeVerificationFailureFeedback(
-                activeTaskNode,
-                context.nodeVerificationRetries,
-              );
-              deps.taskGraphs.updateNodeStatus(activeTaskNode.id, 'ready');
-              const delayMs = computeRetryDelayMs({
-                reason: 'continuation',
-                attempt: context.nodeVerificationRetries,
-              });
-              if (context.retryTimer) clearTimeout(context.retryTimer);
-              context.retryTimer = setTimeout(() => {
-                context.retryTimer = null;
-                if (context.cancelled || !activePipelines.has(threadId)) return;
-                handlers.startExecution(threadId, plan);
-              }, delayMs);
-              return;
-            }
-
-            // nodeOutcome === 'failed' — max retries exhausted
-            const failedGraph = deps.taskGraphs.markNodeFailed(activeTaskNode.id);
-            void postTaskGraphComment(context, failedGraph);
-            emitPhase(
-              threadId,
-              'failed',
-              `Node "${activeTaskNode.stableKey}" failed verification after ${MAX_NODE_VERIFICATION_RETRIES + 1} attempts.`,
-            );
-            activePipelines.delete(threadId);
-            return;
-            // ─── End per-node verification gate ───
-          }
-
-          if (taskGraph?.mode === 'direct' && deps.taskGraphs && taskGraph.status !== 'completed') {
-            try {
-              deps.taskGraphs.updateGraphStatus(taskGraph.id, 'completed');
-            } catch (error) {
-              console.error(
-                `[pipeline] direct task graph completion failed for ${threadId}:`,
-                error,
-              );
-            }
-          }
-
-          if (context.autonomous) {
+          if (nodeOutcome === 'passed') {
+            context.nodeVerificationRetries = 0;
+            context.nodeAnchorSha = null;
+            const updatedGraph = deps.taskGraphs.markNodeCompletedAndPromote(activeTaskNode.id);
+            void postTaskGraphComment(context, updatedGraph);
             resetPhaseState(context);
-            handlers.startTesting(threadId);
-          } else {
-            // Check if executor actually produced code changes
-            const hasChanges = worktreeHasChanges(context);
-            if (!hasChanges) {
-              const errSnippet = extractExecutionErrorSnippet(response.rawOutput);
+            return { next: 'execute', plan };
+          }
+
+          if (nodeOutcome === 'retry') {
+            // Budget check BEFORE scheduling — covers all retry sources (empty diff,
+            // provider error, LLM non-pass). Without this the loop is unbounded.
+            if (context.nodeVerificationRetries >= MAX_NODE_VERIFICATION_RETRIES) {
+              const failedGraph = deps.taskGraphs.markNodeFailed(activeTaskNode.id);
+              void postTaskGraphComment(context, failedGraph);
               emitPhase(
                 threadId,
                 'failed',
-                `Executor exited successfully but produced no code changes${errSnippet ? `: ${errSnippet}` : ''}`,
+                `Node "${activeTaskNode.stableKey}" failed verification after ${MAX_NODE_VERIFICATION_RETRIES + 1} attempts.`,
               );
               activePipelines.delete(threadId);
-              return;
+              return { next: 'failed' };
             }
-            emitPhase(threadId, 'completed');
-            activePipelines.delete(threadId);
+            context.nodeVerificationRetries++;
+            context.stabilizationFeedback = formatNodeVerificationFailureFeedback(
+              activeTaskNode,
+              context.nodeVerificationRetries,
+            );
+            deps.taskGraphs.updateNodeStatus(activeTaskNode.id, 'ready');
+            const delayMs = computeRetryDelayMs({
+              reason: 'continuation',
+              attempt: context.nodeVerificationRetries,
+            });
+            return { next: 'retry', delayMs, andThen: { next: 'execute', plan } };
           }
-        } else {
-          const errSnippet = extractExecutionErrorSnippet(response.rawOutput);
-          if (activeTaskNode && deps.taskGraphs) {
-            const failedGraph = deps.taskGraphs.markNodeFailed(activeTaskNode.id);
-            void postTaskGraphComment(context, failedGraph);
-          } else if (
-            taskGraph?.mode === 'direct' &&
-            deps.taskGraphs &&
-            taskGraph.status !== 'failed'
-          ) {
-            try {
-              deps.taskGraphs.updateGraphStatus(taskGraph.id, 'failed');
-            } catch (error) {
-              console.error(`[pipeline] direct task graph failure failed for ${threadId}:`, error);
-            }
-          }
+
+          // nodeOutcome === 'failed' — max retries exhausted
+          const failedGraph = deps.taskGraphs.markNodeFailed(activeTaskNode.id);
+          void postTaskGraphComment(context, failedGraph);
           emitPhase(
             threadId,
             'failed',
-            `Execution failed (exit ${response.exitCode})${errSnippet ? `: ${errSnippet}` : ''}`,
+            `Node "${activeTaskNode.stableKey}" failed verification after ${MAX_NODE_VERIFICATION_RETRIES + 1} attempts.`,
           );
           activePipelines.delete(threadId);
+          return { next: 'failed' };
+          // ─── End per-node verification gate ───
         }
-      } catch (error) {
-        if (!context.cancelled) {
-          emitPhase(threadId, 'failed', `Execution error: ${String(error)}`);
+
+        if (taskGraph?.mode === 'direct' && deps.taskGraphs && taskGraph.status !== 'completed') {
+          try {
+            deps.taskGraphs.updateGraphStatus(taskGraph.id, 'completed');
+          } catch (error) {
+            console.error(`[pipeline] direct task graph completion failed for ${threadId}:`, error);
+          }
+        }
+
+        if (context.autonomous) {
+          resetPhaseState(context);
+          return { next: 'testing' };
+        }
+        // Check if executor actually produced code changes
+        const hasChanges = worktreeHasChanges(context);
+        if (!hasChanges) {
+          const errSnippet = extractExecutionErrorSnippet(response.rawOutput);
+          emitPhase(
+            threadId,
+            'failed',
+            `Executor exited successfully but produced no code changes${errSnippet ? `: ${errSnippet}` : ''}`,
+          );
           activePipelines.delete(threadId);
+          return { next: 'failed' };
+        }
+        emitPhase(threadId, 'completed');
+        activePipelines.delete(threadId);
+        return { next: 'done' };
+      }
+
+      const errSnippet = extractExecutionErrorSnippet(response.rawOutput);
+      if (activeTaskNode && deps.taskGraphs) {
+        const failedGraph = deps.taskGraphs.markNodeFailed(activeTaskNode.id);
+        void postTaskGraphComment(context, failedGraph);
+      } else if (taskGraph?.mode === 'direct' && deps.taskGraphs && taskGraph.status !== 'failed') {
+        try {
+          deps.taskGraphs.updateGraphStatus(taskGraph.id, 'failed');
+        } catch (error) {
+          console.error(`[pipeline] direct task graph failure failed for ${threadId}:`, error);
         }
       }
-    })();
-  }
-
-  async function startTestFix(threadId: string) {
-    const context = activePipelines.get(threadId);
-    if (!context) return;
-
-    const testOutput = context.testOutput ?? '';
-    context.testOutput = null;
-
-    const latestPlan = deps.plans.getLatest(threadId);
-    const structuredPlan = latestPlan?.structured;
-    if (!structuredPlan) {
       emitPhase(
         threadId,
         'failed',
-        'Test fix cannot start: structured plan missing for this thread.',
+        `Execution failed (exit ${response.exitCode})${errSnippet ? `: ${errSnippet}` : ''}`,
       );
       activePipelines.delete(threadId);
-      return;
+      return { next: 'failed' };
+    } catch (error) {
+      if (!context.cancelled) {
+        emitPhase(threadId, 'failed', `Execution error: ${String(error)}`);
+        activePipelines.delete(threadId);
+        return { next: 'failed' };
+      }
+      return { next: 'paused' };
     }
-
-    // Reset phase state, then inject focused test-fix feedback (consumed-once).
-    resetPhaseState(context);
-    context.stabilizationFeedback = formatTestFixFeedback(testOutput, context.testRetries);
-
-    await handlers.startExecution(threadId, structuredPlan);
   }
 
-  async function startTesting(threadId: string) {
+  async function startTesting(threadId: string): Promise<PhaseOutcome> {
     const context = activePipelines.get(threadId);
-    if (!context) return;
+    if (!context) return { next: 'paused' };
 
     try {
       ensureRepoSetupContract(context);
     } catch (error) {
       emitPhase(threadId, 'failed', error instanceof Error ? error.message : String(error));
       activePipelines.delete(threadId);
-      return;
+      return { next: 'failed' };
     }
 
     const verifyCommands = getVerifyCommands(context);
@@ -1196,11 +1176,11 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
 
     if (verifyCommands.length === 0 && !hasRuntimeQa) {
       resetPhaseState(context);
-      handlers.startVerification(threadId);
-      return;
+      return { next: 'verification' };
     }
 
-    if (queueTestingIfCpuBusy(threadId, context)) return;
+    const cpuQueueOutcome = queueTestingIfCpuBusy(threadId, context);
+    if (cpuQueueOutcome) return cpuQueueOutcome;
 
     emitPhase(threadId, 'testing');
 
@@ -1209,7 +1189,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
     if (!preparation.ok) {
       emitPhase(threadId, 'failed', `Verification preflight failed: ${preparation.error}`);
       activePipelines.delete(threadId);
-      return;
+      return { next: 'failed' };
     }
 
     if (hasVisualQa && context.featureQaState) {
@@ -1217,18 +1197,16 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
         const message =
           `[runtime-qa] Visual QA requires stable selectors, but selectorReadiness is ` +
           `"${context.featureQaState.selectorReadiness}". Add stable data-testid selectors for the visual QA targets.`;
-        if (
-          scheduleCoordinatedTestFixRetry(
-            threadId,
-            context,
-            'runtime-qa:selector-readiness',
-            message,
-          )
-        )
-          return;
+        const selectorRetry = scheduleCoordinatedTestFixRetry(
+          threadId,
+          context,
+          'runtime-qa:selector-readiness',
+          message,
+        );
+        if (selectorRetry) return selectorRetry;
         emitPhase(threadId, 'failed', message);
         activePipelines.delete(threadId);
-        return;
+        return { next: 'failed' };
       }
 
       const visualRoutes = context.featureQaState.visualAssertions ?? [];
@@ -1239,7 +1217,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
           'Configure .shipcode/setup.json runtimeQa.server so ShipCode can start the app under test.';
         emitPhase(threadId, 'failed', message);
         activePipelines.delete(threadId);
-        return;
+        return { next: 'failed' };
       }
 
       try {
@@ -1247,7 +1225,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
         if (!tooling.available) {
           emitPhase(threadId, 'failed', tooling.message);
           activePipelines.delete(threadId);
-          return;
+          return { next: 'failed' };
         }
         emitTerminalLifecycle(threadId, `[runtime-qa] ${tooling.message}\r\n`);
         if (tooling.warning) {
@@ -1263,7 +1241,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
         const message = error instanceof Error ? error.message : String(error);
         emitPhase(threadId, 'failed', `Visual QA generation failed: ${message}`);
         activePipelines.delete(threadId);
-        return;
+        return { next: 'failed' };
       }
     }
 
@@ -1276,28 +1254,33 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
         outputs.push(result.output);
         context.testOutput = outputs.join('\n').slice(-16384);
         if (result.exitCode !== 0) {
-          if (!scheduleCoordinatedTestFixRetry(threadId, context, command, result.output)) {
-            const testSummary = extractTestFailureSummary(context.testOutput ?? '');
-            deps.emitter.emit({
-              type: 'pipeline:verification-exhausted',
-              threadId,
-              retries: context.testRetries,
-              testSummary,
-            });
-            emitPhase(
-              threadId,
-              'failed',
-              `Test fix exhausted after ${context.testRetries + 1} attempt(s): ${testSummary}`,
-            );
-            activePipelines.delete(threadId);
-          }
-          return;
+          const retryOutcome = scheduleCoordinatedTestFixRetry(
+            threadId,
+            context,
+            command,
+            result.output,
+          );
+          if (retryOutcome) return retryOutcome;
+          const testSummary = extractTestFailureSummary(context.testOutput ?? '');
+          deps.emitter.emit({
+            type: 'pipeline:verification-exhausted',
+            threadId,
+            retries: context.testRetries,
+            testSummary,
+          });
+          emitPhase(
+            threadId,
+            'failed',
+            `Test fix exhausted after ${context.testRetries + 1} attempt(s): ${testSummary}`,
+          );
+          activePipelines.delete(threadId);
+          return { next: 'failed' };
         }
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         emitPhase(threadId, 'failed', `Verification command error: ${message}`);
         activePipelines.delete(threadId);
-        return;
+        return { next: 'failed' };
       }
     }
 
@@ -1313,14 +1296,15 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
         if (runtimeQaResult.fatal) {
           emitPhase(threadId, 'failed', runtimeQaResult.error);
           activePipelines.delete(threadId);
+          return { next: 'failed' };
         }
-        return;
+        return runtimeQaResult.outcome;
       }
     }
 
     context.testRetries = 0;
     resetPhaseState(context, ['testOutput', 'runtimeQaOutput']);
-    handlers.startVerification(threadId);
+    return { next: 'verification' };
   }
 
   async function runRuntimeQa(
@@ -1328,7 +1312,11 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
     context: PipelineContext,
     cwd: string,
     config: NonNullable<PipelineContext['repoSetupContract']>['contract']['runtimeQa'],
-  ): Promise<{ ok: true } | { ok: false; fatal: boolean; error: string }> {
+  ): Promise<
+    | { ok: true }
+    | { ok: false; fatal: true; error: string }
+    | { ok: false; fatal: false; outcome: PhaseOutcome }
+  > {
     if (!config) return { ok: true };
 
     emitTerminalLifecycle(threadId, '[runtime-qa] Starting runtime QA\r\n');
@@ -1402,11 +1390,13 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
           context.testOutput = `${context.testOutput ?? ''}\n${context.runtimeQaOutput}`.slice(
             -16384,
           );
-          if (
-            scheduleCoordinatedTestFixRetry(threadId, context, 'runtime-qa:server-crashed', failMsg)
-          ) {
-            return { ok: false, fatal: false, error: failMsg };
-          }
+          const crashRetry = scheduleCoordinatedTestFixRetry(
+            threadId,
+            context,
+            'runtime-qa:server-crashed',
+            failMsg,
+          );
+          if (crashRetry) return { ok: false, fatal: false, outcome: crashRetry };
           return { ok: false, fatal: true, error: failMsg };
         }
 
@@ -1427,9 +1417,13 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
             persistQaFlowResults();
             const visualFeedback = formatVisualQaFailureFeedback(commandQaResults);
             const output = `${context.runtimeQaOutput}${visualFeedback}`;
-            if (scheduleCoordinatedTestFixRetry(threadId, context, command, output)) {
-              return { ok: false, fatal: false, error: `Runtime test failed: ${command}` };
-            }
+            const commandRetry = scheduleCoordinatedTestFixRetry(
+              threadId,
+              context,
+              command,
+              output,
+            );
+            if (commandRetry) return { ok: false, fatal: false, outcome: commandRetry };
             return {
               ok: false,
               fatal: true,
@@ -1452,9 +1446,9 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
     }
   }
 
-  async function startVerification(threadId: string) {
+  async function startVerification(threadId: string): Promise<PhaseOutcome> {
     const context = activePipelines.get(threadId);
-    if (!context) return;
+    if (!context) return { next: 'paused' };
 
     emitPhase(threadId, 'verifying');
 
@@ -1467,7 +1461,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
         'Verification cannot start: structured plan missing for this thread.',
       );
       activePipelines.delete(threadId);
-      return;
+      return { next: 'failed' };
     }
 
     const plan = latestPlan.structured;
@@ -1495,7 +1489,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
       console.error(`[pipeline] pre-verification commit failed for thread ${threadId}:`, msg);
       emitPhase(threadId, 'failed', `Pre-verification commit failed: ${msg}`);
       activePipelines.delete(threadId);
-      return;
+      return { next: 'failed' };
     }
 
     const headSha = execFileSync('git', ['rev-parse', 'HEAD'], { cwd, encoding: 'utf-8' }).trim();
@@ -1525,7 +1519,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
         'Verification skipped: executor produced no file changes (empty diff vs. worktree base).',
       );
       activePipelines.delete(threadId);
-      return;
+      return { next: 'failed' };
     }
 
     deps.diffs.replaceForThread(threadId, parseUnifiedDiff(diff));
@@ -1591,150 +1585,148 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
         `WORKFLOW.md template render error: ${error instanceof Error ? error.message : String(error)}`,
       );
       activePipelines.delete(threadId);
-      return;
+      return { next: 'failed' };
     }
 
-    void (async () => {
-      try {
-        const response = await runProviderPhase(
-          context,
-          'verify',
-          verificationPrompt,
-          verifyMaterials,
-          {
-            reasoningEffort: context.phaseReasoningEfforts.verify,
-          },
+    try {
+      const response = await runProviderPhase(
+        context,
+        'verify',
+        verificationPrompt,
+        verifyMaterials,
+        {
+          reasoningEffort: context.phaseReasoningEfforts.verify,
+        },
+      );
+
+      if (context.cancelled) return { next: 'paused' };
+
+      const parser = new StreamParser();
+      parser.feed(response.rawOutput);
+      const result = parser.extractVerification();
+
+      if (!(result.success && result.data)) {
+        deps.verifications.create(threadId, latestPlan.id, parser.getRawOutput(), null);
+        emitPhase(
+          threadId,
+          'failed',
+          'Verification output could not be parsed — verifier did not emit a shipcode-verify block.',
         );
+        activePipelines.delete(threadId);
+        return { next: 'failed' };
+      }
 
-        if (context.cancelled) return;
+      deps.verifications.create(threadId, latestPlan.id, result.raw, result.data);
+      deps.emitter.emit({ type: 'verification:parsed', threadId, verification: result.data });
 
-        const parser = new StreamParser();
-        parser.feed(response.rawOutput);
-        const result = parser.extractVerification();
-
-        if (result.success && result.data) {
-          deps.verifications.create(threadId, latestPlan.id, result.raw, result.data);
-          deps.emitter.emit({ type: 'verification:parsed', threadId, verification: result.data });
-
-          if (context.featureQaState) {
-            try {
-              const qaFlowResults = extractQaFlowResults(response.rawOutput);
-              if (qaFlowResults.length > 0) {
-                deps.featureQaResults?.insert({
-                  threadId,
-                  featureId: context.featureQaState.featureId,
-                  status: toQaStatus(qaFlowResults),
-                  flowResults: qaFlowResults,
-                  summary: result.data.summary,
-                  evidencePaths: collectQaEvidencePaths(qaFlowResults),
-                });
-              }
-            } catch (err) {
-              console.error('[pipeline] feature QA result insert failed:', err);
-            }
-          }
-
-          if (result.data.result === 'passed') {
-            resetPhaseState(context);
-            handlers.startCommitAndPush(threadId);
-          } else if (context.verificationRetries < MAX_VERIFICATION_RETRIES) {
-            context.verificationRetries++;
-            const delayMs = computeRetryDelayMs({
-              reason: 'continuation',
-              attempt: context.verificationRetries,
-            });
-            if (context.retryTimer) clearTimeout(context.retryTimer);
-            context.retryTimer = setTimeout(() => {
-              context.retryTimer = null;
-              if (context.cancelled || !activePipelines.has(threadId)) return;
-              resetPhaseState(context);
-              handlers.startExecution(threadId, plan);
-            }, delayMs);
-          } else {
-            deps.emitter.emit({
-              type: 'pipeline:verification-exhausted',
+      if (context.featureQaState) {
+        try {
+          const qaFlowResults = extractQaFlowResults(response.rawOutput);
+          if (qaFlowResults.length > 0) {
+            deps.featureQaResults?.insert({
               threadId,
-              retries: context.verificationRetries,
+              featureId: context.featureQaState.featureId,
+              status: toQaStatus(qaFlowResults),
+              flowResults: qaFlowResults,
+              summary: result.data.summary,
+              evidencePaths: collectQaEvidencePaths(qaFlowResults),
             });
-
-            // Turn-level retry: if maxTurns allows, start a new turn
-            // (re-enter planning with a continuation prompt).
-            const maxTurns = context.workflowPolicy.agent.maxTurns;
-            if (context.turnCount + 1 < maxTurns) {
-              deps.emitter.emit({
-                type: 'pipeline:turn-completed',
-                threadId,
-                turnNumber: context.turnCount + 1,
-                result: 'failed',
-              });
-              context.turnCount++;
-              context.verificationRetries = 0;
-              context.testRetries = 0;
-              context.retryCount = 0;
-              deps.emitter.emit({
-                type: 'pipeline:turn-started',
-                threadId,
-                turnNumber: context.turnCount + 1,
-              });
-
-              // Build continuation prompt — short, references prior failure
-              const failureReason =
-                result.data.summary ?? 'Verification failed — address remaining gaps.';
-              const continuationPrompt = buildContinuationPrompt(context, failureReason);
-
-              const delayMs = computeRetryDelayMs({
-                reason: 'continuation',
-                attempt: 1,
-              });
-              if (context.retryTimer) clearTimeout(context.retryTimer);
-              context.retryTimer = setTimeout(() => {
-                context.retryTimer = null;
-                if (context.cancelled || !activePipelines.has(threadId)) return;
-                resetPhaseState(context);
-                handlers.startPlanGeneration(
-                  threadId,
-                  continuationPrompt,
-                  context.projectPath,
-                  context.worktreePath,
-                );
-              }, delayMs);
-            } else {
-              deps.emitter.emit({
-                type: 'pipeline:turn-completed',
-                threadId,
-                turnNumber: context.turnCount + 1,
-                result: 'max_turns_reached',
-              });
-              emitPhase(
-                threadId,
-                'failed',
-                `Verification failed: max turns reached (${context.turnCount + 1}/${maxTurns}).`,
-              );
-              activePipelines.delete(threadId);
-            }
           }
-        } else {
-          deps.verifications.create(threadId, latestPlan.id, parser.getRawOutput(), null);
-          emitPhase(
-            threadId,
-            'failed',
-            'Verification output could not be parsed — verifier did not emit a shipcode-verify block.',
-          );
-          activePipelines.delete(threadId);
-        }
-      } catch (err) {
-        if (!context.cancelled) {
-          const message = err instanceof Error ? err.message : String(err);
-          emitPhase(threadId, 'failed', `Verification error: ${message}`);
-          activePipelines.delete(threadId);
+        } catch (err) {
+          console.error('[pipeline] feature QA result insert failed:', err);
         }
       }
-    })();
+
+      if (result.data.result === 'passed') {
+        resetPhaseState(context);
+        return { next: 'commit' };
+      }
+
+      if (context.verificationRetries < MAX_VERIFICATION_RETRIES) {
+        context.verificationRetries++;
+        const delayMs = computeRetryDelayMs({
+          reason: 'continuation',
+          attempt: context.verificationRetries,
+        });
+        resetPhaseState(context);
+        return { next: 'retry', delayMs, andThen: { next: 'execute', plan } };
+      }
+
+      deps.emitter.emit({
+        type: 'pipeline:verification-exhausted',
+        threadId,
+        retries: context.verificationRetries,
+      });
+
+      // Turn-level retry: if maxTurns allows, start a new turn
+      // (re-enter planning with a continuation prompt).
+      const maxTurns = context.workflowPolicy.agent.maxTurns;
+      if (context.turnCount + 1 < maxTurns) {
+        deps.emitter.emit({
+          type: 'pipeline:turn-completed',
+          threadId,
+          turnNumber: context.turnCount + 1,
+          result: 'failed',
+        });
+        context.turnCount++;
+        context.verificationRetries = 0;
+        context.testRetries = 0;
+        context.retryCount = 0;
+        deps.emitter.emit({
+          type: 'pipeline:turn-started',
+          threadId,
+          turnNumber: context.turnCount + 1,
+        });
+
+        // Build continuation prompt — short, references prior failure
+        const failureReason =
+          result.data.summary ?? 'Verification failed — address remaining gaps.';
+        const continuationPrompt = buildContinuationPrompt(context, failureReason);
+
+        const delayMs = computeRetryDelayMs({
+          reason: 'continuation',
+          attempt: 1,
+        });
+        resetPhaseState(context);
+        return {
+          next: 'retry',
+          delayMs,
+          andThen: {
+            next: 'plan',
+            prompt: continuationPrompt,
+            projectPath: context.projectPath,
+            worktreePath: context.worktreePath,
+          },
+        };
+      }
+
+      deps.emitter.emit({
+        type: 'pipeline:turn-completed',
+        threadId,
+        turnNumber: context.turnCount + 1,
+        result: 'max_turns_reached',
+      });
+      emitPhase(
+        threadId,
+        'failed',
+        `Verification failed: max turns reached (${context.turnCount + 1}/${maxTurns}).`,
+      );
+      activePipelines.delete(threadId);
+      return { next: 'failed' };
+    } catch (err) {
+      if (!context.cancelled) {
+        const message = err instanceof Error ? err.message : String(err);
+        emitPhase(threadId, 'failed', `Verification error: ${message}`);
+        activePipelines.delete(threadId);
+        return { next: 'failed' };
+      }
+      return { next: 'paused' };
+    }
   }
 
-  async function startCommitAndPush(threadId: string) {
+  async function startCommitAndPush(threadId: string): Promise<PhaseOutcome> {
     const context = activePipelines.get(threadId);
-    if (!context) return;
+    if (!context) return { next: 'paused' };
 
     const cwd = context.worktreePath ?? context.projectPath;
 
@@ -1750,7 +1742,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
           'Commit aborted: HEAD moved after verification (verifiedSha mismatch).',
         );
         activePipelines.delete(threadId);
-        return;
+        return { next: 'failed' };
       }
 
       const diffBase = resolveWorktreeDiffBase(context);
@@ -1767,7 +1759,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
           'Commit aborted: no commits ahead of worktree base — nothing to push.',
         );
         activePipelines.delete(threadId);
-        return;
+        return { next: 'failed' };
       }
 
       const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
@@ -1777,7 +1769,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
       execFileSync('git', ['push', 'origin', branch, '--set-upstream'], { cwd, encoding: 'utf-8' });
 
       resetPhaseState(context);
-      handlers.startShipping(threadId);
+      return { next: 'shipping' };
     } catch (firstErr) {
       try {
         const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
@@ -1789,7 +1781,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
           encoding: 'utf-8',
         });
         resetPhaseState(context);
-        handlers.startShipping(threadId);
+        return { next: 'shipping' };
       } catch (secondErr) {
         const message = secondErr instanceof Error ? secondErr.message : String(secondErr);
         const firstMessage = firstErr instanceof Error ? firstErr.message : String(firstErr);
@@ -1799,13 +1791,14 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
           `Commit and push failed (both attempts). first=${firstMessage.slice(0, 120)} retry=${message.slice(0, 120)}`,
         );
         activePipelines.delete(threadId);
+        return { next: 'failed' };
       }
     }
   }
 
-  async function startShipping(threadId: string) {
+  async function startShipping(threadId: string): Promise<PhaseOutcome> {
     const context = activePipelines.get(threadId);
-    if (!context) return;
+    if (!context) return { next: 'paused' };
 
     emitPhase(threadId, 'shipping');
 
@@ -1814,7 +1807,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
       // skip PR shipping. Branch is left on disk for manual follow-up.
       emitPhase(threadId, 'completed');
       activePipelines.delete(threadId);
-      return;
+      return { next: 'done' };
     }
     const issueNumber = context.githubIssueNumber;
 
@@ -1963,11 +1956,14 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
       }
 
       emitPhase(threadId, 'completed');
+      activePipelines.delete(threadId);
+      return { next: 'done' };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       emitPhase(threadId, 'failed', `Shipping failed: ${message}`);
+      activePipelines.delete(threadId);
+      return { next: 'failed' };
     }
-    activePipelines.delete(threadId);
   }
 
   async function startStabilization(
@@ -1978,9 +1974,9 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
       failingChecks: GitHubPrCheckSummary[];
       unresolvedReviewComments: GitHubPrReviewCommentSummary[];
     },
-  ) {
+  ): Promise<PhaseOutcome> {
     const context = activePipelines.get(threadId);
-    if (!context) return;
+    if (!context) return { next: 'paused' };
 
     const latestPlan = deps.plans.getLatest(threadId);
     if (!latestPlan?.structured) {
@@ -1991,7 +1987,7 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
     resetPhaseState(context);
     context.stabilizationFeedback = formatStabilizationFeedback(inputs);
     context.verifiedSha = null;
-    await handlers.startExecution(threadId, latestPlan.structured);
+    return { next: 'execute', plan: latestPlan.structured };
   }
 
   return {

--- a/packages/pipeline/src/pipeline/planning-phases.test.ts
+++ b/packages/pipeline/src/pipeline/planning-phases.test.ts
@@ -10,7 +10,7 @@ import {
   createPlanningPhaseHandlers,
   formatPlanParseFailure,
 } from './planning-phases';
-import type { PipelineContextHelpers, PipelinePhaseHandlers, PipelineRuntime } from './shared';
+import type { PipelineContextHelpers, PipelineRuntime } from './shared';
 
 function clarificationRequest(id: string, questionId: string, title: string) {
   return {
@@ -215,18 +215,11 @@ function makePlanningHarness(context = makePlanningContext()) {
     resolveAgentForPhase: vi.fn(() => context.plannerModel),
     runProviderPhase: vi.fn(async () => ({ rawOutput: planBlock, exitCode: 0 })),
   } as unknown as PipelineRuntime;
-  const handlers = {
-    startExecution: vi.fn(),
-    startReview: vi.fn(),
-    startRevision: vi.fn(),
-  } as unknown as PipelinePhaseHandlers;
-  const phaseHandlers = createPlanningPhaseHandlers({
+  const handlers = createPlanningPhaseHandlers({
     deps: deps as never,
     contextHelpers,
     runtime,
-    handlers,
   });
-  Object.assign(handlers, phaseHandlers);
   return { activePipelines, context, deps, handlers, runtime };
 }
 
@@ -541,19 +534,16 @@ describe('planning phase helpers', () => {
       exitCode: 0,
     });
 
-    await revision.handlers.startReview('thread-1', plan as never);
-    await Promise.resolve();
-    await Promise.resolve();
+    const revisionOutcome = await revision.handlers.startReview('thread-1', plan as never);
 
     expect(revision.deps.threads.incrementReviewRound).toHaveBeenCalledWith('thread-1');
-    expect(revision.runtime.emitPhase).toHaveBeenCalledWith('thread-1', 'revising');
-    expect(revision.runtime.runProviderPhase).toHaveBeenCalledWith(
-      revision.context,
-      'revision',
-      expect.stringContaining('[minor] Missing test'),
-      expect.any(Array),
-      expect.any(Object),
-    );
+    // request_changes within the revision budget returns a revision outcome for
+    // the dispatch loop (it no longer calls startRevision directly).
+    expect(revisionOutcome).toEqual({
+      next: 'revision',
+      plan,
+      reviewFeedback: expect.stringContaining('[minor] Missing test'),
+    });
   });
 
   it('fails review on parser-impossible decisions and ignores cancelled review errors', async () => {

--- a/packages/pipeline/src/pipeline/planning-phases.ts
+++ b/packages/pipeline/src/pipeline/planning-phases.ts
@@ -34,7 +34,7 @@ import { computeRetryDelayMs } from '../retry-scheduler';
 import type { PipelineContext } from '../types';
 import { renderWorkflowPromptTemplate } from '../workflow-prompt';
 import { resetPhaseState } from './context';
-import type { PipelineHelperEnv } from './shared';
+import type { PhaseOutcome, PipelineHelperEnv } from './shared';
 
 const NO_VALID_PLAN_REASON = 'Plan generation failed — no valid shipcode-plan block was produced.';
 
@@ -90,12 +90,7 @@ export function buildClarificationContext(context: PipelineContext): string | nu
   ].join('\n\n');
 }
 
-export function createPlanningPhaseHandlers({
-  deps,
-  contextHelpers,
-  runtime,
-  handlers,
-}: PipelineHelperEnv) {
+export function createPlanningPhaseHandlers({ deps, contextHelpers, runtime }: PipelineHelperEnv) {
   const { activePipelines, ensureContext, skillCallSite } = contextHelpers;
   const {
     buildRepoSetupPlannerNote,
@@ -144,7 +139,7 @@ export function createPlanningPhaseHandlers({
     threadId: string,
     context: ReturnType<typeof ensureContext>,
     request: ClarificationRequest,
-  ) {
+  ): PhaseOutcome {
     const nextRound = context.clarificationRound + 1;
     if (nextRound > MAX_CLARIFICATION_ROUNDS) {
       emitPhase(
@@ -153,7 +148,7 @@ export function createPlanningPhaseHandlers({
         `Planning clarification limit reached after ${MAX_CLARIFICATION_ROUNDS} rounds.`,
       );
       activePipelines.delete(threadId);
-      return;
+      return { next: 'failed' };
     }
 
     context.clarificationRound = nextRound;
@@ -177,6 +172,7 @@ export function createPlanningPhaseHandlers({
       },
     });
     emitPhase(threadId, 'clarifying');
+    return { next: 'paused' };
   }
 
   function clearClarificationState(threadId: string, context: ReturnType<typeof ensureContext>) {
@@ -230,7 +226,7 @@ export function createPlanningPhaseHandlers({
     context: ReturnType<typeof ensureContext>,
     plan: PlanRecord,
     structuredPlan: ShipCodePlan,
-  ) {
+  ): Promise<PhaseOutcome> {
     let taskGraph: TaskGraphWithNodes | null = null;
     try {
       taskGraph =
@@ -250,8 +246,7 @@ export function createPlanningPhaseHandlers({
     if (revisionCount > 0) {
       deps.plans.updateStatus(plan.id, 'pending_review');
       resetPhaseState(context);
-      handlers.startReview(threadId, structuredPlan);
-      return;
+      return { next: 'review', plan: structuredPlan };
     }
 
     deps.plans.updateStatus(plan.id, 'approved');
@@ -279,7 +274,7 @@ export function createPlanningPhaseHandlers({
       deps.plans.updateStatus(plan.id, 'approval');
       void postPlanComment(context, structuredPlan);
       emitPhase(threadId, 'approval');
-      return;
+      return { next: 'paused' };
     }
 
     deps.emitter.emit({
@@ -296,7 +291,7 @@ export function createPlanningPhaseHandlers({
       reasons,
     });
     resetPhaseState(context);
-    handlers.startExecution(threadId, structuredPlan);
+    return { next: 'execute', plan: structuredPlan };
   }
 
   async function startPlanGeneration(
@@ -304,7 +299,7 @@ export function createPlanningPhaseHandlers({
     prompt: string,
     projectPath: string,
     worktreePath: string | null,
-  ) {
+  ): Promise<PhaseOutcome> {
     const context = ensureContext(threadId, { projectPath, worktreePath });
     clearRetryTimer(context);
 
@@ -323,7 +318,7 @@ export function createPlanningPhaseHandlers({
     } catch (error) {
       emitPhase(threadId, 'failed', error instanceof Error ? error.message : String(error));
       activePipelines.delete(threadId);
-      return;
+      return { next: 'failed' };
     }
 
     // PRD quality gate — check issue body for required sections and structure.
@@ -340,7 +335,7 @@ export function createPlanningPhaseHandlers({
           `PRD quality gate: ${issueList}. Update the issue body and re-trigger.`,
         );
         activePipelines.delete(threadId);
-        return;
+        return { next: 'failed' };
       }
 
       // Gate OFF (default) — post/log a warning and continue
@@ -382,7 +377,7 @@ export function createPlanningPhaseHandlers({
         `WORKFLOW.md template render error: ${error instanceof Error ? error.message : String(error)}`,
       );
       activePipelines.delete(threadId);
-      return;
+      return { next: 'failed' };
     }
     const planPrompt =
       (workflowPlanPrompt ??
@@ -400,134 +395,128 @@ export function createPlanningPhaseHandlers({
       buildRepoSetupPlannerNote(context) +
       (previousAttempt ? buildPreviousAttemptContext(previousAttempt) : '');
 
-    void (async () => {
-      try {
-        const response = await runProviderPhase(context, 'plan', planPrompt, planMaterials, {
-          reasoningEffort: context.phaseReasoningEfforts.plan,
-        });
+    try {
+      const response = await runProviderPhase(context, 'plan', planPrompt, planMaterials, {
+        reasoningEffort: context.phaseReasoningEfforts.plan,
+      });
 
-        if (context.cancelled) return;
+      if (context.cancelled) return { next: 'paused' };
 
-        if (response.exitCode === 127) {
-          const agent = resolveAgentForPhase(context, 'plan');
-          const name = agent === 'openrouter' ? 'Provider' : `${agent} CLI`;
-          emitPhase(
-            threadId,
-            'failed',
-            `${name} not found (exit 127). Is the ${agent} binary installed and on PATH?`,
-          );
-          activePipelines.delete(threadId);
-          return;
-        }
-
-        const parser = new StreamParser();
-        parser.feed(response.rawOutput);
-        const clarificationRequest = resolveClarificationRequest(
-          parser,
-          response.clarificationRequest,
+      if (response.exitCode === 127) {
+        const agent = resolveAgentForPhase(context, 'plan');
+        const name = agent === 'openrouter' ? 'Provider' : `${agent} CLI`;
+        emitPhase(
+          threadId,
+          'failed',
+          `${name} not found (exit 127). Is the ${agent} binary installed and on PATH?`,
         );
+        activePipelines.delete(threadId);
+        return { next: 'failed' };
+      }
 
-        if (response.exitCode !== 0) {
-          const result = parser.extractPlan();
-          if (result.success && result.data) {
-            clearClarificationState(threadId, context);
-            const nextVersion = deps.plans.getMaxVersion(threadId) + 1;
-            const plan = deps.plans.create(threadId, result.raw, result.data, nextVersion);
-            await continueFromStructuredPlan(threadId, context, plan, result.data);
-          } else if (clarificationRequest) {
-            enterClarifying(threadId, context, clarificationRequest);
-          } else {
-            const detectedError = parser.detectError();
-            if (context.retryCount < PIPELINE_MAX_RETRIES) {
-              context.retryCount++;
-              context.previousPlanRawOutput = response.rawOutput;
-              const delayMs = computeRetryDelayMs({
-                reason: 'failure',
-                attempt: context.retryCount,
-                maxRetryBackoffMs: context.workflowPolicy.agent.maxRetryBackoffMs,
-              });
-              if (context.retryTimer) clearTimeout(context.retryTimer);
-              context.retryTimer = setTimeout(() => {
-                context.retryTimer = null;
-                if (context.cancelled || !activePipelines.has(threadId)) return;
-                void handlers.startPlanGeneration(threadId, prompt, projectPath, worktreePath);
-              }, delayMs);
-            } else {
-              let cliError: string | null = null;
-              for (const line of parser
-                .getRawOutput()
-                .trim()
-                .split('\n')
-                .filter(Boolean)
-                .reverse()) {
-                try {
-                  const obj = JSON.parse(line.trim()) as Record<string, unknown>;
-                  if (obj.type === 'result') {
-                    if (typeof obj.result === 'string') {
-                      cliError = obj.result.slice(0, 300);
-                      break;
-                    }
-                    if (
-                      Array.isArray(obj.errors) &&
-                      obj.errors.length > 0 &&
-                      typeof obj.errors[0] === 'string'
-                    ) {
-                      cliError = obj.errors[0].slice(0, 300);
-                      break;
-                    }
-                  }
-                } catch {
-                  // skip malformed lines
-                }
-              }
-              const rawSnippet =
-                cliError ??
-                detectedError?.match ??
-                parser
-                  .getRawOutput()
-                  .trim()
-                  .split('\n')
-                  .filter(Boolean)
-                  .slice(-3)
-                  .join(' ')
-                  .slice(0, 300);
-              const reason = rawSnippet?.trimStart().startsWith('{') ? '' : rawSnippet;
-              emitPhase(
-                threadId,
-                'failed',
-                reason || 'Plan generation failed — no structured plan was produced.',
-              );
-              activePipelines.delete(threadId);
-            }
-          }
-          return;
-        }
+      const parser = new StreamParser();
+      parser.feed(response.rawOutput);
+      const clarificationRequest = resolveClarificationRequest(
+        parser,
+        response.clarificationRequest,
+      );
 
+      if (response.exitCode !== 0) {
         const result = parser.extractPlan();
-        const nextVersion = deps.plans.getMaxVersion(threadId) + 1;
         if (result.success && result.data) {
           clearClarificationState(threadId, context);
+          const nextVersion = deps.plans.getMaxVersion(threadId) + 1;
           const plan = deps.plans.create(threadId, result.raw, result.data, nextVersion);
-          await continueFromStructuredPlan(threadId, context, plan, result.data);
-        } else if (clarificationRequest) {
-          enterClarifying(threadId, context, clarificationRequest);
-        } else {
-          deps.plans.create(threadId, result.raw, null, nextVersion);
-          emitPhase(threadId, 'failed', formatPlanParseFailure(result.error));
-          activePipelines.delete(threadId);
+          return await continueFromStructuredPlan(threadId, context, plan, result.data);
         }
-      } catch (error) {
-        if (!context.cancelled) {
-          emitPhase(threadId, 'failed', `Plan generation error: ${String(error)}`);
-          activePipelines.delete(threadId);
+        if (clarificationRequest) {
+          return enterClarifying(threadId, context, clarificationRequest);
         }
+        const detectedError = parser.detectError();
+        if (context.retryCount < PIPELINE_MAX_RETRIES) {
+          context.retryCount++;
+          context.previousPlanRawOutput = response.rawOutput;
+          const delayMs = computeRetryDelayMs({
+            reason: 'failure',
+            attempt: context.retryCount,
+            maxRetryBackoffMs: context.workflowPolicy.agent.maxRetryBackoffMs,
+          });
+          return {
+            next: 'retry',
+            delayMs,
+            andThen: { next: 'plan', prompt, projectPath, worktreePath },
+          };
+        }
+        let cliError: string | null = null;
+        for (const line of parser.getRawOutput().trim().split('\n').filter(Boolean).reverse()) {
+          try {
+            const obj = JSON.parse(line.trim()) as Record<string, unknown>;
+            if (obj.type === 'result') {
+              if (typeof obj.result === 'string') {
+                cliError = obj.result.slice(0, 300);
+                break;
+              }
+              if (
+                Array.isArray(obj.errors) &&
+                obj.errors.length > 0 &&
+                typeof obj.errors[0] === 'string'
+              ) {
+                cliError = obj.errors[0].slice(0, 300);
+                break;
+              }
+            }
+          } catch {
+            // skip malformed lines
+          }
+        }
+        const rawSnippet =
+          cliError ??
+          detectedError?.match ??
+          parser
+            .getRawOutput()
+            .trim()
+            .split('\n')
+            .filter(Boolean)
+            .slice(-3)
+            .join(' ')
+            .slice(0, 300);
+        const reason = rawSnippet?.trimStart().startsWith('{') ? '' : rawSnippet;
+        emitPhase(
+          threadId,
+          'failed',
+          reason || 'Plan generation failed — no structured plan was produced.',
+        );
+        activePipelines.delete(threadId);
+        return { next: 'failed' };
       }
-    })();
+
+      const result = parser.extractPlan();
+      const nextVersion = deps.plans.getMaxVersion(threadId) + 1;
+      if (result.success && result.data) {
+        clearClarificationState(threadId, context);
+        const plan = deps.plans.create(threadId, result.raw, result.data, nextVersion);
+        return await continueFromStructuredPlan(threadId, context, plan, result.data);
+      }
+      if (clarificationRequest) {
+        return enterClarifying(threadId, context, clarificationRequest);
+      }
+      deps.plans.create(threadId, result.raw, null, nextVersion);
+      emitPhase(threadId, 'failed', formatPlanParseFailure(result.error));
+      activePipelines.delete(threadId);
+      return { next: 'failed' };
+    } catch (error) {
+      if (!context.cancelled) {
+        emitPhase(threadId, 'failed', `Plan generation error: ${String(error)}`);
+        activePipelines.delete(threadId);
+        return { next: 'failed' };
+      }
+      return { next: 'paused' };
+    }
   }
 
-  async function startReview(threadId: string, plan: ShipCodePlan) {
+  async function startReview(threadId: string, plan: ShipCodePlan): Promise<PhaseOutcome> {
     const context = activePipelines.get(threadId);
-    if (!context) return;
+    if (!context) return { next: 'paused' };
 
     emitPhase(threadId, 'reviewing');
 
@@ -551,7 +540,7 @@ export function createPlanningPhaseHandlers({
         `WORKFLOW.md template render error: ${error instanceof Error ? error.message : String(error)}`,
       );
       activePipelines.delete(threadId);
-      return;
+      return { next: 'failed' };
     }
     const reviewPromptText =
       workflowReviewPrompt ??
@@ -560,232 +549,238 @@ export function createPlanningPhaseHandlers({
         promptMaterials: reviewMaterials,
       });
 
-    void (async () => {
-      try {
-        const response = await runProviderPhase(
-          context,
-          'review',
-          reviewPromptText,
-          reviewMaterials,
-          {
-            reasoningEffort: context.phaseReasoningEfforts.review,
-          },
+    try {
+      const response = await runProviderPhase(
+        context,
+        'review',
+        reviewPromptText,
+        reviewMaterials,
+        {
+          reasoningEffort: context.phaseReasoningEfforts.review,
+        },
+      );
+
+      if (context.cancelled) return { next: 'paused' };
+
+      if (response.exitCode === 127) {
+        const agent = resolveAgentForPhase(context, 'review');
+        const name = agent === 'openrouter' ? 'Provider' : `${agent} CLI`;
+        emitPhase(
+          threadId,
+          'failed',
+          `${name} not found (exit 127). Is the ${agent} binary installed and on PATH?`,
         );
-
-        if (context.cancelled) return;
-
-        if (response.exitCode === 127) {
-          const agent = resolveAgentForPhase(context, 'review');
-          const name = agent === 'openrouter' ? 'Provider' : `${agent} CLI`;
-          emitPhase(
-            threadId,
-            'failed',
-            `${name} not found (exit 127). Is the ${agent} binary installed and on PATH?`,
-          );
-          activePipelines.delete(threadId);
-          return;
-        }
-
-        const parser = new StreamParser();
-        parser.feed(response.rawOutput);
-
-        const result = parser.extractReview();
-        const latestPlan = deps.plans.getLatest(threadId);
-
-        if (result.success && result.data && latestPlan) {
-          const latestStructuredPlan = latestPlan.structured;
-          if (!latestStructuredPlan) {
-            emitPhase(
-              threadId,
-              'failed',
-              'Review aborted: latest plan record has no structured plan.',
-            );
-            activePipelines.delete(threadId);
-            return;
-          }
-          deps.reviews.create(latestPlan.id, result.raw, result.data);
-          deps.plans.updateStatus(
-            latestPlan.id,
-            result.data.decision === 'approve' ? 'approved' : 'rejected',
-          );
-          deps.emitter.emit({ type: 'review:parsed', threadId, review: result.data });
-
-          if (result.data.decision === 'approve') {
-            const requireApproval = getRequireApprovalForContext(context);
-            const revisionCount = getRevisionCountForContext(context);
-            const reasons: Array<'requireApproval' | 'nonAutonomous' | 'reviewApproved'> = [
-              'reviewApproved',
-            ];
-            if (requireApproval) reasons.push('requireApproval');
-            if (!context.autonomous) reasons.push('nonAutonomous');
-
-            if (requireApproval || !context.autonomous) {
-              deps.emitter.emit({
-                type: 'pipeline:approval-gate',
-                threadId,
-                outcome: 'approval',
-                reviewDecision: 'approve',
-                planVersion: latestPlan.version,
-                requireApproval,
-                autonomous: context.autonomous,
-                reviewRound: context.reviewRound,
-                revisionCount,
-                hasCriticalOrMajor: false,
-                reasons,
-              });
-              deps.plans.updateStatus(latestPlan.id, 'approval');
-              void postPlanComment(context, latestStructuredPlan);
-              emitPhase(threadId, 'approval');
-            } else {
-              deps.emitter.emit({
-                type: 'pipeline:approval-gate',
-                threadId,
-                outcome: 'auto_execute',
-                reviewDecision: 'approve',
-                planVersion: latestPlan.version,
-                requireApproval,
-                autonomous: context.autonomous,
-                reviewRound: context.reviewRound,
-                revisionCount,
-                hasCriticalOrMajor: false,
-                reasons,
-              });
-              resetPhaseState(context);
-              handlers.startExecution(threadId, latestStructuredPlan);
-            }
-          } else if (result.data.decision === 'request_changes') {
-            const revisionCountLimit = getRevisionCountForContext(context);
-            if (context.reviewRound < revisionCountLimit) {
-              context.reviewRound++;
-              deps.threads.incrementReviewRound(threadId);
-              const feedback =
-                result.data.suggestedChanges.join('\n') +
-                '\n\nFindings:\n' +
-                result.data.findings
-                  .map(
-                    (finding: { severity: string; description: string; suggestion?: string }) =>
-                      `[${finding.severity}] ${finding.description}${finding.suggestion ? ` — ${finding.suggestion}` : ''}`,
-                  )
-                  .join('\n');
-              resetPhaseState(context);
-              handlers.startRevision(threadId, latestStructuredPlan, feedback);
-            } else {
-              const hasCriticalOrMajor = result.data.findings.some(
-                (finding: { severity: string }) =>
-                  finding.severity === 'critical' || finding.severity === 'major',
-              );
-              const requireApproval = getRequireApprovalForContext(context);
-              const reasons: Array<
-                'requireApproval' | 'nonAutonomous' | 'criticalFindings' | 'revisionsExhausted'
-              > = ['revisionsExhausted'];
-              if (requireApproval) reasons.push('requireApproval');
-              if (!context.autonomous) reasons.push('nonAutonomous');
-              if (hasCriticalOrMajor) reasons.push('criticalFindings');
-
-              if (requireApproval || !context.autonomous || hasCriticalOrMajor) {
-                deps.emitter.emit({
-                  type: 'pipeline:approval-gate',
-                  threadId,
-                  outcome: 'approval',
-                  reviewDecision: 'request_changes',
-                  planVersion: latestPlan.version,
-                  requireApproval,
-                  autonomous: context.autonomous,
-                  reviewRound: context.reviewRound,
-                  revisionCount: revisionCountLimit,
-                  hasCriticalOrMajor,
-                  reasons,
-                });
-                deps.plans.updateStatus(latestPlan.id, 'approval');
-                void postPlanComment(context, latestStructuredPlan);
-                emitPhase(threadId, 'approval');
-              } else {
-                deps.emitter.emit({
-                  type: 'pipeline:approval-gate',
-                  threadId,
-                  outcome: 'auto_execute',
-                  reviewDecision: 'request_changes',
-                  planVersion: latestPlan.version,
-                  requireApproval,
-                  autonomous: context.autonomous,
-                  reviewRound: context.reviewRound,
-                  revisionCount: revisionCountLimit,
-                  hasCriticalOrMajor,
-                  reasons,
-                });
-                resetPhaseState(context);
-                handlers.startExecution(threadId, latestStructuredPlan);
-              }
-            }
-          } else if (result.data.decision === 'reject') {
-            // Reviewer rejected the plan outright — do not loop revisions
-            // and do not auto-execute even in autonomous mode. Halt at the
-            // approval gate so the user can intervene (edit issue, retry,
-            // or abandon).
-            const hasCriticalOrMajor = result.data.findings.some(
-              (finding: { severity: string }) =>
-                finding.severity === 'critical' || finding.severity === 'major',
-            );
-            const requireApproval = getRequireApprovalForContext(context);
-            const revisionCountLimit = getRevisionCountForContext(context);
-            const reasons: Array<
-              'requireApproval' | 'nonAutonomous' | 'criticalFindings' | 'reviewRejected'
-            > = ['reviewRejected'];
-            if (requireApproval) reasons.push('requireApproval');
-            if (!context.autonomous) reasons.push('nonAutonomous');
-            if (hasCriticalOrMajor) reasons.push('criticalFindings');
-
-            deps.emitter.emit({
-              type: 'pipeline:approval-gate',
-              threadId,
-              outcome: 'approval',
-              reviewDecision: 'reject',
-              planVersion: latestPlan.version,
-              requireApproval,
-              autonomous: context.autonomous,
-              reviewRound: context.reviewRound,
-              revisionCount: revisionCountLimit,
-              hasCriticalOrMajor,
-              reasons,
-            });
-            deps.plans.updateStatus(latestPlan.id, 'approval');
-            void postPlanComment(context, latestStructuredPlan);
-            emitPhase(threadId, 'approval');
-          } else {
-            emitPhase(
-              threadId,
-              'failed',
-              `Review failed: reviewer returned an unexpected decision (${result.data.decision ?? 'unknown'}).`,
-            );
-            activePipelines.delete(threadId);
-          }
-        } else {
-          if (latestPlan) {
-            deps.reviews.create(latestPlan.id, parser.getRawOutput(), null);
-          }
-          emitPhase(
-            threadId,
-            'failed',
-            'Review output could not be parsed — reviewer did not emit a shipcode-review block.',
-          );
-          activePipelines.delete(threadId);
-        }
-      } catch (error) {
-        if (!context.cancelled) {
-          emitPhase(
-            threadId,
-            'failed',
-            `Review error: ${error instanceof Error ? error.message : String(error)}`,
-          );
-          activePipelines.delete(threadId);
-        }
+        activePipelines.delete(threadId);
+        return { next: 'failed' };
       }
-    })();
+
+      const parser = new StreamParser();
+      parser.feed(response.rawOutput);
+
+      const result = parser.extractReview();
+      const latestPlan = deps.plans.getLatest(threadId);
+
+      if (!(result.success && result.data && latestPlan)) {
+        if (latestPlan) {
+          deps.reviews.create(latestPlan.id, parser.getRawOutput(), null);
+        }
+        emitPhase(
+          threadId,
+          'failed',
+          'Review output could not be parsed — reviewer did not emit a shipcode-review block.',
+        );
+        activePipelines.delete(threadId);
+        return { next: 'failed' };
+      }
+
+      const latestStructuredPlan = latestPlan.structured;
+      if (!latestStructuredPlan) {
+        emitPhase(threadId, 'failed', 'Review aborted: latest plan record has no structured plan.');
+        activePipelines.delete(threadId);
+        return { next: 'failed' };
+      }
+      deps.reviews.create(latestPlan.id, result.raw, result.data);
+      deps.plans.updateStatus(
+        latestPlan.id,
+        result.data.decision === 'approve' ? 'approved' : 'rejected',
+      );
+      deps.emitter.emit({ type: 'review:parsed', threadId, review: result.data });
+
+      if (result.data.decision === 'approve') {
+        const requireApproval = getRequireApprovalForContext(context);
+        const revisionCount = getRevisionCountForContext(context);
+        const reasons: Array<'requireApproval' | 'nonAutonomous' | 'reviewApproved'> = [
+          'reviewApproved',
+        ];
+        if (requireApproval) reasons.push('requireApproval');
+        if (!context.autonomous) reasons.push('nonAutonomous');
+
+        if (requireApproval || !context.autonomous) {
+          deps.emitter.emit({
+            type: 'pipeline:approval-gate',
+            threadId,
+            outcome: 'approval',
+            reviewDecision: 'approve',
+            planVersion: latestPlan.version,
+            requireApproval,
+            autonomous: context.autonomous,
+            reviewRound: context.reviewRound,
+            revisionCount,
+            hasCriticalOrMajor: false,
+            reasons,
+          });
+          deps.plans.updateStatus(latestPlan.id, 'approval');
+          void postPlanComment(context, latestStructuredPlan);
+          emitPhase(threadId, 'approval');
+          return { next: 'paused' };
+        }
+        deps.emitter.emit({
+          type: 'pipeline:approval-gate',
+          threadId,
+          outcome: 'auto_execute',
+          reviewDecision: 'approve',
+          planVersion: latestPlan.version,
+          requireApproval,
+          autonomous: context.autonomous,
+          reviewRound: context.reviewRound,
+          revisionCount,
+          hasCriticalOrMajor: false,
+          reasons,
+        });
+        resetPhaseState(context);
+        return { next: 'execute', plan: latestStructuredPlan };
+      }
+
+      if (result.data.decision === 'request_changes') {
+        const revisionCountLimit = getRevisionCountForContext(context);
+        if (context.reviewRound < revisionCountLimit) {
+          context.reviewRound++;
+          deps.threads.incrementReviewRound(threadId);
+          const feedback =
+            result.data.suggestedChanges.join('\n') +
+            '\n\nFindings:\n' +
+            result.data.findings
+              .map(
+                (finding: { severity: string; description: string; suggestion?: string }) =>
+                  `[${finding.severity}] ${finding.description}${finding.suggestion ? ` — ${finding.suggestion}` : ''}`,
+              )
+              .join('\n');
+          resetPhaseState(context);
+          return { next: 'revision', plan: latestStructuredPlan, reviewFeedback: feedback };
+        }
+        const hasCriticalOrMajor = result.data.findings.some(
+          (finding: { severity: string }) =>
+            finding.severity === 'critical' || finding.severity === 'major',
+        );
+        const requireApproval = getRequireApprovalForContext(context);
+        const reasons: Array<
+          'requireApproval' | 'nonAutonomous' | 'criticalFindings' | 'revisionsExhausted'
+        > = ['revisionsExhausted'];
+        if (requireApproval) reasons.push('requireApproval');
+        if (!context.autonomous) reasons.push('nonAutonomous');
+        if (hasCriticalOrMajor) reasons.push('criticalFindings');
+
+        if (requireApproval || !context.autonomous || hasCriticalOrMajor) {
+          deps.emitter.emit({
+            type: 'pipeline:approval-gate',
+            threadId,
+            outcome: 'approval',
+            reviewDecision: 'request_changes',
+            planVersion: latestPlan.version,
+            requireApproval,
+            autonomous: context.autonomous,
+            reviewRound: context.reviewRound,
+            revisionCount: revisionCountLimit,
+            hasCriticalOrMajor,
+            reasons,
+          });
+          deps.plans.updateStatus(latestPlan.id, 'approval');
+          void postPlanComment(context, latestStructuredPlan);
+          emitPhase(threadId, 'approval');
+          return { next: 'paused' };
+        }
+        deps.emitter.emit({
+          type: 'pipeline:approval-gate',
+          threadId,
+          outcome: 'auto_execute',
+          reviewDecision: 'request_changes',
+          planVersion: latestPlan.version,
+          requireApproval,
+          autonomous: context.autonomous,
+          reviewRound: context.reviewRound,
+          revisionCount: revisionCountLimit,
+          hasCriticalOrMajor,
+          reasons,
+        });
+        resetPhaseState(context);
+        return { next: 'execute', plan: latestStructuredPlan };
+      }
+
+      if (result.data.decision === 'reject') {
+        // Reviewer rejected the plan outright — do not loop revisions
+        // and do not auto-execute even in autonomous mode. Halt at the
+        // approval gate so the user can intervene (edit issue, retry,
+        // or abandon).
+        const hasCriticalOrMajor = result.data.findings.some(
+          (finding: { severity: string }) =>
+            finding.severity === 'critical' || finding.severity === 'major',
+        );
+        const requireApproval = getRequireApprovalForContext(context);
+        const revisionCountLimit = getRevisionCountForContext(context);
+        const reasons: Array<
+          'requireApproval' | 'nonAutonomous' | 'criticalFindings' | 'reviewRejected'
+        > = ['reviewRejected'];
+        if (requireApproval) reasons.push('requireApproval');
+        if (!context.autonomous) reasons.push('nonAutonomous');
+        if (hasCriticalOrMajor) reasons.push('criticalFindings');
+
+        deps.emitter.emit({
+          type: 'pipeline:approval-gate',
+          threadId,
+          outcome: 'approval',
+          reviewDecision: 'reject',
+          planVersion: latestPlan.version,
+          requireApproval,
+          autonomous: context.autonomous,
+          reviewRound: context.reviewRound,
+          revisionCount: revisionCountLimit,
+          hasCriticalOrMajor,
+          reasons,
+        });
+        deps.plans.updateStatus(latestPlan.id, 'approval');
+        void postPlanComment(context, latestStructuredPlan);
+        emitPhase(threadId, 'approval');
+        return { next: 'paused' };
+      }
+
+      emitPhase(
+        threadId,
+        'failed',
+        `Review failed: reviewer returned an unexpected decision (${result.data.decision ?? 'unknown'}).`,
+      );
+      activePipelines.delete(threadId);
+      return { next: 'failed' };
+    } catch (error) {
+      if (!context.cancelled) {
+        emitPhase(
+          threadId,
+          'failed',
+          `Review error: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        activePipelines.delete(threadId);
+        return { next: 'failed' };
+      }
+      return { next: 'paused' };
+    }
   }
 
-  async function startRevision(threadId: string, plan: ShipCodePlan, reviewFeedback: string) {
+  async function startRevision(
+    threadId: string,
+    plan: ShipCodePlan,
+    reviewFeedback: string,
+  ): Promise<PhaseOutcome> {
     const context = activePipelines.get(threadId);
-    if (!context) return;
+    if (!context) return { next: 'paused' };
 
     emitPhase(threadId, 'revising');
 
@@ -819,56 +814,56 @@ export function createPlanningPhaseHandlers({
         `WORKFLOW.md template render error: ${error instanceof Error ? error.message : String(error)}`,
       );
       activePipelines.delete(threadId);
-      return;
+      return { next: 'failed' };
     }
 
-    void (async () => {
-      try {
-        const response = await runProviderPhase(
-          context,
-          'revision',
-          revisionPrompt,
-          revisionMaterials,
-          {
-            reasoningEffort: context.phaseReasoningEfforts.revision,
-          },
-        );
+    try {
+      const response = await runProviderPhase(
+        context,
+        'revision',
+        revisionPrompt,
+        revisionMaterials,
+        {
+          reasoningEffort: context.phaseReasoningEfforts.revision,
+        },
+      );
 
-        if (context.cancelled) return;
+      if (context.cancelled) return { next: 'paused' };
 
-        const parser = new StreamParser();
-        parser.feed(response.rawOutput);
+      const parser = new StreamParser();
+      parser.feed(response.rawOutput);
 
-        const result = parser.extractPlan();
-        if (result.success && result.data) {
-          deps.plans.supersedeAll(threadId);
-          const newPlan = deps.plans.create(threadId, result.raw, result.data, plan.version + 1);
-          deps.plans.updateStatus(newPlan.id, 'pending_review');
-          deps.emitter.emit({ type: 'plan:parsed', threadId, plan: result.data });
-          resetPhaseState(context);
-          handlers.startReview(threadId, result.data);
-        } else {
-          deps.plans.supersedeAll(threadId);
-          deps.plans.create(threadId, result.raw, null, plan.version + 1);
-          emitPhase(
-            threadId,
-            'failed',
-            'Revision output could not be parsed — revisor did not emit a shipcode-plan block.',
-          );
-          activePipelines.delete(threadId);
-        }
-      } catch (error) {
-        if (!context.cancelled) {
-          deps.plans.supersedeAll(threadId);
-          emitPhase(
-            threadId,
-            'failed',
-            `Revision error: ${error instanceof Error ? error.message : String(error)}`,
-          );
-          activePipelines.delete(threadId);
-        }
+      const result = parser.extractPlan();
+      if (result.success && result.data) {
+        deps.plans.supersedeAll(threadId);
+        const newPlan = deps.plans.create(threadId, result.raw, result.data, plan.version + 1);
+        deps.plans.updateStatus(newPlan.id, 'pending_review');
+        deps.emitter.emit({ type: 'plan:parsed', threadId, plan: result.data });
+        resetPhaseState(context);
+        return { next: 'review', plan: result.data };
       }
-    })();
+      deps.plans.supersedeAll(threadId);
+      deps.plans.create(threadId, result.raw, null, plan.version + 1);
+      emitPhase(
+        threadId,
+        'failed',
+        'Revision output could not be parsed — revisor did not emit a shipcode-plan block.',
+      );
+      activePipelines.delete(threadId);
+      return { next: 'failed' };
+    } catch (error) {
+      if (!context.cancelled) {
+        deps.plans.supersedeAll(threadId);
+        emitPhase(
+          threadId,
+          'failed',
+          `Revision error: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        activePipelines.delete(threadId);
+        return { next: 'failed' };
+      }
+      return { next: 'paused' };
+    }
   }
 
   return {

--- a/packages/pipeline/src/pipeline/shared.ts
+++ b/packages/pipeline/src/pipeline/shared.ts
@@ -112,36 +112,37 @@ export interface PipelineRuntime {
   postTaskGraphComment: (context: PipelineContext, graph: TaskGraphWithNodes) => Promise<void>;
 }
 
-export interface PipelinePhaseHandlers {
-  startPlanGeneration: (
-    threadId: string,
-    prompt: string,
-    projectPath: string,
-    worktreePath: string | null,
-  ) => Promise<void>;
-  startReview: (threadId: string, plan: ShipCodePlan) => Promise<void>;
-  startRevision: (threadId: string, plan: ShipCodePlan, reviewFeedback: string) => Promise<void>;
-  startExecution: (threadId: string, plan: ShipCodePlan) => Promise<void>;
-  startTesting: (threadId: string) => Promise<void>;
-  startVerification: (threadId: string) => Promise<void>;
-  startCommitAndPush: (threadId: string) => Promise<void>;
-  startShipping: (threadId: string) => Promise<void>;
-  startStabilization: (
-    threadId: string,
-    inputs: {
-      prNumber: number;
-      prUrl: string | null;
-      failingChecks: GitHubPrCheckSummary[];
-      unresolvedReviewComments: GitHubPrReviewCommentSummary[];
-    },
-  ) => Promise<void>;
-}
+/**
+ * The result of running a single pipeline phase. A phase no longer calls the
+ * next phase directly; it returns one of these and the orchestrator dispatch
+ * loop (pipeline.ts) advances. This replaces the implicit `handlers.startX()`
+ * call graph with an explicit state machine.
+ *
+ * Ownership: for `done` / `paused` / `failed`, the phase has ALREADY called
+ * `emitPhase` (and `activePipelines.delete` for `done`/`failed`) together with
+ * its ordered side-effects (approval-gate event, plan comment, turn-completed,
+ * etc.); the loop treats them as pure stop signals and never re-emits.
+ * `retry` emits nothing — the loop owns the (cancelable) delay, then dispatches
+ * `then`.
+ */
+export type PhaseOutcome =
+  | { next: 'plan'; prompt: string; projectPath: string; worktreePath: string | null }
+  | { next: 'review'; plan: ShipCodePlan }
+  | { next: 'revision'; plan: ShipCodePlan; reviewFeedback: string }
+  | { next: 'execute'; plan: ShipCodePlan }
+  | { next: 'testing' }
+  | { next: 'verification' }
+  | { next: 'commit' }
+  | { next: 'shipping' }
+  | { next: 'done' }
+  | { next: 'paused' }
+  | { next: 'failed' }
+  | { next: 'retry'; delayMs: number; andThen: PhaseOutcome };
 
 export interface PipelineHelperEnv {
   deps: PipelineDeps;
   contextHelpers: PipelineContextHelpers;
   runtime: PipelineRuntime;
-  handlers: PipelinePhaseHandlers;
 }
 
 export type ThreadStatus = Parameters<PipelineDeps['threads']['updateStatus']>[1];


### PR DESCRIPTION
Closes #137. Step 3 of epic #126. Supersedes #184 (auto-closed when its stacked base `feat/136` was deleted on #183 merge); rebased onto develop so the diff is #137-only.

## What
Replaces the implicit `handlers.startX()` cross-phase call graph (21 sites) with an explicit state machine: each phase returns a typed `PhaseOutcome`; a central `dispatch` loop in `pipeline.ts` advances.

- **`PhaseOutcome`** (`shared.ts`): phase transitions, `done`/`paused`/`failed` terminals, `retry { delayMs, andThen }`. Removes `PipelinePhaseHandlers` + the `handlers` field on `PipelineHelperEnv`.
- **Phase handlers** return outcomes instead of calling the next phase; the `void (async()=>{})()` IIFEs are gone. Terminal outcomes keep `emitPhase` + `activePipelines.delete` co-located with their ordered side-effects; the loop treats them as stop signals.
- **`dispatch()`** drives the loop. **`cancelableDelay()`** ties retry waits to `context.abort.signal` so `cancel()`/`pause()` abort a pending retry (parity with the old guard). **`launch()`** runs the loop detached → public `startX` stays `Promise<void>` fire-and-forget; IPC/CLI/scheduler unchanged.
- Hard sites: `scheduleCoordinatedTestFixRetry`/`queueTestingIfCpuBusy` → `PhaseOutcome|null`; `startTestFix`→`makeTestFixOutcome`; `runRuntimeQa` surfaces a retry outcome. `then`→`andThen` (thenable footgun).

## Verification
- `bun run typecheck` clean · pipeline suite **475 pass / 7 skip** · coverage **96.55/91.41/99.26/96.95** (gate 95/95/95/90) · biome clean.

## Next
#137 → #138 (wire `buildPhasePayload`) → #139 (typed phase results).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured pipeline orchestration from implicit handler invocations to explicit state-machine outcomes. Phase handlers now return structured outcomes to drive progression through planning, review, execution, testing, and shipping states.

* **Tests**
  * Updated test suites to verify new phase outcome contracts, async timing behavior, and retry-outcome handling across planning and execution phases.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shipshitdev/shipcode/pull/185?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->