### PR TITLE
test: dedupe health env setup

### DIFF
--- a/packages/agents/src/health-check.test.ts
+++ b/packages/agents/src/health-check.test.ts
@@ -296,15 +296,30 @@ function createPromptThenUsagePty(promptText: string, usageText: string) {
   };
 }
 
+function withEnv(overrides: Partial<NodeJS.ProcessEnv>, fn: () => void) {
+  const previous = Object.fromEntries(
+    Object.keys(overrides).map((key) => [key, process.env[key]]),
+  ) as Partial<NodeJS.ProcessEnv>;
+
+  try {
+    Object.assign(process.env, overrides);
+    fn();
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
 describe('shellExecEnv', () => {
   it('hydrates PATH from the login shell and keeps standard tool locations available', () => {
-    const previousBunInstall = process.env.BUN_INSTALL;
-    const previousShell = process.env.SHELL;
-    process.env.BUN_INSTALL = '';
-    process.env.SHELL = '/bin/zsh';
-    mockExecFileSync.mockReturnValue('/shell/bin:/usr/bin\n');
+    withEnv({ BUN_INSTALL: '', SHELL: '/bin/zsh' }, () => {
+      mockExecFileSync.mockReturnValue('/shell/bin:/usr/bin\n');
 
-    try {
       const env = shellExecEnv();
 
       expect(env.PATH.split(':')).toEqual(
@@ -321,88 +336,32 @@ describe('shellExecEnv', () => {
         encoding: 'utf-8',
         timeout: 5000,
       });
-    } finally {
-      if (previousBunInstall === undefined) {
-        delete process.env.BUN_INSTALL;
-      } else {
-        process.env.BUN_INSTALL = previousBunInstall;
-      }
-      if (previousShell === undefined) {
-        delete process.env.SHELL;
-      } else {
-        process.env.SHELL = previousShell;
-      }
-    }
+    });
   });
 
   it('falls back to conservative executable paths for untrusted shells', () => {
-    const previousBunInstall = process.env.BUN_INSTALL;
-    const previousShell = process.env.SHELL;
-    const previousPath = process.env.PATH;
-    process.env.BUN_INSTALL = '';
-    process.env.SHELL = '/tmp/fake-shell';
-    process.env.PATH = '/custom/bin:/usr/bin';
-
-    try {
+    withEnv({ BUN_INSTALL: '', SHELL: '/tmp/fake-shell', PATH: '/custom/bin:/usr/bin' }, () => {
       const env = shellExecEnv();
 
       expect(env.PATH.split(':')).toEqual(
         expect.arrayContaining(['/custom/bin', '/mock/home/.bun/bin', '/opt/homebrew/bin']),
       );
       expect(mockExecFileSync).not.toHaveBeenCalled();
-    } finally {
-      if (previousBunInstall === undefined) {
-        delete process.env.BUN_INSTALL;
-      } else {
-        process.env.BUN_INSTALL = previousBunInstall;
-      }
-      if (previousShell === undefined) {
-        delete process.env.SHELL;
-      } else {
-        process.env.SHELL = previousShell;
-      }
-      if (previousPath === undefined) {
-        delete process.env.PATH;
-      } else {
-        process.env.PATH = previousPath;
-      }
-    }
+    });
   });
 
   it('falls back to process PATH when a trusted login shell probe fails', () => {
-    const previousBunInstall = process.env.BUN_INSTALL;
-    const previousShell = process.env.SHELL;
-    const previousPath = process.env.PATH;
-    process.env.BUN_INSTALL = '';
-    process.env.SHELL = '/bin/zsh';
-    process.env.PATH = '/custom/bin';
-    mockExecFileSync.mockImplementation(() => {
-      throw new Error('shell failed');
-    });
+    withEnv({ BUN_INSTALL: '', SHELL: '/bin/zsh', PATH: '/custom/bin' }, () => {
+      mockExecFileSync.mockImplementation(() => {
+        throw new Error('shell failed');
+      });
 
-    try {
       const env = shellExecEnv();
 
       expect(env.PATH.split(':')).toEqual(
         expect.arrayContaining(['/custom/bin', '/mock/home/.bun/bin', '/usr/bin']),
       );
-    } finally {
-      if (previousBunInstall === undefined) {
-        delete process.env.BUN_INSTALL;
-      } else {
-        process.env.BUN_INSTALL = previousBunInstall;
-      }
-      if (previousShell === undefined) {
-        delete process.env.SHELL;
-      } else {
-        process.env.SHELL = previousShell;
-      }
-      if (previousPath === undefined) {
-        delete process.env.PATH;
-      } else {
-        process.env.PATH = previousPath;
-      }
-    }
+    });
   });
 });
 


### PR DESCRIPTION
## Summary\n- Extract shared process.env override/restore helper in health-check tests\n- Replace three repeated try/finally env setup blocks\n- Net LOC reduction: 29 insertions, 70 deletions (-41)\n\n## Verification\n- bunx biome check packages/agents/src/health-check.test.ts --files-ignore-unknown=true\n- git diff --check\n\n## Notes\n- Focused test execution is blocked in this fresh worktree: direct Bun/Vitest cannot resolve workspace package @shipcode/shared; package script also cannot find vitest/tsc on PATH without installed workspace deps.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test code organization and maintainability through refactored test infrastructure. Test coverage and validation behavior remain unchanged, with modifications focused solely on enhancing long-term code maintainability without affecting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->