### PR TITLE
feat(issue-chat): add issue chat tab

### DIFF
--- a/apps/desktop/src/renderer/components/AssistantPanel.tsx
+++ b/apps/desktop/src/renderer/components/AssistantPanel.tsx
@@ -1,11 +1,4 @@
-import {
-  type AppSettings,
-  formatClockTime,
-  type Project,
-  type ProjectSetupDraft,
-  stripAnsi,
-  type TerminalEventRecord,
-} from '@shipcode/shared';
+import type { AppSettings, Project, ProjectSetupDraft } from '@shipcode/shared';
 import {
   Badge,
   Button,
@@ -19,22 +12,11 @@ import {
 } from '@shipshitdev/ui';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Bot, Plus, Send, Square, X } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { STABLE_APP_STATE_STALE_TIME } from '../query-stale-times';
-import { type AssistantCli, type AssistantUserMessage, useAppStore } from '../stores/app-store';
+import { type AssistantCli, useAppStore } from '../stores/app-store';
 import { toast } from '../stores/toast-store';
-
-const EMPTY_STREAM: TerminalEventRecord[] = [];
-const THINKING_LETTERS = [
-  { id: 't', letter: 'T', delay: 0 },
-  { id: 'h', letter: 'h', delay: 1 },
-  { id: 'i', letter: 'i', delay: 2 },
-  { id: 'n', letter: 'n', delay: 3 },
-  { id: 'k', letter: 'k', delay: 4 },
-  { id: 'i-2', letter: 'i', delay: 5 },
-  { id: 'n-2', letter: 'n', delay: 6 },
-  { id: 'g', letter: 'g', delay: 7 },
-];
+import { AssistantTimeline, useAssistantTranscript } from './assistant/AssistantTimeline';
 
 function setupSummary(setup: ProjectSetupDraft | null): string {
   if (!setup) return 'Setup contract: not loaded.';
@@ -89,443 +71,38 @@ function buildAssistantSystemPrompt(args: {
   ].join('\n');
 }
 
-function useAssistantTranscript(threadId: string | null) {
-  const stream = useAppStore((state) =>
-    threadId ? (state.canonicalTerminalStream[threadId] ?? EMPTY_STREAM) : EMPTY_STREAM,
-  );
-  const hydrateCanonicalEvents = useAppStore((state) => state.hydrateCanonicalEvents);
-
-  useEffect(() => {
-    if (!threadId || stream.length > 0) return;
-
-    let cancelled = false;
-    void window.shipcode
-      .invoke<TerminalEventRecord[]>('terminal:list', { threadId, limit: 1000 })
-      .then((events) => {
-        if (cancelled || !Array.isArray(events) || events.length === 0) return;
-        hydrateCanonicalEvents(threadId, events);
-      })
-      .catch(() => {
-        // Best-effort transcript hydration.
-      });
-
-    return () => {
-      cancelled = true;
-    };
-  }, [hydrateCanonicalEvents, stream.length, threadId]);
-
-  return stream;
-}
-
-type ConversationItem =
-  | { id: string; kind: 'user'; content: string; createdAt: string }
-  | { id: string; kind: 'assistant'; content: string; createdAt: string }
-  | { id: string; kind: 'thinking'; content: string; createdAt: string }
-  | { id: string; kind: 'activity'; content: string; createdAt: string }
-  | {
-      id: string;
-      kind: 'tool';
-      name: string;
-      summary: string;
-      durationMs?: number;
-      exitCode?: number;
-      outputSummary?: string;
-      createdAt: string;
-    }
-  | { id: string; kind: 'error'; message: string; createdAt: string };
-
-function rawActivityLines(content: string): string[] {
-  const lines: string[] = [];
-  for (const raw of stripAnsi(content).replace(/\r/g, '\n').split('\n')) {
-    const line = raw.trim();
-    if (
-      !line ||
-      /^[\d:.\s]+$/.test(line) ||
-      /^esc to cancel/i.test(line) ||
-      /^ctrl[+-]/i.test(line)
-    )
-      continue;
-    lines.push(line);
-  }
-  return lines.slice(-6);
-}
-
-function buildConversationItems(records: TerminalEventRecord[]): ConversationItem[] {
-  const items: ConversationItem[] = [];
-  const pendingTools = new Map<string, ConversationItem & { kind: 'tool' }>();
-  let previousRawLine: string | null = null;
-
-  for (const record of records) {
-    const { event, id, createdAt } = record;
-
-    if (event.kind === 'text') {
-      const content = stripAnsi(event.content).trim();
-      if (content) items.push({ id, kind: 'assistant', content, createdAt });
-    } else if (event.kind === 'thinking') {
-      const content = stripAnsi(event.content).trim();
-      if (content) items.push({ id, kind: 'thinking', content, createdAt });
-    } else if (event.kind === 'tool_start') {
-      const item: ConversationItem & { kind: 'tool' } = {
-        id,
-        kind: 'tool',
-        name: event.name,
-        summary: stripAnsi(event.summary).trim(),
-        createdAt,
-      };
-      pendingTools.set(event.name, item);
-      items.push(item);
-    } else if (event.kind === 'tool_end') {
-      const pending = pendingTools.get(event.name);
-      if (pending) {
-        Object.assign(pending, {
-          durationMs: event.durationMs,
-          exitCode: event.exitCode,
-          outputSummary: event.outputSummary ? stripAnsi(event.outputSummary).trim() : undefined,
-        });
-        pendingTools.delete(event.name);
-      }
-    } else if (event.kind === 'error') {
-      const message = stripAnsi(event.message).trim();
-      if (message) items.push({ id, kind: 'error', message, createdAt });
-    } else if (event.kind === 'raw') {
-      const lines = rawActivityLines(event.content);
-      for (const [index, line] of lines.entries()) {
-        if (line === previousRawLine) continue;
-        previousRawLine = line;
-        items.push({
-          id: `${id}:raw:${index}`,
-          kind: 'activity',
-          content: line,
-          createdAt,
-        });
-      }
-    }
-  }
-
-  return items;
-}
-
-function latestActivity(events: TerminalEventRecord[]) {
-  let thinking: string | null = null;
-  let activeTool: string | null = null;
-  let completedTools = 0;
-  let failedTools = 0;
-  let errorCount = 0;
-
-  for (const record of events) {
-    const event = record.event;
-    if (event.kind === 'thinking') {
-      const content = stripAnsi(event.content).trim();
-      if (content) thinking = content;
-    }
-    if (event.kind === 'tool_start') {
-      activeTool = [event.name, stripAnsi(event.summary).trim()].filter(Boolean).join(' · ');
-    }
-    if (event.kind === 'tool_end') {
-      completedTools += 1;
-      if (typeof event.exitCode === 'number' && event.exitCode !== 0) {
-        failedTools += 1;
-      }
-      activeTool = null;
-    }
-    if (event.kind === 'error') {
-      errorCount += 1;
-    }
-  }
-
-  return { thinking, activeTool, completedTools, failedTools, errorCount };
-}
-
-function AnimatedThinkingWord({ className }: { className?: string }) {
-  return (
-    <span
-      role="status"
-      aria-label="Thinking"
-      className={cn('inline-flex font-medium text-[11px] tracking-wide uppercase', className)}
-    >
-      {THINKING_LETTERS.map(({ id, letter, delay }) => (
-        <span
-          key={id}
-          aria-hidden="true"
-          className="assistant-thinking-letter"
-          style={{ '--thinking-letter-index': delay } as React.CSSProperties}
-        >
-          {letter}
-        </span>
-      ))}
-    </span>
-  );
-}
-
-function AgentActivityOverview({
-  events,
-  isRunning,
-}: {
-  events: TerminalEventRecord[];
-  isRunning: boolean;
-}) {
-  const activity = useMemo(() => latestActivity(events), [events]);
-  const hasActivity =
-    activity.thinking != null ||
-    activity.activeTool != null ||
-    activity.completedTools > 0 ||
-    activity.errorCount > 0;
-
-  if (!hasActivity) return null;
-
-  return (
-    <div className="rounded-md border border-border/70 bg-primary/50 px-3 py-2 text-[11px] text-secondary">
-      <div className="flex flex-wrap items-center gap-2">
-        <Badge variant={isRunning ? 'default' : 'done'} className="text-[10px]">
-          {isRunning ? 'Running' : 'Done'}
-        </Badge>
-        {activity.activeTool ? (
-          <span className="truncate text-primary">Tool: {activity.activeTool}</span>
-        ) : activity.completedTools > 0 ? (
-          <span>
-            Tools: {activity.completedTools}
-            {activity.failedTools > 0 ? ` (${activity.failedTools} failed)` : ''}
-          </span>
-        ) : null}
-        {activity.errorCount > 0 ? (
-          <span className="text-danger">Errors: {activity.errorCount}</span>
-        ) : null}
-      </div>
-      {activity.thinking ? (
-        <div className="mt-1 truncate text-muted-foreground">Thinking: {activity.thinking}</div>
-      ) : null}
-    </div>
-  );
-}
-
-function AssistantTimeline({
-  threadId,
-  events,
-  userMessages,
-  isRunning,
-}: {
-  threadId: string | null;
-  events: TerminalEventRecord[];
-  userMessages: AssistantUserMessage[];
-  isRunning: boolean;
-}) {
-  const bottomRef = useRef<HTMLDivElement | null>(null);
-  const items = useMemo(() => {
-    if (!threadId) return [];
-    const userItems: ConversationItem[] = userMessages.flatMap((message) =>
-      message.threadId === threadId
-        ? [
-            {
-              id: message.id,
-              kind: 'user' as const,
-              content: message.content,
-              createdAt: message.createdAt,
-            },
-          ]
-        : [],
-    );
-    const eventItems = buildConversationItems(events);
-    return [...userItems, ...eventItems].sort((a, b) =>
-      a.createdAt === b.createdAt
-        ? a.id.localeCompare(b.id)
-        : a.createdAt.localeCompare(b.createdAt),
-    );
-  }, [events, threadId, userMessages]);
-
-  useEffect(() => {
-    if (typeof bottomRef.current?.scrollIntoView !== 'function') return;
-    bottomRef.current.scrollIntoView({ block: 'end' });
-  });
-
-  if (!threadId) return null;
-
-  if (items.length === 0) {
-    return (
-      <div className="flex min-h-0 flex-1 flex-col gap-3 p-5 text-sm text-secondary">
-        <AgentActivityOverview events={events} isRunning={isRunning} />
-        <div className="flex flex-1 items-center justify-center">
-          {isRunning ? <AnimatedThinkingWord /> : 'No assistant messages yet.'}
-        </div>
-      </div>
-    );
-  }
-
-  return (
-    <div className="min-h-0 flex-1 overflow-y-auto p-3">
-      <div className="mx-auto flex flex-col gap-3">
-        {items.map((item) => {
-          if (item.kind === 'user') {
-            return (
-              <div key={item.id} className="flex justify-end">
-                <div className="max-w-[78%] rounded-lg border border-agent/25 bg-agent/15 px-3.5 py-2.5 text-primary text-xs leading-5 shadow-sm">
-                  <div className="mb-1 text-[10px] text-agent">
-                    {formatClockTime(item.createdAt)}
-                  </div>
-                  <div className="whitespace-pre-wrap break-words">{item.content}</div>
-                </div>
-              </div>
-            );
-          }
-
-          if (item.kind === 'assistant') {
-            return (
-              <div key={item.id} className="flex justify-start">
-                <div className="max-w-[84%] rounded-lg border border-border bg-elevated px-3.5 py-2.5 text-primary text-xs leading-5 shadow-sm">
-                  <div className="mb-1 text-[10px] text-muted-foreground">
-                    {formatClockTime(item.createdAt)}
-                  </div>
-                  <div className="whitespace-pre-wrap break-words">{item.content}</div>
-                </div>
-              </div>
-            );
-          }
-
-          if (item.kind === 'thinking') {
-            const PREVIEW_LEN = 80;
-            const preview =
-              item.content.length > PREVIEW_LEN
-                ? `${item.content.slice(0, PREVIEW_LEN).trimEnd()}…`
-                : item.content;
-            return (
-              <div key={item.id} className="flex justify-start px-1">
-                <details className="w-full max-w-[84%] rounded-md border border-border/40 bg-secondary/30 px-3 py-1.5">
-                  <summary className="cursor-pointer list-none text-[11px] text-muted-foreground italic">
-                    <span className="mr-2 font-mono text-[10px] text-muted-foreground/60">
-                      {formatClockTime(item.createdAt)}
-                    </span>
-                    Thinking: {preview}
-                  </summary>
-                  <div className="mt-2 whitespace-pre-wrap break-words text-[11px] italic leading-5 text-secondary/80">
-                    {item.content}
-                  </div>
-                </details>
-              </div>
-            );
-          }
-
-          if (item.kind === 'tool') {
-            const failed = typeof item.exitCode === 'number' && item.exitCode !== 0;
-            const durationLabel =
-              typeof item.durationMs === 'number'
-                ? `${(item.durationMs / 1000).toFixed(1)}s`
-                : null;
-
-            const oneLiner = (
-              <div key={`${item.id}:summary`} className="flex items-center gap-2 text-[11px]">
-                <span className="shrink-0 font-mono text-[10px] text-muted-foreground/60">
-                  {formatClockTime(item.createdAt)}
-                </span>
-                <span
-                  className={cn(
-                    'shrink-0 rounded px-1.5 py-0 text-[9px] font-bold uppercase tracking-wide',
-                    failed
-                      ? 'border border-danger/30 bg-danger/15 text-danger'
-                      : 'border border-border/50 bg-border/60 text-secondary',
-                  )}
-                >
-                  {item.name || 'tool'}
-                </span>
-                {item.summary ? (
-                  <span className="truncate text-muted-foreground">{item.summary}</span>
-                ) : null}
-                {durationLabel ? (
-                  <span className="shrink-0 font-mono text-[10px] text-muted-foreground/60">
-                    {durationLabel}
-                  </span>
-                ) : null}
-                {failed ? (
-                  <span className="shrink-0 text-[10px] text-danger">exit {item.exitCode}</span>
-                ) : null}
-              </div>
-            );
-
-            if (!failed || !item.outputSummary) {
-              return (
-                <div key={item.id} className="px-1">
-                  {oneLiner}
-                </div>
-              );
-            }
-
-            return (
-              <div key={item.id} className="px-1">
-                <details className="rounded-md border border-danger/20 bg-danger/5 px-3 py-1.5">
-                  <summary className="cursor-pointer list-none">{oneLiner}</summary>
-                  <pre className="mt-2 whitespace-pre-wrap break-words font-mono text-[10px] leading-4 text-danger">
-                    {item.outputSummary}
-                  </pre>
-                </details>
-              </div>
-            );
-          }
-
-          if (item.kind === 'activity') {
-            return (
-              <div key={item.id} className="px-1">
-                <div className="flex items-start gap-2 text-[11px] text-secondary">
-                  <span className="shrink-0 font-mono text-[10px] text-muted-foreground/60">
-                    {formatClockTime(item.createdAt)}
-                  </span>
-                  <span className="break-words">{item.content}</span>
-                </div>
-              </div>
-            );
-          }
-
-          if (item.kind === 'error') {
-            return (
-              <div key={item.id} className="px-1">
-                <div className="flex items-start gap-2 rounded-md border border-danger/25 bg-danger/8 px-3 py-1.5 text-[11px]">
-                  <span className="shrink-0 font-mono text-[10px] text-muted-foreground/60">
-                    {formatClockTime(item.createdAt)}
-                  </span>
-                  <span className="font-medium text-danger">Error</span>
-                  <span className="break-words text-danger/80">{item.message}</span>
-                </div>
-              </div>
-            );
-          }
-
-          return null;
-        })}
-        <AgentActivityOverview events={events} isRunning={isRunning} />
-        {isRunning ? (
-          <div className="flex items-center justify-start px-1">
-            <AnimatedThinkingWord />
-          </div>
-        ) : null}
-        <div ref={bottomRef} className="h-px shrink-0" />
-      </div>
-    </div>
-  );
-}
-
 function suggestedPromptButtons(setAssistantDraft: (draft: string) => void) {
   return (
     <div className="space-y-2 text-xs text-muted-foreground">
-      <button
+      <Button
         type="button"
-        className="block text-left hover:text-primary"
+        variant="ghost"
+        size="sm"
+        className="h-auto w-full justify-start px-0 py-0 text-left text-xs font-normal text-muted-foreground hover:bg-transparent hover:text-primary"
         onClick={() => setAssistantDraft('Review this project setup and tell me what is missing.')}
       >
         Review this project setup and tell me what is missing.
-      </button>
-      <button
+      </Button>
+      <Button
         type="button"
-        className="block text-left hover:text-primary"
+        variant="ghost"
+        size="sm"
+        className="h-auto w-full justify-start px-0 py-0 text-left text-xs font-normal text-muted-foreground hover:bg-transparent hover:text-primary"
         onClick={() =>
           setAssistantDraft('Look at the Kanban board and suggest what I should run next.')
         }
       >
         Look at the Kanban board and suggest what I should run next.
-      </button>
-      <button
+      </Button>
+      <Button
         type="button"
-        className="block text-left hover:text-primary"
+        variant="ghost"
+        size="sm"
+        className="h-auto w-full justify-start px-0 py-0 text-left text-xs font-normal text-muted-foreground hover:bg-transparent hover:text-primary"
         onClick={() => setAssistantDraft('Help me turn this idea into GitHub issues.')}
       >
         Help me turn this idea into GitHub issues.
-      </button>
+      </Button>
     </div>
   );
 }

--- a/apps/desktop/src/renderer/components/assistant/AssistantTimeline.tsx
+++ b/apps/desktop/src/renderer/components/assistant/AssistantTimeline.tsx
@@ -1,0 +1,444 @@
+import { formatClockTime, stripAnsi, type TerminalEventRecord } from '@shipcode/shared';
+import { CollapsibleSection } from '@shipcode/ui';
+import { Badge, cn } from '@shipshitdev/ui';
+import { type CSSProperties, useEffect, useMemo, useRef } from 'react';
+import { useAppStore } from '../../stores/app-store';
+
+const EMPTY_STREAM: TerminalEventRecord[] = [];
+const THINKING_LETTERS = [
+  { id: 't', letter: 'T', delay: 0 },
+  { id: 'h', letter: 'h', delay: 1 },
+  { id: 'i', letter: 'i', delay: 2 },
+  { id: 'n', letter: 'n', delay: 3 },
+  { id: 'k', letter: 'k', delay: 4 },
+  { id: 'i-2', letter: 'i', delay: 5 },
+  { id: 'n-2', letter: 'n', delay: 6 },
+  { id: 'g', letter: 'g', delay: 7 },
+];
+
+export interface AssistantTimelineUserMessage {
+  id: string;
+  threadId: string;
+  content: string;
+  createdAt: string;
+}
+
+type ConversationItem =
+  | { id: string; kind: 'user'; content: string; createdAt: string }
+  | { id: string; kind: 'assistant'; content: string; createdAt: string }
+  | { id: string; kind: 'thinking'; content: string; createdAt: string }
+  | { id: string; kind: 'activity'; content: string; createdAt: string }
+  | {
+      id: string;
+      kind: 'tool';
+      name: string;
+      summary: string;
+      durationMs?: number;
+      exitCode?: number;
+      outputSummary?: string;
+      createdAt: string;
+    }
+  | { id: string; kind: 'error'; message: string; createdAt: string };
+
+export function useAssistantTranscript(threadId: string | null) {
+  const stream = useAppStore((state) =>
+    threadId ? (state.canonicalTerminalStream[threadId] ?? EMPTY_STREAM) : EMPTY_STREAM,
+  );
+  const hydrateCanonicalEvents = useAppStore((state) => state.hydrateCanonicalEvents);
+
+  useEffect(() => {
+    if (!threadId || stream.length > 0) return;
+
+    let cancelled = false;
+    void window.shipcode
+      .invoke<TerminalEventRecord[]>('terminal:list', { threadId, limit: 1000 })
+      .then((events) => {
+        if (cancelled || !Array.isArray(events) || events.length === 0) return;
+        hydrateCanonicalEvents(threadId, events);
+      })
+      .catch(() => {
+        // Best-effort transcript hydration.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [hydrateCanonicalEvents, stream.length, threadId]);
+
+  return stream;
+}
+
+function rawActivityLines(content: string): string[] {
+  const lines: string[] = [];
+  for (const raw of stripAnsi(content).replace(/\r/g, '\n').split('\n')) {
+    const line = raw.trim();
+    if (
+      !line ||
+      /^[\d:.\s]+$/.test(line) ||
+      /^esc to cancel/i.test(line) ||
+      /^ctrl[+-]/i.test(line)
+    )
+      continue;
+    lines.push(line);
+  }
+  return lines.slice(-6);
+}
+
+export function buildConversationItems(records: TerminalEventRecord[]): ConversationItem[] {
+  const items: ConversationItem[] = [];
+  const pendingTools = new Map<string, ConversationItem & { kind: 'tool' }>();
+  let previousRawLine: string | null = null;
+
+  for (const record of records) {
+    const { event, id, createdAt } = record;
+
+    if (event.kind === 'text') {
+      const content = stripAnsi(event.content).trim();
+      if (content) items.push({ id, kind: 'assistant', content, createdAt });
+    } else if (event.kind === 'thinking') {
+      const content = stripAnsi(event.content).trim();
+      if (content) items.push({ id, kind: 'thinking', content, createdAt });
+    } else if (event.kind === 'tool_start') {
+      const item: ConversationItem & { kind: 'tool' } = {
+        id,
+        kind: 'tool',
+        name: event.name,
+        summary: stripAnsi(event.summary).trim(),
+        createdAt,
+      };
+      pendingTools.set(event.name, item);
+      items.push(item);
+    } else if (event.kind === 'tool_end') {
+      const pending = pendingTools.get(event.name);
+      if (pending) {
+        Object.assign(pending, {
+          durationMs: event.durationMs,
+          exitCode: event.exitCode,
+          outputSummary: event.outputSummary ? stripAnsi(event.outputSummary).trim() : undefined,
+        });
+        pendingTools.delete(event.name);
+      }
+    } else if (event.kind === 'error') {
+      const message = stripAnsi(event.message).trim();
+      if (message) items.push({ id, kind: 'error', message, createdAt });
+    } else if (event.kind === 'raw') {
+      const lines = rawActivityLines(event.content);
+      for (const [index, line] of lines.entries()) {
+        if (line === previousRawLine) continue;
+        previousRawLine = line;
+        items.push({
+          id: `${id}:raw:${index}`,
+          kind: 'activity',
+          content: line,
+          createdAt,
+        });
+      }
+    }
+  }
+
+  return items;
+}
+
+function latestActivity(events: TerminalEventRecord[]) {
+  let thinking: string | null = null;
+  let activeTool: string | null = null;
+  let completedTools = 0;
+  let failedTools = 0;
+  let errorCount = 0;
+
+  for (const record of events) {
+    const event = record.event;
+    if (event.kind === 'thinking') {
+      const content = stripAnsi(event.content).trim();
+      if (content) thinking = content;
+    }
+    if (event.kind === 'tool_start') {
+      activeTool = [event.name, stripAnsi(event.summary).trim()].filter(Boolean).join(' · ');
+    }
+    if (event.kind === 'tool_end') {
+      completedTools += 1;
+      if (typeof event.exitCode === 'number' && event.exitCode !== 0) {
+        failedTools += 1;
+      }
+      activeTool = null;
+    }
+    if (event.kind === 'error') {
+      errorCount += 1;
+    }
+  }
+
+  return { thinking, activeTool, completedTools, failedTools, errorCount };
+}
+
+function AnimatedThinkingWord({ className }: { className?: string }) {
+  return (
+    <span
+      role="status"
+      aria-label="Thinking"
+      className={cn('inline-flex font-medium text-[11px] tracking-wide uppercase', className)}
+    >
+      {THINKING_LETTERS.map(({ id, letter, delay }) => (
+        <span
+          key={id}
+          aria-hidden="true"
+          className="assistant-thinking-letter"
+          style={{ '--thinking-letter-index': delay } as CSSProperties}
+        >
+          {letter}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+function AgentActivityOverview({
+  events,
+  isRunning,
+}: {
+  events: TerminalEventRecord[];
+  isRunning: boolean;
+}) {
+  const activity = useMemo(() => latestActivity(events), [events]);
+  const hasActivity =
+    activity.thinking != null ||
+    activity.activeTool != null ||
+    activity.completedTools > 0 ||
+    activity.errorCount > 0;
+
+  if (!hasActivity) return null;
+
+  return (
+    <div className="rounded-md border border-border/70 bg-primary/50 px-3 py-2 text-[11px] text-secondary">
+      <div className="flex flex-wrap items-center gap-2">
+        <Badge variant={isRunning ? 'default' : 'done'} className="text-[10px]">
+          {isRunning ? 'Running' : 'Done'}
+        </Badge>
+        {activity.activeTool ? (
+          <span className="truncate text-primary">Tool: {activity.activeTool}</span>
+        ) : activity.completedTools > 0 ? (
+          <span>
+            Tools: {activity.completedTools}
+            {activity.failedTools > 0 ? ` (${activity.failedTools} failed)` : ''}
+          </span>
+        ) : null}
+        {activity.errorCount > 0 ? (
+          <span className="text-danger">Errors: {activity.errorCount}</span>
+        ) : null}
+      </div>
+      {activity.thinking ? (
+        <div className="mt-1 truncate text-muted-foreground">Thinking: {activity.thinking}</div>
+      ) : null}
+    </div>
+  );
+}
+
+export function AssistantTimeline({
+  threadId,
+  events,
+  userMessages,
+  isRunning,
+}: {
+  threadId: string | null;
+  events: TerminalEventRecord[];
+  userMessages: AssistantTimelineUserMessage[];
+  isRunning: boolean;
+}) {
+  const bottomRef = useRef<HTMLDivElement | null>(null);
+  const items = useMemo(() => {
+    if (!threadId) return [];
+    const userItems: ConversationItem[] = userMessages.flatMap((message) =>
+      message.threadId === threadId
+        ? [
+            {
+              id: message.id,
+              kind: 'user' as const,
+              content: message.content,
+              createdAt: message.createdAt,
+            },
+          ]
+        : [],
+    );
+    const eventItems = buildConversationItems(events);
+    return [...userItems, ...eventItems].sort((a, b) =>
+      a.createdAt === b.createdAt
+        ? a.id.localeCompare(b.id)
+        : a.createdAt.localeCompare(b.createdAt),
+    );
+  }, [events, threadId, userMessages]);
+
+  useEffect(() => {
+    if (typeof bottomRef.current?.scrollIntoView !== 'function') return;
+    bottomRef.current.scrollIntoView({ block: 'end' });
+  });
+
+  if (!threadId) return null;
+
+  if (items.length === 0) {
+    return (
+      <div className="flex min-h-0 flex-1 flex-col gap-3 p-5 text-sm text-secondary">
+        <AgentActivityOverview events={events} isRunning={isRunning} />
+        <div className="flex flex-1 items-center justify-center">
+          {isRunning ? <AnimatedThinkingWord /> : 'No assistant messages yet.'}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="min-h-0 flex-1 overflow-y-auto p-3">
+      <div className="mx-auto flex flex-col gap-3">
+        {items.map((item) => {
+          if (item.kind === 'user') {
+            return (
+              <div key={item.id} className="flex justify-end">
+                <div className="max-w-[78%] rounded-lg border border-agent/25 bg-agent/15 px-3.5 py-2.5 text-primary text-xs leading-5 shadow-sm">
+                  <div className="mb-1 text-[10px] text-agent">
+                    {formatClockTime(item.createdAt)}
+                  </div>
+                  <div className="whitespace-pre-wrap break-words">{item.content}</div>
+                </div>
+              </div>
+            );
+          }
+
+          if (item.kind === 'assistant') {
+            return (
+              <div key={item.id} className="flex justify-start">
+                <div className="max-w-[84%] rounded-lg border border-border bg-elevated px-3.5 py-2.5 text-primary text-xs leading-5 shadow-sm">
+                  <div className="mb-1 text-[10px] text-muted-foreground">
+                    {formatClockTime(item.createdAt)}
+                  </div>
+                  <div className="whitespace-pre-wrap break-words">{item.content}</div>
+                </div>
+              </div>
+            );
+          }
+
+          if (item.kind === 'thinking') {
+            const PREVIEW_LEN = 80;
+            const preview =
+              item.content.length > PREVIEW_LEN
+                ? `${item.content.slice(0, PREVIEW_LEN).trimEnd()}...`
+                : item.content;
+            return (
+              <div key={item.id} className="flex justify-start px-1">
+                <CollapsibleSection
+                  title={`Thinking: ${preview}`}
+                  count={formatClockTime(item.createdAt)}
+                  className="w-full max-w-[84%] border-border/40 bg-secondary/30 px-3 py-1.5"
+                  contentClassName="mt-2"
+                >
+                  <div className="mt-2 whitespace-pre-wrap break-words text-[11px] italic leading-5 text-secondary/80">
+                    {item.content}
+                  </div>
+                </CollapsibleSection>
+              </div>
+            );
+          }
+
+          if (item.kind === 'tool') {
+            const failed = typeof item.exitCode === 'number' && item.exitCode !== 0;
+            const durationLabel =
+              typeof item.durationMs === 'number'
+                ? `${(item.durationMs / 1000).toFixed(1)}s`
+                : null;
+
+            const oneLiner = (
+              <div key={`${item.id}:summary`} className="flex items-center gap-2 text-[11px]">
+                <span className="shrink-0 font-mono text-[10px] text-muted-foreground/60">
+                  {formatClockTime(item.createdAt)}
+                </span>
+                <span
+                  className={cn(
+                    'shrink-0 rounded px-1.5 py-0 text-[9px] font-bold uppercase tracking-wide',
+                    failed
+                      ? 'border border-danger/30 bg-danger/15 text-danger'
+                      : 'border border-border/50 bg-border/60 text-secondary',
+                  )}
+                >
+                  {item.name || 'tool'}
+                </span>
+                {item.summary ? (
+                  <span className="truncate text-muted-foreground">{item.summary}</span>
+                ) : null}
+                {durationLabel ? (
+                  <span className="shrink-0 font-mono text-[10px] text-muted-foreground/60">
+                    {durationLabel}
+                  </span>
+                ) : null}
+                {failed ? (
+                  <span className="shrink-0 text-[10px] text-danger">exit {item.exitCode}</span>
+                ) : null}
+              </div>
+            );
+
+            if (!failed || !item.outputSummary) {
+              return (
+                <div key={item.id} className="px-1">
+                  {oneLiner}
+                </div>
+              );
+            }
+
+            return (
+              <div key={item.id} className="px-1">
+                <CollapsibleSection
+                  title={[item.name || 'tool', item.summary].filter(Boolean).join(' - ')}
+                  count={[
+                    durationLabel,
+                    failed && typeof item.exitCode === 'number' ? `exit ${item.exitCode}` : null,
+                  ]
+                    .filter(Boolean)
+                    .join(' ')}
+                  className="border-danger/20 bg-danger/5 px-3 py-1.5"
+                  contentClassName="mt-2"
+                >
+                  {oneLiner}
+                  <pre className="mt-2 whitespace-pre-wrap break-words font-mono text-[10px] leading-4 text-danger">
+                    {item.outputSummary}
+                  </pre>
+                </CollapsibleSection>
+              </div>
+            );
+          }
+
+          if (item.kind === 'activity') {
+            return (
+              <div key={item.id} className="px-1">
+                <div className="flex items-start gap-2 text-[11px] text-secondary">
+                  <span className="shrink-0 font-mono text-[10px] text-muted-foreground/60">
+                    {formatClockTime(item.createdAt)}
+                  </span>
+                  <span className="break-words">{item.content}</span>
+                </div>
+              </div>
+            );
+          }
+
+          if (item.kind === 'error') {
+            return (
+              <div key={item.id} className="px-1">
+                <div className="flex items-start gap-2 rounded-md border border-danger/25 bg-danger/8 px-3 py-1.5 text-[11px]">
+                  <span className="shrink-0 font-mono text-[10px] text-muted-foreground/60">
+                    {formatClockTime(item.createdAt)}
+                  </span>
+                  <span className="font-medium text-danger">Error</span>
+                  <span className="break-words text-danger/80">{item.message}</span>
+                </div>
+              </div>
+            );
+          }
+
+          return null;
+        })}
+        <AgentActivityOverview events={events} isRunning={isRunning} />
+        {isRunning ? (
+          <div className="flex items-center justify-start px-1">
+            <AnimatedThinkingWord />
+          </div>
+        ) : null}
+        <div ref={bottomRef} className="h-px shrink-0" />
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/components/issue-detail/IssueChatTab.test.tsx
+++ b/apps/desktop/src/renderer/components/issue-detail/IssueChatTab.test.tsx
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+
+import '@testing-library/jest-dom/vitest';
+import type { TerminalEventRecord } from '@shipcode/shared';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAppStore } from '../../stores/app-store';
+import { IssueChatTab } from './IssueChatTab';
+
+const invokeMock = vi.fn<(channel: string, args?: unknown) => Promise<unknown>>();
+
+function renderWithClient() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, refetchOnWindowFocus: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <IssueChatTab threadId="thread-1" issueNumber={196} issueTitle="Add issue Chat tab" />
+    </QueryClientProvider>,
+  );
+}
+
+function makeTerminalEvent(overrides: Partial<TerminalEventRecord> = {}): TerminalEventRecord {
+  return {
+    id: 'event-1',
+    threadId: 'thread-1',
+    runId: null,
+    event: { kind: 'text', content: 'Agent response' },
+    createdAt: '2026-06-01T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('IssueChatTab', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    window.shipcode.invoke = invokeMock as unknown as typeof window.shipcode.invoke;
+    invokeMock.mockImplementation(async (channel: string) => {
+      if (channel === 'terminal:list') return [];
+      if (channel === 'issue-chat:start') {
+        return {
+          threadId: 'thread-1',
+          provider: 'claude',
+          modelId: null,
+          worktreePath: '/tmp/worktree',
+          reattached: false,
+          activeProcessId: null,
+        };
+      }
+      if (channel === 'issue-chat:turn') {
+        return {
+          threadId: 'thread-1',
+          promptId: 'prompt-1',
+          responseId: 'response-1',
+          round: 1,
+          exitCode: 0,
+          content: 'done',
+        };
+      }
+      if (channel === 'issue-chat:stop') return { threadId: 'thread-1', stopped: true };
+      return null;
+    });
+    useAppStore.setState({ canonicalTerminalStream: {} });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('starts the issue chat session on the first turn and reuses it for follow-ups', async () => {
+    renderWithClient();
+
+    expect(screen.getByText('Explain this issue.')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Ask the issue agent...'), {
+      target: { value: 'Draft a plan' },
+    });
+    fireEvent.click(screen.getByTitle('Send'));
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith('issue-chat:start', {
+        threadId: 'thread-1',
+        provider: 'claude',
+        reasoningEffort: 'medium',
+      });
+      expect(invokeMock).toHaveBeenCalledWith('issue-chat:turn', {
+        threadId: 'thread-1',
+        text: 'Draft a plan',
+      });
+    });
+    expect(await screen.findByText('Draft a plan')).toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText('Ask the issue agent...'), {
+      target: { value: 'Now list files' },
+    });
+    fireEvent.click(screen.getByTitle('Send'));
+
+    await waitFor(() => {
+      expect(
+        invokeMock.mock.calls.filter(([channel]) => channel === 'issue-chat:start'),
+      ).toHaveLength(1);
+      expect(invokeMock).toHaveBeenCalledWith('issue-chat:turn', {
+        threadId: 'thread-1',
+        text: 'Now list files',
+      });
+    });
+  });
+
+  it('renders only the active issue thread stream and stops a running turn', async () => {
+    useAppStore.setState({
+      canonicalTerminalStream: {
+        'thread-1': [
+          makeTerminalEvent({
+            id: 'thread-1-raw',
+            event: { kind: 'raw', content: 'active thread output' },
+          }),
+        ],
+        'thread-2': [
+          makeTerminalEvent({
+            id: 'thread-2-text',
+            threadId: 'thread-2',
+            event: { kind: 'text', content: 'other thread output' },
+          }),
+        ],
+      },
+    });
+
+    renderWithClient();
+
+    expect(screen.getByText('active thread output')).toBeInTheDocument();
+    expect(screen.queryByText('other thread output')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByTitle('Stop'));
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith('issue-chat:stop', { threadId: 'thread-1' });
+    });
+  });
+});

--- a/apps/desktop/src/renderer/components/issue-detail/IssueChatTab.tsx
+++ b/apps/desktop/src/renderer/components/issue-detail/IssueChatTab.tsx
@@ -1,0 +1,259 @@
+import type { TerminalEventRecord } from '@shipcode/shared';
+import {
+  Badge,
+  Button,
+  cn,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  Textarea,
+} from '@shipshitdev/ui';
+import { useQueryClient } from '@tanstack/react-query';
+import { Bot, Send, Square } from 'lucide-react';
+import { useCallback, useMemo, useState } from 'react';
+import { toast } from '../../stores/toast-store';
+import {
+  AssistantTimeline,
+  type AssistantTimelineUserMessage,
+  useAssistantTranscript,
+} from '../assistant/AssistantTimeline';
+
+type IssueChatProvider = 'claude' | 'codex';
+
+interface IssueChatTabProps {
+  threadId: string;
+  issueNumber: number;
+  issueTitle: string;
+}
+
+function isIssueChatTurnRunning({
+  events,
+  isSubmitting,
+}: {
+  events: TerminalEventRecord[];
+  isSubmitting: boolean;
+}) {
+  if (isSubmitting) return true;
+  const latestEvent = events[events.length - 1]?.event;
+  if (!latestEvent) return false;
+  if (latestEvent.kind === 'done') return false;
+  if (
+    latestEvent.kind === 'lifecycle' &&
+    (/exited with code/i.test(latestEvent.message) ||
+      /session stopped/i.test(latestEvent.message) ||
+      /process exited/i.test(latestEvent.message))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+function appendLocalUserMessage(
+  threadId: string,
+  content: string,
+  count: number,
+): AssistantTimelineUserMessage {
+  return {
+    id: `${threadId}:issue-chat:${Date.now()}:${count}`,
+    threadId,
+    content,
+    createdAt: new Date().toISOString(),
+  };
+}
+
+export function IssueChatTab({ threadId, issueNumber, issueTitle }: IssueChatTabProps) {
+  const queryClient = useQueryClient();
+  const transcript = useAssistantTranscript(threadId);
+  const [draft, setDraft] = useState('');
+  const [provider, setProvider] = useState<IssueChatProvider>('claude');
+  const [sessionStarted, setSessionStarted] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [userMessages, setUserMessages] = useState<AssistantTimelineUserMessage[]>([]);
+
+  const isRunning = useMemo(
+    () => isIssueChatTurnRunning({ events: transcript, isSubmitting }),
+    [isSubmitting, transcript],
+  );
+  const hasVisibleConversation = userMessages.length > 0 || transcript.length > 0;
+
+  const submitTurn = useCallback(
+    async (text: string) => {
+      const trimmed = text.trim();
+      if (!trimmed || isSubmitting || isRunning) return;
+      setIsSubmitting(true);
+      try {
+        if (!sessionStarted) {
+          await window.shipcode.invoke('issue-chat:start', {
+            threadId,
+            provider,
+            reasoningEffort: 'medium',
+          });
+          setSessionStarted(true);
+        }
+
+        setUserMessages((previous) => [
+          ...previous,
+          appendLocalUserMessage(threadId, trimmed, previous.length),
+        ]);
+        setDraft('');
+
+        await window.shipcode.invoke('issue-chat:turn', { threadId, text: trimmed });
+        await queryClient.invalidateQueries({
+          queryKey: ['agent-conversations', threadId],
+        });
+      } catch (error) {
+        toast.error('Issue chat failed', error instanceof Error ? error.message : undefined);
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [isRunning, isSubmitting, provider, queryClient, sessionStarted, threadId],
+  );
+
+  const handleSubmit = useCallback(() => {
+    void submitTurn(draft);
+  }, [draft, submitTurn]);
+
+  const handleStop = useCallback(async () => {
+    try {
+      await window.shipcode.invoke('issue-chat:stop', { threadId });
+      setSessionStarted(false);
+    } catch (error) {
+      toast.error('Issue chat stop failed', error instanceof Error ? error.message : undefined);
+    }
+  }, [threadId]);
+
+  const setSuggestedPrompt = useCallback((prompt: string) => {
+    setDraft(prompt);
+  }, []);
+
+  return (
+    <section className="flex min-h-[520px] flex-1 flex-col overflow-hidden rounded-md border border-border bg-primary">
+      <div className="flex min-h-11 shrink-0 items-center gap-2 border-b border-border px-3">
+        <div className="flex size-7 items-center justify-center rounded-md border border-border bg-secondary">
+          <Bot size={14} className="text-primary" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-xs font-semibold text-primary">Issue Chat</div>
+          <div className="truncate text-[10px] text-muted-foreground">
+            #{issueNumber} {issueTitle}
+          </div>
+        </div>
+        <Badge variant={isRunning ? 'default' : sessionStarted ? 'done' : 'info'}>
+          {isRunning ? 'Running' : sessionStarted ? 'Ready' : 'Idle'}
+        </Badge>
+      </div>
+
+      <div className="flex min-h-0 flex-1 flex-col">
+        {hasVisibleConversation ? (
+          <AssistantTimeline
+            threadId={threadId}
+            events={transcript}
+            userMessages={userMessages}
+            isRunning={isRunning}
+          />
+        ) : (
+          <div className="flex min-h-0 flex-1 flex-col justify-center gap-3 px-5 text-sm text-secondary">
+            <p className="text-primary">No chat yet.</p>
+            <div className="space-y-2 text-xs text-muted-foreground">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-auto w-full justify-start px-0 py-0 text-left text-xs font-normal text-muted-foreground hover:bg-transparent hover:text-primary"
+                onClick={() => setSuggestedPrompt(`Explain issue #${issueNumber}: ${issueTitle}`)}
+              >
+                Explain this issue.
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-auto w-full justify-start px-0 py-0 text-left text-xs font-normal text-muted-foreground hover:bg-transparent hover:text-primary"
+                onClick={() =>
+                  setSuggestedPrompt(`Draft an implementation approach for issue #${issueNumber}.`)
+                }
+              >
+                Draft an approach.
+              </Button>
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-auto w-full justify-start px-0 py-0 text-left text-xs font-normal text-muted-foreground hover:bg-transparent hover:text-primary"
+                onClick={() =>
+                  setSuggestedPrompt(`What files should change for issue #${issueNumber}?`)
+                }
+              >
+                What files would change?
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="shrink-0 border-t border-border bg-primary p-3">
+        <div className="flex w-full flex-col rounded-lg border border-border bg-elevated">
+          <Textarea
+            value={draft}
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && !event.shiftKey && !isRunning) {
+                event.preventDefault();
+                handleSubmit();
+              }
+            }}
+            placeholder="Ask the issue agent..."
+            className="min-h-[76px] resize-none border-0 bg-transparent text-xs shadow-none focus-visible:ring-0"
+          />
+          <div className="flex items-center gap-1 border-t border-border/50 px-2 py-1.5">
+            <Select
+              value={provider}
+              onValueChange={(next) => setProvider(next as IssueChatProvider)}
+              disabled={sessionStarted || isRunning}
+            >
+              <SelectTrigger
+                aria-label="Issue chat provider"
+                className="h-6 w-auto gap-1 rounded border-0 bg-transparent px-1.5 text-[10px] text-muted-foreground hover:text-primary"
+              >
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="claude">Claude</SelectItem>
+                <SelectItem value="codex">Codex</SelectItem>
+              </SelectContent>
+            </Select>
+            <div className="flex-1" />
+            {isRunning ? (
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                onClick={() => void handleStop()}
+                className="h-6 gap-1.5 text-[10px]"
+                title="Stop"
+              >
+                <Square size={10} />
+                Stop
+              </Button>
+            ) : (
+              <Button
+                type="button"
+                variant="default"
+                size="icon"
+                disabled={!draft.trim() || isSubmitting}
+                onClick={handleSubmit}
+                className={cn('h-6 w-6 rounded-full', isSubmitting && 'opacity-80')}
+                title="Send"
+              >
+                <Send size={12} />
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/desktop/src/renderer/components/issue-detail/IssueDetailTabs.test.tsx
+++ b/apps/desktop/src/renderer/components/issue-detail/IssueDetailTabs.test.tsx
@@ -1,0 +1,147 @@
+// @vitest-environment jsdom
+
+import '@testing-library/jest-dom/vitest';
+import type { GitHubIssueCacheRecord } from '@shipcode/shared';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { IssueDetailTabs } from './IssueDetailTabs';
+
+vi.mock('./CommentsTab', () => ({ CommentsTab: () => <div>comments tab</div> }));
+vi.mock('./ConsoleTab', () => ({ ConsoleTab: () => <div>console tab</div> }));
+vi.mock('./ConversationsTab', () => ({ ConversationsTab: () => <div>conversations tab</div> }));
+vi.mock('./DiffTab', () => ({ DiffTab: () => <div>diff tab</div> }));
+vi.mock('./FindingsTab', () => ({ FindingsTab: () => <div>findings tab</div> }));
+vi.mock('./IssueHistoryTab', () => ({ IssueHistoryTab: () => <div>activity tab</div> }));
+vi.mock('./IssueChatTab', () => ({
+  IssueChatTab: ({ threadId }: { threadId: string }) => <div>chat tab {threadId}</div>,
+}));
+vi.mock('./PlanHistoryTab', () => ({ PlanHistoryTab: () => <div>history tab</div> }));
+vi.mock('./PrdTab', () => ({ PrdTab: () => <div>issue tab</div> }));
+vi.mock('./RunsTab', () => ({ RunsTab: () => <div>runs tab</div> }));
+
+afterEach(() => {
+  cleanup();
+});
+
+function makeIssue(overrides: Partial<GitHubIssueCacheRecord> = {}): GitHubIssueCacheRecord {
+  return {
+    id: 'issue-196',
+    projectId: 'project-1',
+    issueNumber: 196,
+    title: 'Add issue Chat tab',
+    body: 'Issue body',
+    labels: ['enhancement'],
+    assignee: null,
+    state: 'open',
+    pipelineStatus: 'todo',
+    threadId: 'thread-1',
+    claimedAt: null,
+    claimedBy: null,
+    lastPhaseUpdate: null,
+    lastStatusLabel: null,
+    plannerModelOverride: null,
+    reviewerModelOverride: null,
+    executorModelOverride: null,
+    verifierModelOverride: null,
+    plannerModelIdOverride: null,
+    reviewerModelIdOverride: null,
+    executorModelIdOverride: null,
+    verifierModelIdOverride: null,
+    plannerReasoningEffortOverride: null,
+    reviewerReasoningEffortOverride: null,
+    executorReasoningEffortOverride: null,
+    verifierReasoningEffortOverride: null,
+    revisionCountOverride: null,
+    linkedPrNumber: null,
+    linkedPrUrl: null,
+    linkedPrIsDraft: false,
+    ciBlocked: false,
+    failingChecks: [],
+    unresolvedReviewComments: [],
+    unresolvedReviewCommentCount: 0,
+    prLastSyncAt: null,
+    fetchedAt: '2026-06-01T00:00:00.000Z',
+    priorityRank: null,
+    priorityRaw: null,
+    priorityFetchedAt: null,
+    isQuickMode: false,
+    ...overrides,
+  };
+}
+
+function renderTabs(activeThreadId: string | null = 'thread-1') {
+  return render(
+    <IssueDetailTabs
+      activeIssue={makeIssue({ threadId: activeThreadId })}
+      activeTab={activeThreadId ? 'chat' : 'prd'}
+      activeThreadId={activeThreadId}
+      approvedAwaitingExecution={false}
+      checkpoints={[]}
+      currentPhaseSelections={{} as never}
+      diffs={[]}
+      effectiveExpanded={null}
+      executorEditable={false}
+      hasPrFeedbackBlockers={false}
+      isRefreshingFromGithub={false}
+      isSubmitting={false}
+      isShowingAllPlanRuns={false}
+      effectiveRequireApproval={false}
+      effectiveRevisionCount={0}
+      inheritedRequireApproval={false}
+      inheritedRevisionCount={0}
+      loadingPlanDetailIds={[]}
+      normalizedIssueActivity={[]}
+      normalizedPlanHistory={[]}
+      reviewFindings={[]}
+      normalizedReviewsByPlanId={{}}
+      normalizedThreadPlanHistory={[]}
+      isPlanHistoryLoading={false}
+      currentPhaseReasoningEfforts={{} as never}
+      inheritedPhaseReasoningEfforts={{} as never}
+      phaseEffortSelectValues={{} as never}
+      phaseModelValidation={{}}
+      phaseSelectValues={{} as never}
+      requireApprovalSelectValue="false"
+      revisionCountSelectValue="0"
+      planHistoryCollapsed={false}
+      planRunCount={0}
+      planRunGroups={[]}
+      projectDefaultPhaseSelections={{} as never}
+      qaResults={[]}
+      runNumberByThreadId={{}}
+      taskGraph={null}
+      thread={null}
+      threadPhase="idle"
+      githubIssueUrl={null}
+      projectId="project-1"
+      onEditPrd={() => undefined}
+      onActiveTabChange={() => undefined}
+      onFullScreenPlan={() => undefined}
+      onPhaseAgentChange={() => undefined}
+      onPhaseEffortChange={() => undefined}
+      onRequireApprovalChange={() => undefined}
+      onRevisionCountChange={() => undefined}
+      onPhaseOpenRouterSlugBlur={() => undefined}
+      onPlanExpandedChange={() => undefined}
+      onPlanHistoryCollapsedChange={() => undefined}
+      onShowAllPlanRunsChange={() => undefined}
+      onRefreshFromGithub={() => undefined}
+      onRestoreCheckpoint={() => undefined}
+      onStabilizePr={() => undefined}
+    />,
+  );
+}
+
+describe('IssueDetailTabs', () => {
+  it('shows the issue Chat tab only when the issue has an active thread', () => {
+    const { unmount } = renderTabs('thread-1');
+
+    expect(screen.getByRole('tab', { name: 'Chat' })).toBeInTheDocument();
+    expect(screen.getByText('chat tab thread-1')).toBeInTheDocument();
+
+    unmount();
+    renderTabs(null);
+
+    expect(screen.queryByRole('tab', { name: 'Chat' })).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/renderer/components/issue-detail/IssueDetailTabs.tsx
+++ b/apps/desktop/src/renderer/components/issue-detail/IssueDetailTabs.tsx
@@ -19,6 +19,7 @@ import { ConsoleTab } from './ConsoleTab';
 import { ConversationsTab } from './ConversationsTab';
 import { DiffTab } from './DiffTab';
 import { FindingsTab } from './FindingsTab';
+import { IssueChatTab } from './IssueChatTab';
 import { IssueHistoryTab } from './IssueHistoryTab';
 import { PlanHistoryTab } from './PlanHistoryTab';
 import { PrdTab } from './PrdTab';
@@ -148,6 +149,7 @@ export function IssueDetailTabs(props: IssueDetailTabsProps) {
       label: `Activity${normalizedIssueActivity.length > 0 ? ` (${normalizedIssueActivity.length})` : ''}`,
     },
     ...(activeThreadId ? [{ value: 'conversations' as const, label: 'Conversations' }] : []),
+    ...(activeThreadId ? [{ value: 'chat' as const, label: 'Chat' }] : []),
   ];
 
   return (
@@ -242,6 +244,16 @@ export function IssueDetailTabs(props: IssueDetailTabsProps) {
       {activeThreadId && (
         <TabsContent value="conversations" className={'mt-0'}>
           <ConversationsTab threadId={activeThreadId} />
+        </TabsContent>
+      )}
+
+      {activeThreadId && (
+        <TabsContent value="chat" className="mt-0 overflow-hidden">
+          <IssueChatTab
+            threadId={activeThreadId}
+            issueNumber={activeIssue.issueNumber}
+            issueTitle={activeIssue.title}
+          />
         </TabsContent>
       )}
     </Tabs>

--- a/apps/desktop/src/renderer/components/issue-detail/tab-types.ts
+++ b/apps/desktop/src/renderer/components/issue-detail/tab-types.ts
@@ -10,7 +10,8 @@ export type IssueDetailTab =
   | 'diff'
   | 'runs'
   | 'activity'
-  | 'conversations';
+  | 'conversations'
+  | 'chat';
 
 export type PhaseSelection = {
   provider: ExecutorModel;


### PR DESCRIPTION
## Summary
- extract the AssistantPanel terminal timeline into a reusable renderer component
- add an Issue Detail Chat tab wired to real issue-chat:start, issue-chat:turn, and issue-chat:stop IPC handlers
- cover first-turn session start, follow-up reuse, thread filtering, stop behavior, and tab visibility

Closes #196

## Verification
- bun --filter @shipcode/desktop test -- src/renderer/components/AssistantPanel.test.tsx src/renderer/components/issue-detail/IssueChatTab.test.tsx src/renderer/components/issue-detail/IssueDetailTabs.test.tsx src/renderer/components/issue-detail/ConversationsTab.test.tsx
- bun --filter @shipcode/desktop typecheck
- bunx biome check apps/desktop/src/renderer/components/AssistantPanel.tsx apps/desktop/src/renderer/components/assistant/AssistantTimeline.tsx apps/desktop/src/renderer/components/issue-detail/IssueChatTab.tsx apps/desktop/src/renderer/components/issue-detail/IssueChatTab.test.tsx apps/desktop/src/renderer/components/issue-detail/IssueDetailTabs.tsx apps/desktop/src/renderer/components/issue-detail/IssueDetailTabs.test.tsx apps/desktop/src/renderer/components/issue-detail/tab-types.ts --files-ignore-unknown=true
