### PR TITLE
refactor: dedupe stdin cli providers

### DIFF
--- a/packages/agents/src/providers/cursor-cli-provider.ts
+++ b/packages/agents/src/providers/cursor-cli-provider.ts
@@ -1,16 +1,7 @@
 import type { ProcessManager } from '../process-manager';
 import { measurePromptPayload } from '../prompt-scope';
+import { clampCliFailure, runStdinCli, type StdinCliCommand, stripAnsi } from './stdin-cli-runner';
 import type { AgentProvider, ProviderPhase, ProviderRequest, ProviderResponse } from './types';
-
-interface CursorCommand {
-  args: string[];
-  stdin: string;
-}
-
-interface CursorRunResult {
-  rawOutput: string;
-  exitCode: number;
-}
 
 const CURSOR_ENV_KEYS = [
   'PATH',
@@ -27,23 +18,7 @@ const CURSOR_ENV_KEYS = [
   'CURSOR_API_KEY',
 ] as const;
 
-type ProcessManagerWithStdin = ProcessManager & {
-  spawnWithStdin?: (
-    type: 'cursor',
-    command: string,
-    args: string[],
-    cwd: string,
-    input: string,
-    threadId?: string,
-    options?: Parameters<ProcessManager['spawn']>[5],
-  ) => ReturnType<ProcessManager['spawn']>;
-};
-
-function stripAnsi(value: string): string {
-  return value.replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g'), '');
-}
-
-function buildCursorCommand(req: ProviderRequest): CursorCommand {
+function buildCursorCommand(req: ProviderRequest): StdinCliCommand {
   // `-p` (print) makes cursor-agent non-interactive; the prompt is piped on
   // stdin. `--output-format json` emits a single result object we can parse.
   const args = ['-p', '--output-format', 'json'];
@@ -55,89 +30,6 @@ function buildCursorCommand(req: ProviderRequest): CursorCommand {
   // receive auto-apply.
   if (req.phase === 'execute') args.push('--force');
   return { args, stdin: req.prompt };
-}
-
-async function runCursorCli(
-  processManager: ProcessManager,
-  command: CursorCommand,
-  req: ProviderRequest,
-): Promise<CursorRunResult> {
-  if (req.signal.aborted) return { rawOutput: '', exitCode: 130 };
-
-  let process: ReturnType<ProcessManager['spawn']>;
-  try {
-    const options = {
-      ...(req.workspaceRoot !== undefined ? { workspaceRoot: req.workspaceRoot } : {}),
-      envKeyAllowlist: [...CURSOR_ENV_KEYS],
-    };
-    const processManagerWithStdin = processManager as ProcessManagerWithStdin;
-    if (processManagerWithStdin.spawnWithStdin) {
-      process = processManagerWithStdin.spawnWithStdin(
-        'cursor',
-        'cursor-agent',
-        command.args,
-        req.cwd,
-        command.stdin,
-        req.threadId,
-        options,
-      );
-    } else {
-      return {
-        rawOutput: 'Cursor CLI stdin execution is unavailable',
-        exitCode: 1,
-      };
-    }
-  } catch (err) {
-    return { rawOutput: err instanceof Error ? err.message : String(err), exitCode: 127 };
-  }
-
-  req.onTerminalEvent?.({ kind: 'lifecycle', message: 'Cursor CLI started' });
-
-  return new Promise<CursorRunResult>((resolve) => {
-    let rawOutput = '';
-    let settled = false;
-
-    const cleanup = () => {
-      processManager.removeListener('output', outputHandler);
-      processManager.removeListener('exit', exitHandler);
-      req.signal.removeEventListener('abort', abortHandler);
-    };
-
-    const settle = (result: CursorRunResult) => {
-      /* v8 ignore next -- listeners are removed during cleanup; guard is for event races */
-      if (settled) return;
-      settled = true;
-      cleanup();
-      resolve(result);
-    };
-
-    const outputHandler = (processId: string, data: string) => {
-      if (processId !== process.id) return;
-      rawOutput += data;
-      req.onTerminalEvent?.({ kind: 'raw', content: data });
-    };
-
-    const exitHandler = (processId: string, exitCode: number) => {
-      if (processId !== process.id) return;
-      req.onTerminalEvent?.({ kind: 'done' });
-      settle({ rawOutput, exitCode });
-    };
-
-    const abortHandler = () => {
-      try {
-        processManager.kill(process.id);
-      } catch {
-        // Exit handler owns settlement when the process is already gone.
-      }
-      setTimeout(() => {
-        if (!settled) settle({ rawOutput, exitCode: 130 });
-      }, 2000);
-    };
-
-    processManager.on('output', outputHandler);
-    processManager.on('exit', exitHandler);
-    req.signal.addEventListener('abort', abortHandler, { once: true });
-  });
 }
 
 function firstString(...values: unknown[]): string | null {
@@ -200,16 +92,7 @@ function parseCursorOutput(rawOutput: string): { text: string; resolvedModel?: s
 }
 
 function clampCursorFailure(rawOutput: string, prompt: string): string {
-  const promptText = stripAnsi(prompt).trim();
-  const lines = stripAnsi(rawOutput)
-    .split('\n')
-    .map((entry) => entry.trim())
-    .filter(Boolean)
-    .filter((entry) => !promptText || (!promptText.includes(entry) && !entry.includes(promptText)));
-  const line =
-    lines.find((entry) => /\b(error|failed|unauthorized|auth|permission|denied)\b/i.test(entry)) ??
-    lines[0];
-  return (line ?? 'Cursor CLI failed').slice(0, 280);
+  return clampCliFailure(rawOutput, prompt, 'Cursor CLI failed');
 }
 
 export function createCursorCliProvider(processManager: ProcessManager): AgentProvider {
@@ -222,7 +105,14 @@ export function createCursorCliProvider(processManager: ProcessManager): AgentPr
     supports: new Set<ProviderPhase>(['execute']),
     async generate(req: ProviderRequest): Promise<ProviderResponse> {
       const command = buildCursorCommand(req);
-      const result = await runCursorCli(processManager, command, req);
+      const result = await runStdinCli(processManager, req, {
+        type: 'cursor',
+        command: 'cursor-agent',
+        commandInput: command,
+        envKeys: CURSOR_ENV_KEYS,
+        lifecycleMessage: 'Cursor CLI started',
+        unavailableMessage: 'Cursor CLI stdin execution is unavailable',
+      });
       const parsed = parseCursorOutput(result.rawOutput);
       const promptTelemetry = {
         phase: req.phase,

--- a/packages/agents/src/providers/gemini-cli-provider.ts
+++ b/packages/agents/src/providers/gemini-cli-provider.ts
@@ -1,16 +1,7 @@
 import type { ProcessManager } from '../process-manager';
 import { measurePromptPayload } from '../prompt-scope';
+import { clampCliFailure, runStdinCli, type StdinCliCommand, stripAnsi } from './stdin-cli-runner';
 import type { AgentProvider, ProviderPhase, ProviderRequest, ProviderResponse } from './types';
-
-interface GeminiCommand {
-  args: string[];
-  stdin: string;
-}
-
-interface GeminiRunResult {
-  rawOutput: string;
-  exitCode: number;
-}
 
 const GEMINI_ENV_KEYS = [
   'PATH',
@@ -25,23 +16,7 @@ const GEMINI_ENV_KEYS = [
   'XDG_RUNTIME_DIR',
 ] as const;
 
-type ProcessManagerWithStdin = ProcessManager & {
-  spawnWithStdin?: (
-    type: 'gemini',
-    command: string,
-    args: string[],
-    cwd: string,
-    input: string,
-    threadId?: string,
-    options?: Parameters<ProcessManager['spawn']>[5],
-  ) => ReturnType<ProcessManager['spawn']>;
-};
-
-function stripAnsi(value: string): string {
-  return value.replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g'), '');
-}
-
-function buildGeminiCommand(req: ProviderRequest): GeminiCommand {
+function buildGeminiCommand(req: ProviderRequest): StdinCliCommand {
   const args = ['-p', '-', '--output-format', 'json'];
   if (req.modelHint) args.push('-m', req.modelHint);
   if (req.phase !== 'execute') {
@@ -50,89 +25,6 @@ function buildGeminiCommand(req: ProviderRequest): GeminiCommand {
     args.push('--approval-mode', 'never', '--sandbox', 'workspace-write');
   }
   return { args, stdin: req.prompt };
-}
-
-async function runGeminiCli(
-  processManager: ProcessManager,
-  command: GeminiCommand,
-  req: ProviderRequest,
-): Promise<GeminiRunResult> {
-  if (req.signal.aborted) return { rawOutput: '', exitCode: 130 };
-
-  let process: ReturnType<ProcessManager['spawn']>;
-  try {
-    const options = {
-      ...(req.workspaceRoot !== undefined ? { workspaceRoot: req.workspaceRoot } : {}),
-      envKeyAllowlist: [...GEMINI_ENV_KEYS],
-    };
-    const processManagerWithStdin = processManager as ProcessManagerWithStdin;
-    if (processManagerWithStdin.spawnWithStdin) {
-      process = processManagerWithStdin.spawnWithStdin(
-        'gemini',
-        'gemini',
-        command.args,
-        req.cwd,
-        command.stdin,
-        req.threadId,
-        options,
-      );
-    } else {
-      return {
-        rawOutput: 'Gemini CLI stdin execution is unavailable',
-        exitCode: 1,
-      };
-    }
-  } catch (err) {
-    return { rawOutput: err instanceof Error ? err.message : String(err), exitCode: 127 };
-  }
-
-  req.onTerminalEvent?.({ kind: 'lifecycle', message: 'Gemini CLI started' });
-
-  return new Promise<GeminiRunResult>((resolve) => {
-    let rawOutput = '';
-    let settled = false;
-
-    const cleanup = () => {
-      processManager.removeListener('output', outputHandler);
-      processManager.removeListener('exit', exitHandler);
-      req.signal.removeEventListener('abort', abortHandler);
-    };
-
-    const settle = (result: GeminiRunResult) => {
-      /* v8 ignore next -- listeners are removed during cleanup; guard is for event races */
-      if (settled) return;
-      settled = true;
-      cleanup();
-      resolve(result);
-    };
-
-    const outputHandler = (processId: string, data: string) => {
-      if (processId !== process.id) return;
-      rawOutput += data;
-      req.onTerminalEvent?.({ kind: 'raw', content: data });
-    };
-
-    const exitHandler = (processId: string, exitCode: number) => {
-      if (processId !== process.id) return;
-      req.onTerminalEvent?.({ kind: 'done' });
-      settle({ rawOutput, exitCode });
-    };
-
-    const abortHandler = () => {
-      try {
-        processManager.kill(process.id);
-      } catch {
-        // Exit handler owns settlement when the process is already gone.
-      }
-      setTimeout(() => {
-        if (!settled) settle({ rawOutput, exitCode: 130 });
-      }, 2000);
-    };
-
-    processManager.on('output', outputHandler);
-    processManager.on('exit', exitHandler);
-    req.signal.addEventListener('abort', abortHandler, { once: true });
-  });
 }
 
 function firstString(...values: unknown[]): string | null {
@@ -172,16 +64,7 @@ function parseGeminiOutput(rawOutput: string): { text: string; resolvedModel?: s
 }
 
 function clampGeminiFailure(rawOutput: string, prompt: string): string {
-  const promptText = stripAnsi(prompt).trim();
-  const lines = stripAnsi(rawOutput)
-    .split('\n')
-    .map((entry) => entry.trim())
-    .filter(Boolean)
-    .filter((entry) => !promptText || (!promptText.includes(entry) && !entry.includes(promptText)));
-  const line =
-    lines.find((entry) => /\b(error|failed|unauthorized|auth|permission|denied)\b/i.test(entry)) ??
-    lines[0];
-  return (line ?? 'Gemini CLI failed').slice(0, 280);
+  return clampCliFailure(rawOutput, prompt, 'Gemini CLI failed');
 }
 
 export function createGeminiCliProvider(processManager: ProcessManager): AgentProvider {
@@ -190,7 +73,14 @@ export function createGeminiCliProvider(processManager: ProcessManager): AgentPr
     supports: new Set<ProviderPhase>(['plan', 'review', 'revision', 'verify', 'execute']),
     async generate(req: ProviderRequest): Promise<ProviderResponse> {
       const command = buildGeminiCommand(req);
-      const result = await runGeminiCli(processManager, command, req);
+      const result = await runStdinCli(processManager, req, {
+        type: 'gemini',
+        command: 'gemini',
+        commandInput: command,
+        envKeys: GEMINI_ENV_KEYS,
+        lifecycleMessage: 'Gemini CLI started',
+        unavailableMessage: 'Gemini CLI stdin execution is unavailable',
+      });
       const parsed = parseGeminiOutput(result.rawOutput);
       const promptTelemetry = {
         phase: req.phase,

--- a/packages/agents/src/providers/stdin-cli-runner.ts
+++ b/packages/agents/src/providers/stdin-cli-runner.ts
@@ -1,0 +1,128 @@
+import type { AgentType } from '@shipcode/shared';
+import type { ProcessManager } from '../process-manager';
+import type { ProviderRequest } from './types';
+
+export interface StdinCliCommand {
+  args: string[];
+  stdin: string;
+}
+
+export interface StdinCliRunResult {
+  rawOutput: string;
+  exitCode: number;
+}
+
+type ProcessManagerWithStdin = ProcessManager & {
+  spawnWithStdin?: (
+    type: AgentType,
+    command: string,
+    args: string[],
+    cwd: string,
+    input: string,
+    threadId?: string,
+    options?: Parameters<ProcessManager['spawn']>[5],
+  ) => ReturnType<ProcessManager['spawn']>;
+};
+
+export function stripAnsi(value: string): string {
+  return value.replace(new RegExp(`${String.fromCharCode(27)}\\[[0-9;]*m`, 'g'), '');
+}
+
+export async function runStdinCli(
+  processManager: ProcessManager,
+  req: ProviderRequest,
+  config: {
+    type: AgentType;
+    command: string;
+    commandInput: StdinCliCommand;
+    envKeys: readonly string[];
+    lifecycleMessage: string;
+    unavailableMessage: string;
+  },
+): Promise<StdinCliRunResult> {
+  if (req.signal.aborted) return { rawOutput: '', exitCode: 130 };
+
+  let process: ReturnType<ProcessManager['spawn']>;
+  try {
+    const options = {
+      ...(req.workspaceRoot !== undefined ? { workspaceRoot: req.workspaceRoot } : {}),
+      envKeyAllowlist: [...config.envKeys],
+    };
+    const processManagerWithStdin = processManager as ProcessManagerWithStdin;
+    if (!processManagerWithStdin.spawnWithStdin) {
+      return { rawOutput: config.unavailableMessage, exitCode: 1 };
+    }
+    process = processManagerWithStdin.spawnWithStdin(
+      config.type,
+      config.command,
+      config.commandInput.args,
+      req.cwd,
+      config.commandInput.stdin,
+      req.threadId,
+      options,
+    );
+  } catch (err) {
+    return { rawOutput: err instanceof Error ? err.message : String(err), exitCode: 127 };
+  }
+
+  req.onTerminalEvent?.({ kind: 'lifecycle', message: config.lifecycleMessage });
+
+  return new Promise<StdinCliRunResult>((resolve) => {
+    let rawOutput = '';
+    let settled = false;
+
+    const cleanup = () => {
+      processManager.removeListener('output', outputHandler);
+      processManager.removeListener('exit', exitHandler);
+      req.signal.removeEventListener('abort', abortHandler);
+    };
+
+    const settle = (result: StdinCliRunResult) => {
+      /* v8 ignore next -- listeners are removed during cleanup; guard is for event races */
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(result);
+    };
+
+    const outputHandler = (processId: string, data: string) => {
+      if (processId !== process.id) return;
+      rawOutput += data;
+      req.onTerminalEvent?.({ kind: 'raw', content: data });
+    };
+
+    const exitHandler = (processId: string, exitCode: number) => {
+      if (processId !== process.id) return;
+      req.onTerminalEvent?.({ kind: 'done' });
+      settle({ rawOutput, exitCode });
+    };
+
+    const abortHandler = () => {
+      try {
+        processManager.kill(process.id);
+      } catch {
+        // Exit handler owns settlement when the process is already gone.
+      }
+      setTimeout(() => {
+        if (!settled) settle({ rawOutput, exitCode: 130 });
+      }, 2000);
+    };
+
+    processManager.on('output', outputHandler);
+    processManager.on('exit', exitHandler);
+    req.signal.addEventListener('abort', abortHandler, { once: true });
+  });
+}
+
+export function clampCliFailure(rawOutput: string, prompt: string, fallback: string): string {
+  const promptText = stripAnsi(prompt).trim();
+  const lines = stripAnsi(rawOutput)
+    .split('\n')
+    .map((entry) => entry.trim())
+    .filter(Boolean)
+    .filter((entry) => !promptText || (!promptText.includes(entry) && !entry.includes(promptText)));
+  const line =
+    lines.find((entry) => /\b(error|failed|unauthorized|auth|permission|denied)\b/i.test(entry)) ??
+    lines[0];
+  return (line ?? fallback).slice(0, 280);
+}


### PR DESCRIPTION
## Summary
- Extract shared stdin CLI runner for Cursor and Gemini providers
- Keep provider-specific command construction, output parsing, and failure messages intact
- Reduce duplicated provider lifecycle code by 92 LOC net

## Verification
- bunx biome check packages/agents/src/providers/cursor-cli-provider.ts packages/agents/src/providers/gemini-cli-provider.ts packages/agents/src/providers/stdin-cli-runner.ts --files-ignore-unknown=true
- bun run --filter @shipcode/agents typecheck
- bun run --filter @shipcode/agents test -- src/providers/gemini-cli-provider.test.ts src/providers/cursor-cli-provider.test.ts

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated CLI command execution and error handling across Cursor and Gemini providers through a new shared stdin-based runner utility, reducing code duplication and improving consistency in failure reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->