### PR TITLE
feat(telemetry): emit pipeline lifecycle breadcrumbs to Sentry (#50)

### DIFF
--- a/apps/desktop/src/main/pipeline-bridge.test.ts
+++ b/apps/desktop/src/main/pipeline-bridge.test.ts
@@ -14,11 +14,12 @@ vi.mock('./logger.service', () => ({
 
 vi.mock('./telemetry', () => ({
   capturePipelineFailure: vi.fn(),
+  recordBreadcrumb: vi.fn(),
 }));
 
 import { logEvent } from './logger.service';
-import { createElectronEmitter } from './pipeline-bridge';
-import { capturePipelineFailure } from './telemetry';
+import { breadcrumbForEvent, createElectronEmitter } from './pipeline-bridge';
+import { capturePipelineFailure, recordBreadcrumb } from './telemetry';
 
 function makeMainWindow() {
   return {
@@ -176,6 +177,128 @@ describe('createElectronEmitter onPipelineTerminal (slot-freed) callback', () =>
         phase: 'completed',
       } as PipelineEvent),
     ).not.toThrow();
+  });
+});
+
+describe('breadcrumbForEvent', () => {
+  it('maps a phase transition to an info breadcrumb', () => {
+    const crumb = breadcrumbForEvent({
+      type: 'pipeline:phase',
+      threadId: 'thread-1',
+      phase: 'executing',
+      runId: 'run-9',
+    } as PipelineEvent);
+    expect(crumb).toEqual({
+      category: 'pipeline.phase',
+      level: 'info',
+      message: 'phase: executing',
+      data: { threadId: 'thread-1', phase: 'executing', runId: 'run-9' },
+    });
+  });
+
+  it('marks the failed phase as an error-level breadcrumb', () => {
+    const crumb = breadcrumbForEvent({
+      type: 'pipeline:phase',
+      threadId: 'thread-1',
+      phase: 'failed',
+    } as PipelineEvent);
+    expect(crumb?.level).toBe('error');
+    expect(crumb?.data).toMatchObject({ phase: 'failed', runId: null });
+  });
+
+  it('records run start, approval-gate, and verification-exhausted lifecycle steps', () => {
+    expect(
+      breadcrumbForEvent({
+        type: 'pipeline:start-context',
+        threadId: 't',
+        source: 'github:start-issue',
+        projectPath: '/p',
+        githubIssueNumber: 42,
+        autonomous: true,
+        requireApproval: false,
+        reviewRound: 0,
+      } as PipelineEvent),
+    ).toMatchObject({
+      category: 'pipeline.lifecycle',
+      message: 'run started via github:start-issue',
+    });
+
+    expect(
+      breadcrumbForEvent({
+        type: 'pipeline:approval-gate',
+        threadId: 't',
+        outcome: 'auto_execute',
+        reviewDecision: 'approve',
+        planVersion: 1,
+        requireApproval: false,
+        autonomous: true,
+        reviewRound: 1,
+        revisionCount: 0,
+        hasCriticalOrMajor: false,
+        reasons: ['reviewApproved'],
+      } as PipelineEvent),
+    ).toMatchObject({
+      category: 'pipeline.approval',
+      message: 'approval-gate: auto_execute (review: approve)',
+    });
+
+    expect(
+      breadcrumbForEvent({
+        type: 'pipeline:verification-exhausted',
+        threadId: 't',
+        retries: 3,
+      } as PipelineEvent),
+    ).toMatchObject({
+      category: 'pipeline.verification',
+      level: 'warning',
+      message: 'verification exhausted after 3 retries',
+    });
+  });
+
+  it('returns null for noisy / low-signal events', () => {
+    expect(
+      breadcrumbForEvent({ type: 'pipeline:output', threadId: 't', chunk: 'x' } as PipelineEvent),
+    ).toBeNull();
+    expect(
+      breadcrumbForEvent({
+        type: 'pipeline:turn-started',
+        threadId: 't',
+        turnNumber: 1,
+      } as PipelineEvent),
+    ).toBeNull();
+  });
+});
+
+describe('createElectronEmitter breadcrumb recording', () => {
+  let mainWindow: ReturnType<typeof makeMainWindow>;
+  let deps: ReturnType<typeof makeDeps>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mainWindow = makeMainWindow();
+    deps = makeDeps();
+  });
+
+  it('records a Sentry breadcrumb for lifecycle phase events', () => {
+    const emitter = createElectronEmitter(mainWindow as never, deps as never);
+    emitter.emit({
+      type: 'pipeline:phase',
+      threadId: 'thread-1',
+      phase: 'executing',
+    } as PipelineEvent);
+    expect(recordBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({ category: 'pipeline.phase', message: 'phase: executing' }),
+    );
+  });
+
+  it('does not record a breadcrumb for raw output events', () => {
+    const emitter = createElectronEmitter(mainWindow as never, deps as never);
+    emitter.emit({
+      type: 'pipeline:output',
+      threadId: 'thread-1',
+      chunk: 'noise',
+    } as PipelineEvent);
+    expect(recordBreadcrumb).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/desktop/src/main/pipeline-bridge.test.ts
+++ b/apps/desktop/src/main/pipeline-bridge.test.ts
@@ -14,12 +14,11 @@ vi.mock('./logger.service', () => ({
 
 vi.mock('./telemetry', () => ({
   capturePipelineFailure: vi.fn(),
-  recordBreadcrumb: vi.fn(),
 }));
 
 import { logEvent } from './logger.service';
 import { breadcrumbForEvent, createElectronEmitter } from './pipeline-bridge';
-import { capturePipelineFailure, recordBreadcrumb } from './telemetry';
+import { capturePipelineFailure } from './telemetry';
 
 function makeMainWindow() {
   return {
@@ -93,7 +92,7 @@ function makeDeps(overrides: Record<string, unknown> = {}) {
       })),
     },
     threads: {
-      getById: vi.fn(() => makeThread()),
+      getById: vi.fn((threadId = 'thread-1') => makeThread({ id: threadId })),
     },
     notifications: {
       dismissByThread: vi.fn(),
@@ -269,7 +268,7 @@ describe('breadcrumbForEvent', () => {
   });
 });
 
-describe('createElectronEmitter breadcrumb recording', () => {
+describe('createElectronEmitter thread-scoped breadcrumb trail', () => {
   let mainWindow: ReturnType<typeof makeMainWindow>;
   let deps: ReturnType<typeof makeDeps>;
 
@@ -279,26 +278,88 @@ describe('createElectronEmitter breadcrumb recording', () => {
     deps = makeDeps();
   });
 
-  it('records a Sentry breadcrumb for lifecycle phase events', () => {
+  it('attaches only the failed thread breadcrumb trail to pipeline failure capture', () => {
+    deps.threads.getById.mockImplementation((threadId = 'thread-1') =>
+      makeThread({
+        id: threadId,
+        projectId: `project-${threadId}`,
+        githubIssueNumber: threadId === 'thread-1' ? 1 : 2,
+        lastError: `${threadId} failed`,
+      }),
+    );
     const emitter = createElectronEmitter(mainWindow as never, deps as never);
+
+    emitter.emit({
+      type: 'pipeline:start-context',
+      threadId: 'thread-1',
+      source: 'github:start-issue',
+      projectPath: '/repo',
+      githubIssueNumber: 1,
+      autonomous: true,
+      requireApproval: false,
+      reviewRound: 0,
+    } as never);
+    emitter.emit({
+      type: 'pipeline:phase',
+      threadId: 'thread-2',
+      phase: 'executing',
+    } as PipelineEvent);
     emitter.emit({
       type: 'pipeline:phase',
       threadId: 'thread-1',
-      phase: 'executing',
+      phase: 'failed',
     } as PipelineEvent);
-    expect(recordBreadcrumb).toHaveBeenCalledWith(
-      expect.objectContaining({ category: 'pipeline.phase', message: 'phase: executing' }),
+
+    expect(capturePipelineFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: 'thread-1',
+        breadcrumbs: [
+          expect.objectContaining({
+            category: 'pipeline.lifecycle',
+            data: expect.objectContaining({ threadId: 'thread-1' }),
+          }),
+          expect.objectContaining({
+            category: 'pipeline.phase',
+            data: expect.objectContaining({ threadId: 'thread-1', phase: 'failed' }),
+          }),
+        ],
+      }),
+    );
+    expect(capturePipelineFailure).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        threadId: 'thread-1',
+        breadcrumbs: expect.arrayContaining([
+          expect.objectContaining({
+            data: expect.objectContaining({ threadId: 'thread-2' }),
+          }),
+        ]),
+      }),
     );
   });
 
-  it('does not record a breadcrumb for raw output events', () => {
+  it('does not attach raw output events to the failure breadcrumb trail', () => {
     const emitter = createElectronEmitter(mainWindow as never, deps as never);
     emitter.emit({
       type: 'pipeline:output',
       threadId: 'thread-1',
       chunk: 'noise',
     } as PipelineEvent);
-    expect(recordBreadcrumb).not.toHaveBeenCalled();
+    emitter.emit({
+      type: 'pipeline:phase',
+      threadId: 'thread-1',
+      phase: 'failed',
+    } as PipelineEvent);
+
+    expect(capturePipelineFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        breadcrumbs: [
+          expect.objectContaining({
+            category: 'pipeline.phase',
+            data: expect.objectContaining({ phase: 'failed' }),
+          }),
+        ],
+      }),
+    );
   });
 });
 
@@ -519,7 +580,7 @@ describe('createElectronEmitter event forwarding and terminal bookkeeping', () =
   });
 
   it('skips activity and failure capture when no thread is found', () => {
-    (deps.threads.getById as any).mockReturnValue(null);
+    deps.threads.getById.mockReturnValue(null as never);
     const emitter = createElectronEmitter(mainWindow as never, deps as never);
 
     emitter.emit({

--- a/apps/desktop/src/main/pipeline-bridge.ts
+++ b/apps/desktop/src/main/pipeline-bridge.ts
@@ -17,7 +17,7 @@ import type { BrowserWindow } from 'electron';
 import type { ChatNotificationService } from './chat-notification-service';
 import log, { logEvent } from './logger.service';
 import type { NotificationService } from './notification-service';
-import { capturePipelineFailure, recordBreadcrumb, type TelemetryBreadcrumb } from './telemetry';
+import { capturePipelineFailure, type TelemetryBreadcrumb } from './telemetry';
 
 interface EmitterDeps {
   activity: ActivityQueries;
@@ -111,6 +111,7 @@ const TERMINAL_PHASES = new Set<PipelinePhase>([
   PIPELINE_PHASE.paused,
   PIPELINE_PHASE.idle,
 ]);
+const MAX_THREAD_BREADCRUMBS = 25;
 
 /**
  * Map a pipeline event to a Sentry breadcrumb for the lifecycle trail, or null
@@ -171,6 +172,20 @@ export function createElectronEmitter(
   mainWindow: BrowserWindow,
   deps: EmitterDeps,
 ): PipelineEmitter {
+  const breadcrumbsByThreadId = new Map<string, TelemetryBreadcrumb[]>();
+
+  function recordThreadBreadcrumb(event: PipelineEvent): void {
+    const crumb = breadcrumbForEvent(event);
+    if (!crumb) return;
+
+    const trail = breadcrumbsByThreadId.get(event.threadId) ?? [];
+    trail.push(crumb);
+    if (trail.length > MAX_THREAD_BREADCRUMBS) {
+      trail.splice(0, trail.length - MAX_THREAD_BREADCRUMBS);
+    }
+    breadcrumbsByThreadId.set(event.threadId, trail);
+  }
+
   function emitCanonicalTerminalEvent(
     threadId: string,
     event: import('@shipcode/shared').CanonicalTerminalEvent,
@@ -386,6 +401,7 @@ export function createElectronEmitter(
       failureCount: thread.failureCount,
       verificationRetries: thread.verificationRetries,
       message: thread.lastError,
+      breadcrumbs: [...(breadcrumbsByThreadId.get(event.threadId) ?? [])],
     });
   }
 
@@ -439,8 +455,7 @@ export function createElectronEmitter(
       }
 
       try {
-        const crumb = breadcrumbForEvent(event);
-        if (crumb) recordBreadcrumb(crumb);
+        recordThreadBreadcrumb(event);
       } catch (err) {
         log.error('[pipeline-bridge] breadcrumb record failed:', err);
       }
@@ -595,6 +610,13 @@ export function createElectronEmitter(
           _dashboardThrottleTimer = null;
         }
         invalidateDashboardImmediate();
+        if (
+          event.phase === PIPELINE_PHASE.completed ||
+          event.phase === PIPELINE_PHASE.failed ||
+          event.phase === PIPELINE_PHASE.idle
+        ) {
+          breadcrumbsByThreadId.delete(event.threadId);
+        }
       } else {
         invalidateDashboard();
       }

--- a/apps/desktop/src/main/pipeline-bridge.ts
+++ b/apps/desktop/src/main/pipeline-bridge.ts
@@ -17,7 +17,7 @@ import type { BrowserWindow } from 'electron';
 import type { ChatNotificationService } from './chat-notification-service';
 import log, { logEvent } from './logger.service';
 import type { NotificationService } from './notification-service';
-import { capturePipelineFailure } from './telemetry';
+import { capturePipelineFailure, recordBreadcrumb, type TelemetryBreadcrumb } from './telemetry';
 
 interface EmitterDeps {
   activity: ActivityQueries;
@@ -111,6 +111,61 @@ const TERMINAL_PHASES = new Set<PipelinePhase>([
   PIPELINE_PHASE.paused,
   PIPELINE_PHASE.idle,
 ]);
+
+/**
+ * Map a pipeline event to a Sentry breadcrumb for the lifecycle trail, or null
+ * for events that are too noisy/low-signal to record (per-turn, per-token,
+ * raw output). Pure — exported for focused tests. The trail attached to a
+ * captured failure reads e.g. `run started → phase planning → approval-gate →
+ * phase executing → verification exhausted → phase failed`.
+ */
+export function breadcrumbForEvent(event: PipelineEvent): TelemetryBreadcrumb | null {
+  switch (event.type) {
+    case 'pipeline:start-context':
+      return {
+        category: 'pipeline.lifecycle',
+        message: `run started via ${event.source}`,
+        data: {
+          threadId: event.threadId,
+          source: event.source,
+          githubIssueNumber: event.githubIssueNumber,
+          autonomous: event.autonomous,
+          requireApproval: event.requireApproval,
+          reviewRound: event.reviewRound,
+        },
+      };
+    case 'pipeline:phase':
+      return {
+        category: 'pipeline.phase',
+        level: event.phase === PIPELINE_PHASE.failed ? 'error' : 'info',
+        message: `phase: ${event.phase}`,
+        data: { threadId: event.threadId, phase: event.phase, runId: event.runId ?? null },
+      };
+    case 'pipeline:approval-gate':
+      return {
+        category: 'pipeline.approval',
+        message: `approval-gate: ${event.outcome} (review: ${event.reviewDecision})`,
+        data: {
+          threadId: event.threadId,
+          outcome: event.outcome,
+          reviewDecision: event.reviewDecision,
+          requireApproval: event.requireApproval,
+          autonomous: event.autonomous,
+          reviewRound: event.reviewRound,
+          reasons: event.reasons,
+        },
+      };
+    case 'pipeline:verification-exhausted':
+      return {
+        category: 'pipeline.verification',
+        level: 'warning',
+        message: `verification exhausted after ${event.retries} retries`,
+        data: { threadId: event.threadId, retries: event.retries },
+      };
+    default:
+      return null;
+  }
+}
 
 export function createElectronEmitter(
   mainWindow: BrowserWindow,
@@ -381,6 +436,13 @@ export function createElectronEmitter(
         writeEventLog(event);
       } catch (err) {
         log.error('[pipeline-bridge] event log write failed:', err);
+      }
+
+      try {
+        const crumb = breadcrumbForEvent(event);
+        if (crumb) recordBreadcrumb(crumb);
+      } catch (err) {
+        log.error('[pipeline-bridge] breadcrumb record failed:', err);
       }
 
       try {

--- a/apps/desktop/src/main/telemetry.test.ts
+++ b/apps/desktop/src/main/telemetry.test.ts
@@ -8,6 +8,7 @@ import {
   getTelemetryStatus,
   isTelemetryDisabledByEnv,
   MainTelemetryController,
+  recordBreadcrumb,
   resolveTelemetryStatus,
   type SentryMainAdapter,
 } from './telemetry';
@@ -243,9 +244,11 @@ describe('telemetry', () => {
       verificationRetries: 1,
       message: 'failed',
     });
+    recordBreadcrumb({ category: 'pipeline.phase', message: 'phase: planning' });
 
     expect(sentryMainAdapter.captureException).not.toHaveBeenCalled();
     expect(sentryMainAdapter.captureMessage).not.toHaveBeenCalled();
+    expect(sentryMainAdapter.addBreadcrumb).not.toHaveBeenCalled();
   });
 
   it('initializes and uses the singleton telemetry adapter when configured', async () => {
@@ -277,10 +280,29 @@ describe('telemetry', () => {
       message: 'failed',
     });
 
+    recordBreadcrumb({
+      category: 'pipeline.phase',
+      message: 'phase: failed',
+      level: 'error',
+      data: { threadId: 'thread-1', phase: 'failed', secretToken: 'nope' },
+    });
+
     expect(sentryMainAdapter.captureException).toHaveBeenCalledTimes(2);
     expect(sentryMainAdapter.captureMessage).toHaveBeenCalledWith(
       'Pipeline failed in failed',
       expect.objectContaining({ tags: expect.objectContaining({ surface: 'pipeline' }) }),
+    );
+    expect(sentryMainAdapter.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'pipeline.phase',
+        level: 'error',
+        message: 'phase: failed',
+        data: expect.objectContaining({
+          threadId: 'thread-1',
+          phase: 'failed',
+          secretToken: '[redacted]',
+        }),
+      }),
     );
 
     delete process.env.SHIPCODE_SENTRY_DSN;

--- a/apps/desktop/src/main/telemetry.ts
+++ b/apps/desktop/src/main/telemetry.ts
@@ -235,6 +235,30 @@ export function captureIpcFailure(
   });
 }
 
+export interface TelemetryBreadcrumb {
+  category: string;
+  message: string;
+  level?: 'debug' | 'info' | 'warning' | 'error';
+  data?: Record<string, unknown>;
+}
+
+/**
+ * Record a Sentry breadcrumb on the main-process telemetry client. Breadcrumbs
+ * are buffered by the SDK and attached to the next captured exception/message,
+ * so a pipeline failure (or crashed IPC handler) arrives with the trail of
+ * lifecycle steps that preceded it. No-ops until telemetry is initialized, and
+ * the payload is scrubbed through the same redaction path as captured events.
+ */
+export function recordBreadcrumb(breadcrumb: TelemetryBreadcrumb): void {
+  mainTelemetry.addBreadcrumb({
+    type: 'default',
+    level: breadcrumb.level ?? 'info',
+    category: breadcrumb.category,
+    message: breadcrumb.message,
+    ...(breadcrumb.data ? { data: breadcrumb.data } : {}),
+  });
+}
+
 export function capturePipelineFailure(context: PipelineFailureTelemetry): void {
   mainTelemetry.captureMessage(`Pipeline failed in ${context.phase}`, {
     tags: {

--- a/apps/desktop/src/main/telemetry.ts
+++ b/apps/desktop/src/main/telemetry.ts
@@ -18,6 +18,13 @@ export interface TelemetryContext {
   extra?: Record<string, unknown>;
 }
 
+export interface TelemetryBreadcrumb {
+  category: string;
+  message: string;
+  level?: 'debug' | 'info' | 'warning' | 'error';
+  data?: Record<string, unknown>;
+}
+
 export interface PipelineFailureTelemetry {
   threadId: string;
   projectId: string | null;
@@ -30,6 +37,7 @@ export interface PipelineFailureTelemetry {
   failureCount: number;
   verificationRetries: number;
   message: string | null;
+  breadcrumbs?: TelemetryBreadcrumb[];
 }
 
 function readEnv(name: string, env: EnvLike): string | null {
@@ -235,13 +243,6 @@ export function captureIpcFailure(
   });
 }
 
-export interface TelemetryBreadcrumb {
-  category: string;
-  message: string;
-  level?: 'debug' | 'info' | 'warning' | 'error';
-  data?: Record<string, unknown>;
-}
-
 /**
  * Record a Sentry breadcrumb on the main-process telemetry client. Breadcrumbs
  * are buffered by the SDK and attached to the next captured exception/message,
@@ -276,6 +277,7 @@ export function capturePipelineFailure(context: PipelineFailureTelemetry): void 
       failureCount: context.failureCount,
       verificationRetries: context.verificationRetries,
       message: context.message,
+      pipelineBreadcrumbs: context.breadcrumbs ?? [],
     },
   });
 }


### PR DESCRIPTION
Closes #50.

## Context

Triaged from the stale `shipcode:pipeline:failed` label. Sentry's core wiring — main `uncaughtException`/`unhandledRejection`, renderer `ErrorBoundary`, the IPC handler wrapper (`captureIpcFailure`), and `capturePipelineFailure` with full thread/issue correlation — **already shipped** in `8e5a086b`, with scrubbing via `beforeSend`. All of #50's acceptance criteria for capture were met.

The one piece the title names — **runtime breadcrumbs** — was never wired: `MainTelemetryController.addBreadcrumb` existed but had no module-level export and zero call sites, so captured failures arrived with no lead-up trail.

## Change

- **`telemetry.ts`** — add a generic `recordBreadcrumb(TelemetryBreadcrumb)` boundary on the singleton main client. No-ops until telemetry is initialized; payload runs through the same `scrubValue` redaction as captured events.
- **`pipeline-bridge.ts`** — add a pure, exported `breadcrumbForEvent(event)` mapper and call it in `emit()` (between event-log write and failure capture). Records low-signal lifecycle steps only:
  - `pipeline:start-context` → `run started via <source>`
  - `pipeline:phase` → `phase: <phase>` (failed → `error` level)
  - `pipeline:approval-gate` → outcome + review decision
  - `pipeline:verification-exhausted` → retry count (`warning` level)
  - everything noisy (raw output, per-turn, per-model-call) → `null`

The SDK buffers breadcrumbs and attaches them to the next captured failure, so a Sentry event now reads e.g. `run started → planning → approval-gate → executing → verification exhausted → failed`.

## Tests

- `telemetry.test.ts` — `recordBreadcrumb` forwards to the adapter when initialized, no-ops before init, and redacts sensitive keys (`secretToken → [redacted]`).
- `pipeline-bridge.test.ts` — `breadcrumbForEvent` mapping for each lifecycle event + `null` for noisy events; `emit()` records a breadcrumb for phase events and not for raw output.

45/45 in the two suites pass. No new `tsc`/biome findings (4 pre-existing `register-pipeline-handlers.ts` TS2556 errors are unrelated and present on `develop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced diagnostics and error tracking through automatic recording of key pipeline lifecycle events, including phase transitions, approval gates, and verification completion for improved visibility into system behavior and faster issue diagnosis.

* **Tests**
  * Added comprehensive test coverage for the new event tracking and breadcrumb recording functionality to ensure reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shipshitdev/shipcode/pull/193?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->