### PR TITLE
refactor provider output helpers

### DIFF
--- a/packages/agents/src/providers/cursor-cli-provider.ts
+++ b/packages/agents/src/providers/cursor-cli-provider.ts
@@ -1,5 +1,6 @@
 import type { ProcessManager } from '../process-manager';
 import { measurePromptPayload } from '../prompt-scope';
+import { clampProviderFailure, firstString, stripAnsi } from './output-summary';
 import type { AgentProvider, ProviderPhase, ProviderRequest, ProviderResponse } from './types';
 
 interface CursorCommand {
@@ -38,10 +39,6 @@ type ProcessManagerWithStdin = ProcessManager & {
     options?: Parameters<ProcessManager['spawn']>[5],
   ) => ReturnType<ProcessManager['spawn']>;
 };
-
-function stripAnsi(value: string): string {
-  return value.replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g'), '');
-}
 
 function buildCursorCommand(req: ProviderRequest): CursorCommand {
   // `-p` (print) makes cursor-agent non-interactive; the prompt is piped on
@@ -140,13 +137,6 @@ async function runCursorCli(
   });
 }
 
-function firstString(...values: unknown[]): string | null {
-  for (const value of values) {
-    if (typeof value === 'string' && value.trim()) return value.trim();
-  }
-  return null;
-}
-
 function extractFromResultObject(
   parsed: Record<string, unknown>,
 ): { text: string; resolvedModel?: string } | null {
@@ -200,16 +190,7 @@ function parseCursorOutput(rawOutput: string): { text: string; resolvedModel?: s
 }
 
 function clampCursorFailure(rawOutput: string, prompt: string): string {
-  const promptText = stripAnsi(prompt).trim();
-  const lines = stripAnsi(rawOutput)
-    .split('\n')
-    .map((entry) => entry.trim())
-    .filter(Boolean)
-    .filter((entry) => !promptText || (!promptText.includes(entry) && !entry.includes(promptText)));
-  const line =
-    lines.find((entry) => /\b(error|failed|unauthorized|auth|permission|denied)\b/i.test(entry)) ??
-    lines[0];
-  return (line ?? 'Cursor CLI failed').slice(0, 280);
+  return clampProviderFailure(rawOutput, prompt, 'Cursor CLI failed');
 }
 
 export function createCursorCliProvider(processManager: ProcessManager): AgentProvider {

--- a/packages/agents/src/providers/gemini-cli-provider.ts
+++ b/packages/agents/src/providers/gemini-cli-provider.ts
@@ -1,5 +1,6 @@
 import type { ProcessManager } from '../process-manager';
 import { measurePromptPayload } from '../prompt-scope';
+import { clampProviderFailure, firstString, stripAnsi } from './output-summary';
 import type { AgentProvider, ProviderPhase, ProviderRequest, ProviderResponse } from './types';
 
 interface GeminiCommand {
@@ -36,10 +37,6 @@ type ProcessManagerWithStdin = ProcessManager & {
     options?: Parameters<ProcessManager['spawn']>[5],
   ) => ReturnType<ProcessManager['spawn']>;
 };
-
-function stripAnsi(value: string): string {
-  return value.replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g'), '');
-}
 
 function buildGeminiCommand(req: ProviderRequest): GeminiCommand {
   const args = ['-p', '-', '--output-format', 'json'];
@@ -135,13 +132,6 @@ async function runGeminiCli(
   });
 }
 
-function firstString(...values: unknown[]): string | null {
-  for (const value of values) {
-    if (typeof value === 'string' && value.trim()) return value.trim();
-  }
-  return null;
-}
-
 function parseGeminiOutput(rawOutput: string): { text: string; resolvedModel?: string } {
   const cleaned = stripAnsi(rawOutput).trim();
   if (!cleaned) return { text: '' };
@@ -172,16 +162,7 @@ function parseGeminiOutput(rawOutput: string): { text: string; resolvedModel?: s
 }
 
 function clampGeminiFailure(rawOutput: string, prompt: string): string {
-  const promptText = stripAnsi(prompt).trim();
-  const lines = stripAnsi(rawOutput)
-    .split('\n')
-    .map((entry) => entry.trim())
-    .filter(Boolean)
-    .filter((entry) => !promptText || (!promptText.includes(entry) && !entry.includes(promptText)));
-  const line =
-    lines.find((entry) => /\b(error|failed|unauthorized|auth|permission|denied)\b/i.test(entry)) ??
-    lines[0];
-  return (line ?? 'Gemini CLI failed').slice(0, 280);
+  return clampProviderFailure(rawOutput, prompt, 'Gemini CLI failed');
 }
 
 export function createGeminiCliProvider(processManager: ProcessManager): AgentProvider {

--- a/packages/agents/src/providers/output-summary.ts
+++ b/packages/agents/src/providers/output-summary.ts
@@ -2,6 +2,30 @@ import { clampTextBlock, stripAnsi } from '@shipcode/shared';
 
 export { stripAnsi };
 
+const PROVIDER_FAILURE_PATTERN = /\b(error|failed|unauthorized|auth|permission|denied)\b/i;
+
+export function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === 'string' && value.trim()) return value.trim();
+  }
+  return null;
+}
+
+export function clampProviderFailure(
+  rawOutput: string,
+  prompt: string,
+  fallbackMessage: string,
+): string {
+  const promptText = stripAnsi(prompt).trim();
+  const lines = stripAnsi(rawOutput)
+    .split('\n')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .filter((entry) => !promptText || (!promptText.includes(entry) && !entry.includes(promptText)));
+  const line = lines.find((entry) => PROVIDER_FAILURE_PATTERN.test(entry)) ?? lines[0];
+  return (line ?? fallbackMessage).slice(0, 280);
+}
+
 export function summarizeTerminalText(
   raw: string | null | undefined,
   options: { maxLines?: number; maxChars?: number } = {},


### PR DESCRIPTION
## Summary
- Extract shared provider output helpers for first-string selection and failure-message clamping.
- Reuse the existing ANSI stripping path for Cursor and Gemini CLI provider parsing.
- Keep provider-specific command construction and JSON parsing behavior unchanged.

## Validation
- `bun --filter @shipcode/shared build`
- `bun --filter @shipcode/agents test -- src/providers/cursor-cli-provider.test.ts src/providers/gemini-cli-provider.test.ts`
- `bun --filter @shipcode/agents typecheck`
- `bunx biome check packages/agents/src/providers/output-summary.ts packages/agents/src/providers/gemini-cli-provider.ts packages/agents/src/providers/cursor-cli-provider.ts --files-ignore-unknown=true`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal utilities for output processing have been consolidated and reorganized across multiple CLI providers for improved code maintainability and reduced code duplication. Shared utility functions now handle text processing, whitespace normalization, and error message truncation consistently. All existing functionality and behavior remain unchanged with no user-visible impact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->