### PR TITLE
feat(github): project PRD metadata onto native GitHub fields (#45)

### DIFF
--- a/apps/desktop/src/main/ipc/register-github-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/register-github-handlers.test.ts
@@ -2873,6 +2873,73 @@ describe('registerGitHubHandlers', () => {
     });
   });
 
+  it('projects complexity + blast radius onto native labels even without a project board (#45)', async () => {
+    const createdRecord = {
+      ...baseIssue,
+      id: 'issue-77',
+      issueNumber: 77,
+      title: 'New issue',
+      body: 'Body',
+      labels: ['enhancement', 'complexity:medium', 'blast:contained'],
+    };
+    createIssueMock.mockResolvedValue({
+      number: 77,
+      title: 'New issue',
+      body: 'Body',
+      labels: ['enhancement', 'complexity:medium', 'blast:contained'],
+      assignee: null,
+      state: 'open',
+      url: 'https://github.com/acme/repo/issues/77',
+    });
+    const queries = {
+      projects: {
+        getById: vi.fn(() => baseProject),
+      },
+      githubIssues: {
+        upsert: vi.fn(),
+        list: vi.fn(() => [createdRecord]),
+        getByNumber: vi.fn(() => createdRecord),
+        setIssueType: vi.fn(),
+        setPriority: vi.fn(),
+      },
+    };
+
+    registerGitHubHandlers({
+      ipcMain,
+      mainWindow: mainWindow as never,
+      queries: queries as never,
+      pipeline: {} as never,
+      emitter: { emit: vi.fn() } as never,
+      notificationService: {} as never,
+      chatNotificationService: {} as never,
+      processManager: {} as never,
+    });
+
+    const createIssue = handlers.get('github:create-issue');
+    if (!createIssue) throw new Error('github:create-issue handler not registered');
+
+    await createIssue(undefined, {
+      projectId: 'project-1',
+      title: 'New issue',
+      body: 'Body',
+      labels: ['enhancement'],
+      prdMetadata: {
+        estimatedComplexity: 'medium',
+        blastRadius: 'contained',
+      },
+    });
+
+    // complexity:* / blast:* are written as native issue labels regardless of
+    // whether a Projects v2 board is configured.
+    expect(createIssueMock).toHaveBeenCalledWith({
+      title: 'New issue',
+      body: 'Body',
+      labels: ['enhancement', 'complexity:medium', 'blast:contained'],
+    });
+    // baseProject has no board URL, so the project-field path never runs.
+    expect(setIssueProjectMetadataMock).not.toHaveBeenCalled();
+  });
+
   it('creates a PRD issue on the configured project board and returns metadata warnings', async () => {
     const projectWithBoard = {
       ...baseProject,
@@ -3134,6 +3201,79 @@ describe('registerGitHubHandlers', () => {
     expect(mainWindow.webContents.send).toHaveBeenCalledWith('github:issues-updated', {
       projectId: 'project-1',
       issues: [updatedRecord],
+    });
+  });
+
+  it('refreshes the cached issue type after editing PRD metadata on the board (#45)', async () => {
+    const projectWithBoard = {
+      ...baseProject,
+      githubProjectUrl: 'https://github.com/orgs/acme/projects/1',
+    };
+    const editedRecord = {
+      ...baseIssue,
+      id: 'issue-42',
+      title: 'Edited',
+      body: 'Edited body',
+      labels: ['enhancement', 'complexity:high', 'blast:infra'],
+    };
+    getIssueMock.mockResolvedValue({
+      number: 42,
+      title: 'Edited',
+      body: 'Edited body',
+      labels: ['enhancement', 'complexity:high', 'blast:infra'],
+      assignee: null,
+      state: 'open',
+      author: null,
+    });
+    setIssueProjectMetadataMock.mockResolvedValue([]);
+    const queries = {
+      projects: {
+        getById: vi.fn(() => projectWithBoard),
+      },
+      githubIssues: {
+        getByNumber: vi.fn(() => editedRecord),
+        upsert: vi.fn(),
+        list: vi.fn(() => [editedRecord]),
+        setIssueType: vi.fn(),
+      },
+    };
+
+    registerGitHubHandlers({
+      ipcMain,
+      mainWindow: mainWindow as never,
+      queries: queries as never,
+      pipeline: {} as never,
+      emitter: { emit: vi.fn() } as never,
+      notificationService: {} as never,
+      chatNotificationService: {} as never,
+      processManager: {} as never,
+    });
+
+    const editIssue = handlers.get('github:edit-issue-body');
+    if (!editIssue) throw new Error('github:edit-issue-body handler not registered');
+
+    await editIssue(undefined, {
+      projectId: 'project-1',
+      issueNumber: 42,
+      title: 'Edited',
+      body: 'Edited body',
+      labels: ['enhancement'],
+      prdMetadata: {
+        estimatedComplexity: 'high',
+        blastRadius: 'infra',
+      },
+    });
+
+    // native labels projected onto the edit too
+    expect(editIssueMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        labels: expect.arrayContaining(['enhancement', 'complexity:high', 'blast:infra']),
+      }),
+    );
+    // local cache issue type refreshed so it isn't stale until next sync (AC4)
+    expect(queries.githubIssues.setIssueType).toHaveBeenCalledWith({
+      id: 'issue-42',
+      issueType: 'Feature',
     });
   });
 

--- a/apps/desktop/src/main/ipc/register-github-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/register-github-handlers.test.ts
@@ -64,11 +64,17 @@ const {
   setIssueLabelPresenceMock: vi.fn(async () => undefined),
   setIssueProjectMetadataMock: vi.fn(async () => [] as string[]),
   syncIssueLabelsMock: vi.fn(async () => undefined),
-  ensureLabelsMock: vi.fn(async () => ({
-    created: [],
-    alreadyPresent: [],
-    failed: [],
-  })),
+  ensureLabelsMock: vi.fn(
+    async (): Promise<{
+      created: string[];
+      alreadyPresent: string[];
+      failed: Array<{ name: string; error: string }>;
+    }> => ({
+      created: [],
+      alreadyPresent: [],
+      failed: [],
+    }),
+  ),
 }));
 
 vi.mock('@shipcode/agents', async () => {
@@ -2931,6 +2937,18 @@ describe('registerGitHubHandlers', () => {
 
     // complexity:* / blast:* are written as native issue labels regardless of
     // whether a Projects v2 board is configured.
+    expect(ensureLabelsMock).toHaveBeenCalledWith([
+      {
+        name: 'complexity:medium',
+        color: 'fbca04',
+        description: 'PRD estimated complexity: medium.',
+      },
+      {
+        name: 'blast:contained',
+        color: '1f883d',
+        description: 'PRD blast radius: contained.',
+      },
+    ]);
     expect(createIssueMock).toHaveBeenCalledWith({
       title: 'New issue',
       body: 'Body',
@@ -2938,6 +2956,56 @@ describe('registerGitHubHandlers', () => {
     });
     // baseProject has no board URL, so the project-field path never runs.
     expect(setIssueProjectMetadataMock).not.toHaveBeenCalled();
+  });
+
+  it('fails before creating a PRD issue when metadata labels cannot be ensured (#45)', async () => {
+    ensureLabelsMock.mockResolvedValueOnce({
+      created: [],
+      alreadyPresent: ['complexity:medium'],
+      failed: [{ name: 'blast:contained', error: 'missing permission' }],
+    });
+    const queries = {
+      projects: {
+        getById: vi.fn(() => baseProject),
+      },
+      githubIssues: {
+        upsert: vi.fn(),
+        list: vi.fn(),
+        getByNumber: vi.fn(),
+        setIssueType: vi.fn(),
+        setPriority: vi.fn(),
+      },
+    };
+
+    registerGitHubHandlers({
+      ipcMain,
+      mainWindow: mainWindow as never,
+      queries: queries as never,
+      pipeline: {} as never,
+      emitter: { emit: vi.fn() } as never,
+      notificationService: {} as never,
+      chatNotificationService: {} as never,
+      processManager: {} as never,
+    });
+
+    const createIssue = handlers.get('github:create-issue');
+    if (!createIssue) throw new Error('github:create-issue handler not registered');
+
+    await expect(
+      createIssue(undefined, {
+        projectId: 'project-1',
+        title: 'New issue',
+        body: 'Body',
+        labels: ['enhancement'],
+        prdMetadata: {
+          estimatedComplexity: 'medium',
+          blastRadius: 'contained',
+        },
+      }),
+    ).rejects.toThrow('Failed to create PRD metadata labels: blast:contained: missing permission');
+
+    expect(createIssueMock).not.toHaveBeenCalled();
+    expect(queries.githubIssues.upsert).not.toHaveBeenCalled();
   });
 
   it('creates a PRD issue on the configured project board and returns metadata warnings', async () => {

--- a/apps/desktop/src/main/ipc/register-github-handlers.ts
+++ b/apps/desktop/src/main/ipc/register-github-handlers.ts
@@ -27,6 +27,7 @@ import {
   isAgentRoutingLabel,
   isRealGithubIssueNumber,
   PIPELINE_PHASE,
+  PRD_METADATA_LABELS,
   parseGithubProjectUrl,
   parseGithubRemote,
   pipelineStatusFromLabels,
@@ -950,6 +951,19 @@ export function registerGitHubHandlers({
       const metadataLabels = prdMetadata
         ? buildPrdMetadataLabels(prdMetadata.estimatedComplexity, prdMetadata.blastRadius)
         : [];
+      if (metadataLabels.length > 0) {
+        const requiredMetadataLabels = PRD_METADATA_LABELS.filter((label) =>
+          metadataLabels.includes(label.name),
+        );
+        const labelSync = await ghCli.ensureLabels(requiredMetadataLabels);
+        if (labelSync.failed.length > 0) {
+          throw new Error(
+            `Failed to create PRD metadata labels: ${labelSync.failed
+              .map((failure) => `${failure.name}: ${failure.error}`)
+              .join('; ')}`,
+          );
+        }
+      }
       const issueLabels = [...new Set([...(labels ?? []), ...metadataLabels])];
       const issue = await ghCli.createIssue({ title, body, labels: issueLabels });
       let projectAttachWarning: string | null = null;

--- a/apps/desktop/src/main/ipc/register-github-handlers.ts
+++ b/apps/desktop/src/main/ipc/register-github-handlers.ts
@@ -20,6 +20,7 @@ import type {
 } from '@shipcode/shared';
 import {
   agentLabelForExecutor,
+  buildPrdMetadataLabels,
   clampError,
   deriveGithubIssueUrl,
   ISSUE_PIPELINE_STATUS,
@@ -943,7 +944,14 @@ export function registerGitHubHandlers({
       if (!project) throw new Error(`Project ${projectId} not found`);
 
       const ghCli = new GhCli(project.path);
-      const issue = await ghCli.createIssue({ title, body, labels });
+      // Project complexity + blast radius onto native issue labels (#45) so the
+      // metadata lives on the issue itself, not just the Projects v2 board (and
+      // survives for repos with no board configured).
+      const metadataLabels = prdMetadata
+        ? buildPrdMetadataLabels(prdMetadata.estimatedComplexity, prdMetadata.blastRadius)
+        : [];
+      const issueLabels = [...new Set([...(labels ?? []), ...metadataLabels])];
+      const issue = await ghCli.createIssue({ title, body, labels: issueLabels });
       let projectAttachWarning: string | null = null;
 
       queries.githubIssues.upsert({
@@ -1041,7 +1049,14 @@ export function registerGitHubHandlers({
       assertRealGithubIssue(cachedIssue, 'edit on GitHub');
 
       const ghCli = new GhCli(project.path);
-      await ghCli.editIssue({ issueNumber, title, body, labels });
+      // Keep complexity + blast radius projected onto native labels on edit too;
+      // syncIssueLabels adds/removes only PRD-managed prefixes, so user labels
+      // are untouched (#45).
+      const metadataLabels = prdMetadata
+        ? buildPrdMetadataLabels(prdMetadata.estimatedComplexity, prdMetadata.blastRadius)
+        : [];
+      const issueLabels = [...new Set([...(labels ?? []), ...metadataLabels])];
+      await ghCli.editIssue({ issueNumber, title, body, labels: issueLabels });
       if (prdMetadata) {
         await attachIssueToConfiguredProjectBoard(
           project,
@@ -1060,6 +1075,12 @@ export function registerGitHubHandlers({
               blastRadius: prdMetadata.blastRadius,
             },
           });
+          // Mirror the create path: reflect the written issue type in the local
+          // cache so it isn't stale until the next full refresh (#45 AC4).
+          const editedRecord = queries.githubIssues.getByNumber(projectId, issueNumber);
+          if (editedRecord) {
+            queries.githubIssues.setIssueType({ id: editedRecord.id, issueType: 'Feature' });
+          }
         } catch (err) {
           log.warn(`[github:edit-issue-body] project metadata failed for #${issueNumber}:`, err);
         }

--- a/packages/agents/src/github/gh-cli.test.ts
+++ b/packages/agents/src/github/gh-cli.test.ts
@@ -786,6 +786,43 @@ describe('GhCli', () => {
   });
 
   describe('editIssue', () => {
+    it('writes native milestone and assignees on edit (#45)', async () => {
+      const fake = createFakeProc();
+      mockSpawn.mockReturnValueOnce(fake.proc);
+      // syncIssueLabels runs after the edit spawn; fail its label discovery so
+      // the assertion can focus on the edit spawn args.
+      mockExecFileAsync.mockRejectedValueOnce(new Error('gh label list failed'));
+
+      const promise = gh.editIssue({
+        issueNumber: 42,
+        title: 'T',
+        body: 'B',
+        labels: ['complexity:high'],
+        milestone: 'v2.0',
+        assignees: ['octocat'],
+      });
+      fake.complete(0);
+
+      await expect(promise).rejects.toThrow('gh label list failed');
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'gh',
+        [
+          'issue',
+          'edit',
+          '42',
+          '--title',
+          'T',
+          '--body-file',
+          '-',
+          '--milestone',
+          'v2.0',
+          '--add-assignee',
+          'octocat',
+        ],
+        ghSpawnOptions,
+      );
+    });
+
     it('surfaces label discovery failures instead of clearing managed labels', async () => {
       const fake = createFakeProc();
       mockSpawn.mockReturnValueOnce(fake.proc);
@@ -842,6 +879,56 @@ describe('GhCli', () => {
   });
 
   describe('createIssue', () => {
+    it('writes native milestone and assignees on creation (#45)', async () => {
+      success(JSON.stringify([{ name: 'enhancement' }]));
+      const fake = createFakeProc();
+      mockSpawn.mockReturnValueOnce(fake.proc);
+      success(
+        JSON.stringify({
+          number: 77,
+          title: 'Native meta',
+          body: 'b',
+          labels: [{ name: 'enhancement' }],
+          assignees: [{ login: 'octocat' }],
+          state: 'OPEN',
+          url: 'https://github.com/o/r/issues/77',
+        }),
+      );
+
+      const promise = gh.createIssue({
+        title: 'Native meta',
+        body: 'b',
+        labels: ['enhancement'],
+        milestone: 'v1.0',
+        assignees: ['octocat', 'hubot'],
+      });
+      await waitForSpawnCall();
+      fake.proc.stdout.emit('data', 'https://github.com/o/r/issues/77\n');
+      fake.complete(0);
+
+      await promise;
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'gh',
+        [
+          'issue',
+          'create',
+          '--title',
+          'Native meta',
+          '--body-file',
+          '-',
+          '--label',
+          'enhancement',
+          '--milestone',
+          'v1.0',
+          '--assignee',
+          'octocat',
+          '--assignee',
+          'hubot',
+        ],
+        ghSpawnOptions,
+      );
+    });
+
     it('filters labels, pipes issue body through stdin, and returns the created issue', async () => {
       success(JSON.stringify([{ name: 'enhancement' }, { name: 'bug' }]));
       const fake = createFakeProc();

--- a/packages/agents/src/github/gh-cli.ts
+++ b/packages/agents/src/github/gh-cli.ts
@@ -462,12 +462,18 @@ export class GhCli {
     title: string;
     body: string;
     labels?: string[];
+    milestone?: string;
+    assignees?: string[];
   }): Promise<GitHubIssue> {
     // Body is piped via stdin (`--body-file -`) to avoid argv length limits
     // and shell-escaping issues for multi-KB PRDs.
     const args = ['issue', 'create', '--title', options.title, '--body-file', '-'];
     const labels = await this.filterExistingLabels(options.labels ?? []);
     if (labels.length) args.push('--label', labels.join(','));
+    // Native metadata fields (#45): set milestone + assignees at creation so
+    // the data lives in GitHub's first-class fields, not body frontmatter.
+    if (options.milestone) args.push('--milestone', options.milestone);
+    for (const assignee of options.assignees ?? []) args.push('--assignee', assignee);
 
     const stdout = await this.spawnWithStdin('gh', args, options.body);
     // gh issue create outputs the issue URL, e.g. https://github.com/owner/repo/issues/42
@@ -720,12 +726,23 @@ export class GhCli {
     title: string;
     body: string;
     labels?: string[];
+    milestone?: string;
+    assignees?: string[];
   }): Promise<void> {
-    await this.spawnWithStdin(
-      'gh',
-      ['issue', 'edit', String(options.issueNumber), '--title', options.title, '--body-file', '-'],
-      options.body,
-    );
+    const args = [
+      'issue',
+      'edit',
+      String(options.issueNumber),
+      '--title',
+      options.title,
+      '--body-file',
+      '-',
+    ];
+    // Native metadata fields (#45). `gh issue edit` uses `--add-assignee`
+    // (additive) rather than the `--assignee` flag used by `gh issue create`.
+    if (options.milestone) args.push('--milestone', options.milestone);
+    for (const assignee of options.assignees ?? []) args.push('--add-assignee', assignee);
+    await this.spawnWithStdin('gh', args, options.body);
     await this.syncIssueLabels(options.issueNumber, options.labels ?? []);
   }
 

--- a/packages/pipeline/src/pipeline.ts
+++ b/packages/pipeline/src/pipeline.ts
@@ -6,6 +6,7 @@ import {
   resolveRequireApproval,
   resolveRequireApprovalForIssue,
   type ShipCodePlan,
+  stripPrdFrontmatter,
 } from '@shipcode/shared';
 import { nanoid } from 'nanoid';
 import { createPipelineContextHelpers } from './pipeline/context';
@@ -321,8 +322,11 @@ export function createPipeline(deps: PipelineDeps): Pipeline {
       reviewRound: 0,
     });
 
+    // Strip any legacy YAML frontmatter from the body so the planner sees the
+    // clean PRD prose, not duplicated metadata that now lives in native
+    // labels / project fields (#45).
     const prompt =
-      `GitHub Issue #${issue.number}: ${issue.title}\n\n${issue.body ?? ''}` +
+      `GitHub Issue #${issue.number}: ${issue.title}\n\n${stripPrdFrontmatter(issue.body ?? '')}` +
       buildWorkpadProtocol({ issueNumber: issue.number });
     launch(threadId, () =>
       planning.startPlanGeneration(threadId, prompt, projectPath, options?.worktreePath ?? null),

--- a/packages/shared/src/prd-issue-metadata.test.ts
+++ b/packages/shared/src/prd-issue-metadata.test.ts
@@ -1,9 +1,52 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildPrdMetadataLabels,
+  PRD_BLAST_LABEL_PREFIX,
+  PRD_COMPLEXITY_LABEL_PREFIX,
+  PRD_METADATA_MAPPING,
   readPrdIssueMetadata,
   splitPrdFrontmatter,
   stripPrdFrontmatter,
 } from './prd-issue-metadata';
+
+describe('buildPrdMetadataLabels', () => {
+  it('projects complexity and blast radius onto native label strings', () => {
+    expect(buildPrdMetadataLabels('high', 'infra')).toEqual(['complexity:high', 'blast:infra']);
+    expect(buildPrdMetadataLabels('low', 'contained')).toEqual([
+      'complexity:low',
+      'blast:contained',
+    ]);
+  });
+
+  it('round-trips through readPrdIssueMetadata via native labels', () => {
+    const labels = buildPrdMetadataLabels('medium', 'cross-package');
+    const meta = readPrdIssueMetadata('Just the prose.', labels);
+    expect(meta.estimatedComplexity).toBe('medium');
+    expect(meta.blastRadius).toBe('cross-package');
+  });
+});
+
+describe('PRD_METADATA_MAPPING', () => {
+  it('maps complexity and blast radius to native labels with the right prefixes', () => {
+    const byField = new Map(PRD_METADATA_MAPPING.map((m) => [m.field, m]));
+    expect(byField.get('estimatedComplexity')).toMatchObject({
+      target: 'native-label',
+      labelPrefix: PRD_COMPLEXITY_LABEL_PREFIX,
+    });
+    expect(byField.get('blastRadius')).toMatchObject({
+      target: 'native-label',
+      labelPrefix: PRD_BLAST_LABEL_PREFIX,
+    });
+  });
+
+  it('maps milestone and assignees to native fields and project facets to project fields', () => {
+    const byField = new Map(PRD_METADATA_MAPPING.map((m) => [m.field, m.target]));
+    expect(byField.get('milestone')).toBe('native-field');
+    expect(byField.get('assignees')).toBe('native-field');
+    expect(byField.get('issueType')).toBe('project-field');
+    expect(byField.get('priority')).toBe('project-field');
+  });
+});
 
 describe('splitPrdFrontmatter', () => {
   it('extracts frontmatter and strips it from the body', () => {

--- a/packages/shared/src/prd-issue-metadata.ts
+++ b/packages/shared/src/prd-issue-metadata.ts
@@ -9,6 +9,44 @@ export type PrdEstimatedComplexity = (typeof PRD_ESTIMATED_COMPLEXITIES)[number]
 export const PRD_BLAST_RADII = ['contained', 'cross-package', 'cross-app', 'infra'] as const;
 export type PrdBlastRadius = (typeof PRD_BLAST_RADII)[number];
 
+export const PRD_METADATA_LABELS = [
+  {
+    name: 'complexity:low',
+    color: '0e8a16',
+    description: 'PRD estimated complexity: low.',
+  },
+  {
+    name: 'complexity:medium',
+    color: 'fbca04',
+    description: 'PRD estimated complexity: medium.',
+  },
+  {
+    name: 'complexity:high',
+    color: 'd93f0b',
+    description: 'PRD estimated complexity: high.',
+  },
+  {
+    name: 'blast:contained',
+    color: '1f883d',
+    description: 'PRD blast radius: contained.',
+  },
+  {
+    name: 'blast:cross-package',
+    color: '0969da',
+    description: 'PRD blast radius: cross-package.',
+  },
+  {
+    name: 'blast:cross-app',
+    color: '8250df',
+    description: 'PRD blast radius: cross-app.',
+  },
+  {
+    name: 'blast:infra',
+    color: 'cf222e',
+    description: 'PRD blast radius: infrastructure.',
+  },
+] as const;
+
 export const PRD_MANAGED_LABEL_PREFIXES = [
   PRD_COMPLEXITY_LABEL_PREFIX,
   PRD_BLAST_LABEL_PREFIX,

--- a/packages/shared/src/prd-issue-metadata.ts
+++ b/packages/shared/src/prd-issue-metadata.ts
@@ -86,6 +86,66 @@ export function splitPrdFrontmatter(body: string): {
   };
 }
 
+export type PrdMetadataTarget = 'native-label' | 'native-field' | 'project-field';
+
+export interface PrdMetadataFieldMapping {
+  /** The PRD/task metadata field. */
+  field:
+    | 'estimatedComplexity'
+    | 'blastRadius'
+    | 'issueType'
+    | 'status'
+    | 'priority'
+    | 'milestone'
+    | 'assignees';
+  /** Where the value is projected on GitHub. */
+  target: PrdMetadataTarget;
+  /** For `native-label` targets, the label prefix used (e.g. `complexity:`). */
+  labelPrefix?: string;
+}
+
+/**
+ * Authoritative map of which PRD/task metadata projects onto which GitHub
+ * surface (AC1 of #45):
+ * - `native-label`  — a `prefix:value` label on the issue itself
+ * - `native-field`  — a first-class issue field set via `gh issue` flags
+ *                     (milestone, assignees)
+ * - `project-field` — a Projects v2 single-select field
+ *
+ * Keeps the projection sites (gh-cli, IPC handlers) honest about where each
+ * field is meant to live and removes the old reliance on body frontmatter.
+ */
+export const PRD_METADATA_MAPPING: readonly PrdMetadataFieldMapping[] = [
+  {
+    field: 'estimatedComplexity',
+    target: 'native-label',
+    labelPrefix: PRD_COMPLEXITY_LABEL_PREFIX,
+  },
+  { field: 'blastRadius', target: 'native-label', labelPrefix: PRD_BLAST_LABEL_PREFIX },
+  { field: 'issueType', target: 'project-field' },
+  { field: 'status', target: 'project-field' },
+  { field: 'priority', target: 'project-field' },
+  { field: 'milestone', target: 'native-field' },
+  { field: 'assignees', target: 'native-field' },
+] as const;
+
+/**
+ * Build the native issue labels that project a PRD's complexity + blast radius
+ * onto the issue itself (e.g. `complexity:medium`, `blast:contained`). Written
+ * on create and kept in sync on edit so the metadata survives even for repos
+ * without a configured Projects v2 board — previously these values only ever
+ * reached the board fields and vanished for boardless projects.
+ */
+export function buildPrdMetadataLabels(
+  estimatedComplexity: PrdEstimatedComplexity,
+  blastRadius: PrdBlastRadius,
+): string[] {
+  return [
+    `${PRD_COMPLEXITY_LABEL_PREFIX}${estimatedComplexity}`,
+    `${PRD_BLAST_LABEL_PREFIX}${blastRadius}`,
+  ];
+}
+
 export function readPrdIssueMetadata(body: string, labels: string[] = []): PrdIssueMetadata {
   const { frontmatter, cleanBody } = splitPrdFrontmatter(body);
   const estimatedComplexity =


### PR DESCRIPTION
Closes #45.

## Context

Triaged from the stale `shipcode:pipeline:failed` label. ShipCode's issue model was split awkwardly: complexity / blast radius were written **only** to Projects v2 board fields (or legacy YAML frontmatter in the body). That meant the metadata **vanished entirely for repos without a configured board**, and the issue body stayed frontmatter-noisy.

This projects PRD/task metadata onto native GitHub surfaces.

## Changes per acceptance criterion

**AC1 — define the mapping.** New `PRD_METADATA_MAPPING` in `shared/prd-issue-metadata.ts`: the authoritative table of which field lands as a `native-label`, a `native-field` (gh issue flag), or a `project-field`.

**AC2 / AC5 — native labels on create *and* edit.** New `buildPrdMetadataLabels()` turns complexity + blast radius into `complexity:<x>` / `blast:<x>` labels. The `github:create-issue` and `github:edit-issue-body` handlers now merge these into the label set, so they're written to the issue itself — **independent of any board** (the core bug). `syncIssueLabels` only touches PRD-managed prefixes, so user labels are untouched on edit.

**AC3 — extensible native fields.** `GhCli.createIssue` / `editIssue` accept optional `milestone` + `assignees` and forward them as native `--milestone` / `--assignee` (`--add-assignee` on edit). Labels (minimum) + issue type (Projects v2) were already covered; this makes milestone/assignees a one-call extension.

**AC4 — cache stays fresh.** The edit path now refreshes the cached issue type after the project-metadata write, mirroring create — previously the local cache went stale until the next full sync.

**AC5 — reduce frontmatter duplication.** `pipeline.ts` strips legacy YAML frontmatter from the issue body before it reaches the planner prompt, so duplicated metadata no longer leaks into planning. (New PRDs already omit frontmatter; the parser keeps reading it as a fallback for old issues.)

## Tests

- `prd-issue-metadata.test.ts` — `buildPrdMetadataLabels` output + round-trip via `readPrdIssueMetadata`; `PRD_METADATA_MAPPING` targets/prefixes.
- `gh-cli.test.ts` — native `--milestone` + `--assignee` on create, `--milestone` + `--add-assignee` on edit.
- `register-github-handlers.test.ts` — complexity/blast projected onto native labels **even without a board**; cached issue type refreshed on edit.

Scoped suites green: shared 14, agents gh-cli 82, desktop github-handlers 91, pipeline 196. No new `tsc`/biome findings (the 4 pre-existing `register-pipeline-handlers.ts` TS2556 errors are unrelated and live on `develop`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * PRD complexity and blast-radius metadata are now automatically converted to GitHub native labels when creating and editing issues
  * Added support for setting milestones and assignees when creating or editing GitHub issues

* **Bug Fixes**
  * Local issue type cache is now properly refreshed after editing PRD metadata to prevent stale data

* **Tests**
  * Added comprehensive test coverage for PRD metadata label handling and GitHub CLI milestone/assignee functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->