### PR TITLE
feat(issue-chat): sync GitHub comments

### DIFF
--- a/apps/desktop/src/main/ipc/register-issue-chat-handlers.ts
+++ b/apps/desktop/src/main/ipc/register-issue-chat-handlers.ts
@@ -1,3 +1,4 @@
+import { startIssueChatCommentSync, stopIssueChatCommentSync } from '../issue-chat-comment-sync';
 import {
   sendIssueChatTurn,
   startIssueChatSession,
@@ -11,13 +12,23 @@ export function registerIssueChatHandlers({
   processManager,
   queries,
 }: IpcHandlerDeps): void {
-  ipcMain.handle('issue-chat:start', (_event, args) => startIssueChatSession({ args, queries }));
+  ipcMain.handle('issue-chat:start', async (_event, args) => {
+    const result = await startIssueChatSession({ args, queries });
+    startIssueChatCommentSync({
+      threadId: result.threadId,
+      queries,
+      processManager,
+      mainWindow,
+    });
+    return result;
+  });
 
   ipcMain.handle('issue-chat:turn', (_event, args) =>
     sendIssueChatTurn({ args, queries, processManager, mainWindow }),
   );
 
-  ipcMain.handle('issue-chat:stop', (_event, { threadId }: { threadId: string }) =>
-    stopIssueChatSession({ threadId, queries, processManager, mainWindow }),
-  );
+  ipcMain.handle('issue-chat:stop', (_event, { threadId }: { threadId: string }) => {
+    stopIssueChatCommentSync(threadId);
+    return stopIssueChatSession({ threadId, queries, processManager, mainWindow });
+  });
 }

--- a/apps/desktop/src/main/issue-chat-comment-sync.test.ts
+++ b/apps/desktop/src/main/issue-chat-comment-sync.test.ts
@@ -1,0 +1,172 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  listIssueComments: vi.fn(),
+  sendIssueChatTurn: vi.fn(),
+  isIssueChatSessionLive: vi.fn(() => true),
+  logError: vi.fn(),
+}));
+
+vi.mock('@shipcode/agents/source', () => ({
+  GhCli: vi.fn(function GhCli() {
+    return {
+      listIssueComments: mocks.listIssueComments,
+    };
+  }),
+}));
+
+vi.mock('./issue-chat-session', () => ({
+  isIssueChatSessionLive: mocks.isIssueChatSessionLive,
+  sendIssueChatTurn: mocks.sendIssueChatTurn,
+}));
+
+vi.mock('./logger.service', () => ({
+  default: {
+    error: mocks.logError,
+  },
+}));
+
+import {
+  buildGithubIssueChatTurn,
+  stopIssueChatCommentSync,
+  syncIssueChatCommentsOnce,
+} from './issue-chat-comment-sync';
+
+function makeComment(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 1,
+    author: 'octocat',
+    body: '/ask explain this issue',
+    createdAt: '2026-06-01T00:00:00.000Z',
+    url: 'https://github.test/comment/1',
+    ...overrides,
+  };
+}
+
+function makeHarness() {
+  return {
+    threadId: 'thread-1',
+    queries: {
+      threads: {
+        getById: vi.fn(() => ({
+          id: 'thread-1',
+          projectId: 'project-1',
+          githubIssueNumber: 42,
+        })),
+      },
+      projects: {
+        getById: vi.fn(() => ({
+          id: 'project-1',
+          path: '/tmp/shipcode',
+        })),
+      },
+    },
+    processManager: {},
+    mainWindow: {},
+  };
+}
+
+describe('issue chat comment sync', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.isIssueChatSessionLive.mockReturnValue(true);
+    mocks.sendIssueChatTurn.mockResolvedValue({
+      threadId: 'thread-1',
+      promptId: 'prompt-1',
+      responseId: 'response-1',
+      round: 1,
+      exitCode: 0,
+      content: 'ok',
+    });
+    stopIssueChatCommentSync('thread-1');
+  });
+
+  afterEach(() => {
+    stopIssueChatCommentSync('thread-1');
+  });
+
+  it('extracts opt-in GitHub comment markers into untrusted chat turns', () => {
+    expect(buildGithubIssueChatTurn(makeComment({ body: 'plain comment' }))).toBeNull();
+    expect(buildGithubIssueChatTurn(makeComment({ body: '/ask' }))).toBeNull();
+    expect(buildGithubIssueChatTurn(makeComment({ body: '@shipcode draft a plan' }))).toEqual({
+      speaker: 'github:octocat',
+      text: 'GitHub issue comment from @octocat (untrusted user input):\n\ndraft a plan',
+    });
+  });
+
+  it('baselines existing comments and dispatches only new marker comments once', async () => {
+    const h = makeHarness();
+    mocks.listIssueComments
+      .mockResolvedValueOnce([
+        makeComment({ id: 1, body: '/ask old prompt', createdAt: '2026-06-01T00:00:00.000Z' }),
+        makeComment({ id: 2, body: 'plain old', createdAt: '2026-06-01T00:01:00.000Z' }),
+      ])
+      .mockResolvedValueOnce([
+        makeComment({ id: 1, body: '/ask old prompt', createdAt: '2026-06-01T00:00:00.000Z' }),
+        makeComment({ id: 2, body: 'plain old', createdAt: '2026-06-01T00:01:00.000Z' }),
+        makeComment({ id: 3, body: 'plain new', createdAt: '2026-06-01T00:02:00.000Z' }),
+        makeComment({ id: 4, body: '/ask new prompt', createdAt: '2026-06-01T00:03:00.000Z' }),
+      ]);
+
+    await expect(syncIssueChatCommentsOnce({ ...h, baselineOnly: true } as never)).resolves.toEqual(
+      {
+        checked: 2,
+        dispatched: 0,
+        ignored: 2,
+        lastSeenCommentId: 2,
+      },
+    );
+    expect(mocks.sendIssueChatTurn).not.toHaveBeenCalled();
+
+    await expect(syncIssueChatCommentsOnce(h as never)).resolves.toEqual({
+      checked: 4,
+      dispatched: 1,
+      ignored: 1,
+      lastSeenCommentId: 4,
+    });
+    expect(mocks.sendIssueChatTurn).toHaveBeenCalledWith({
+      args: {
+        threadId: 'thread-1',
+        speaker: 'github:octocat',
+        text: 'GitHub issue comment from @octocat (untrusted user input):\n\nnew prompt',
+      },
+      queries: h.queries,
+      processManager: h.processManager,
+      mainWindow: h.mainWindow,
+    });
+  });
+
+  it('does not advance the marker cursor when dispatch fails', async () => {
+    const h = makeHarness();
+    mocks.sendIssueChatTurn.mockRejectedValueOnce(new Error('turn already running'));
+    mocks.listIssueComments
+      .mockResolvedValueOnce([
+        makeComment({ id: 1, body: 'old', createdAt: '2026-06-01T00:00:00.000Z' }),
+      ])
+      .mockResolvedValueOnce([
+        makeComment({ id: 1, body: 'old', createdAt: '2026-06-01T00:00:00.000Z' }),
+        makeComment({ id: 2, body: '/ask retry me', createdAt: '2026-06-01T00:01:00.000Z' }),
+      ]);
+
+    await syncIssueChatCommentsOnce({ ...h, baselineOnly: true } as never);
+    await expect(syncIssueChatCommentsOnce(h as never)).resolves.toMatchObject({
+      dispatched: 0,
+      lastSeenCommentId: 1,
+    });
+    expect(mocks.logError).toHaveBeenCalledWith(
+      expect.stringContaining('failed to dispatch comment 2'),
+    );
+  });
+
+  it('stops without polling when the chat session is no longer live', async () => {
+    mocks.isIssueChatSessionLive.mockReturnValue(false);
+
+    await expect(syncIssueChatCommentsOnce(makeHarness() as never)).resolves.toEqual({
+      checked: 0,
+      dispatched: 0,
+      ignored: 0,
+      lastSeenCommentId: null,
+    });
+    expect(mocks.listIssueComments).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/main/issue-chat-comment-sync.ts
+++ b/apps/desktop/src/main/issue-chat-comment-sync.ts
@@ -1,0 +1,200 @@
+import { GhCli } from '@shipcode/agents/source';
+import { clampError, GITHUB_POLL_INTERVAL_MS, type GitHubIssueComment } from '@shipcode/shared';
+import type { BrowserWindow } from 'electron';
+import type { IpcHandlerDeps, Queries } from './ipc/types';
+import { isIssueChatSessionLive, sendIssueChatTurn } from './issue-chat-session';
+import log from './logger.service';
+
+interface IssueChatCommentSyncState {
+  threadId: string;
+  lastSeenCommentId: number | null;
+  timer: ReturnType<typeof setInterval> | null;
+  isPolling: boolean;
+}
+
+interface IssueChatCommentSyncDeps {
+  threadId: string;
+  queries: Queries;
+  processManager: IpcHandlerDeps['processManager'];
+  mainWindow: BrowserWindow;
+}
+
+interface IssueChatCommentSyncResult {
+  checked: number;
+  dispatched: number;
+  ignored: number;
+  lastSeenCommentId: number | null;
+}
+
+interface GithubCommentTurn {
+  speaker: string;
+  text: string;
+}
+
+const syncStates = new Map<string, IssueChatCommentSyncState>();
+
+function sortComments(comments: GitHubIssueComment[]): GitHubIssueComment[] {
+  return [...comments].sort((a, b) => {
+    const byCreatedAt = Date.parse(a.createdAt) - Date.parse(b.createdAt);
+    return byCreatedAt === 0 ? a.id - b.id : byCreatedAt;
+  });
+}
+
+function latestCommentId(comments: GitHubIssueComment[]): number | null {
+  return sortComments(comments).at(-1)?.id ?? null;
+}
+
+function stripMarker(body: string): string | null {
+  const trimmed = body.trimStart();
+  if (trimmed.toLowerCase().startsWith('/ask')) {
+    return trimmed.slice('/ask'.length).trim();
+  }
+  if (trimmed.toLowerCase().startsWith('@shipcode')) {
+    return trimmed.slice('@shipcode'.length).trim();
+  }
+  return null;
+}
+
+export function buildGithubIssueChatTurn(comment: GitHubIssueComment): GithubCommentTurn | null {
+  const body = stripMarker(comment.body);
+  if (!body) return null;
+  const author = comment.author?.trim() || 'unknown';
+  return {
+    speaker: `github:${author}`.slice(0, 80),
+    text: `GitHub issue comment from @${author} (untrusted user input):\n\n${body}`,
+  };
+}
+
+async function listCommentsForThread(
+  queries: Queries,
+  threadId: string,
+): Promise<GitHubIssueComment[]> {
+  const thread = queries.threads.getById(threadId);
+  if (!thread) throw new Error(`Thread not found: ${threadId}`);
+  if (thread.githubIssueNumber == null) {
+    throw new Error(`Thread ${threadId} is not linked to a GitHub issue`);
+  }
+  const project = queries.projects.getById(thread.projectId);
+  if (!project) throw new Error(`Project not found: ${thread.projectId}`);
+  const gh = new GhCli(project.path);
+  return gh.listIssueComments(thread.githubIssueNumber);
+}
+
+export async function syncIssueChatCommentsOnce({
+  threadId,
+  queries,
+  processManager,
+  mainWindow,
+  baselineOnly = false,
+}: IssueChatCommentSyncDeps & { baselineOnly?: boolean }): Promise<IssueChatCommentSyncResult> {
+  if (!isIssueChatSessionLive(threadId)) {
+    stopIssueChatCommentSync(threadId);
+    return { checked: 0, dispatched: 0, ignored: 0, lastSeenCommentId: null };
+  }
+
+  const state =
+    syncStates.get(threadId) ??
+    ({
+      threadId,
+      lastSeenCommentId: null,
+      timer: null,
+      isPolling: false,
+    } satisfies IssueChatCommentSyncState);
+  syncStates.set(threadId, state);
+
+  if (state.isPolling) {
+    return {
+      checked: 0,
+      dispatched: 0,
+      ignored: 0,
+      lastSeenCommentId: state.lastSeenCommentId,
+    };
+  }
+
+  state.isPolling = true;
+  try {
+    const comments = sortComments(await listCommentsForThread(queries, threadId));
+    if (baselineOnly || state.lastSeenCommentId == null) {
+      state.lastSeenCommentId = latestCommentId(comments);
+      return {
+        checked: comments.length,
+        dispatched: 0,
+        ignored: comments.length,
+        lastSeenCommentId: state.lastSeenCommentId,
+      };
+    }
+
+    let dispatched = 0;
+    let ignored = 0;
+    for (const comment of comments) {
+      if (comment.id <= state.lastSeenCommentId) continue;
+      const turn = buildGithubIssueChatTurn(comment);
+      if (!turn) {
+        state.lastSeenCommentId = comment.id;
+        ignored++;
+        continue;
+      }
+
+      try {
+        await sendIssueChatTurn({
+          args: { threadId, text: turn.text, speaker: turn.speaker },
+          queries,
+          processManager,
+          mainWindow,
+        });
+        state.lastSeenCommentId = comment.id;
+        dispatched++;
+      } catch (error) {
+        log.error(
+          `[issue-chat-sync] failed to dispatch comment ${comment.id} for ${threadId}: ${clampError(error)}`,
+        );
+        break;
+      }
+    }
+
+    return {
+      checked: comments.length,
+      dispatched,
+      ignored,
+      lastSeenCommentId: state.lastSeenCommentId,
+    };
+  } finally {
+    state.isPolling = false;
+  }
+}
+
+export function startIssueChatCommentSync(deps: IssueChatCommentSyncDeps): void {
+  const existing = syncStates.get(deps.threadId);
+  if (existing?.timer) return;
+
+  const settings = deps.queries.settings.get();
+  const intervalMs =
+    Number.isFinite(settings.githubPollingIntervalMs) && settings.githubPollingIntervalMs >= 5_000
+      ? settings.githubPollingIntervalMs
+      : GITHUB_POLL_INTERVAL_MS;
+  const state: IssueChatCommentSyncState = {
+    threadId: deps.threadId,
+    lastSeenCommentId: existing?.lastSeenCommentId ?? null,
+    timer: null,
+    isPolling: false,
+  };
+  syncStates.set(deps.threadId, state);
+
+  void syncIssueChatCommentsOnce({ ...deps, baselineOnly: true }).catch((error) => {
+    log.error(`[issue-chat-sync] baseline failed for ${deps.threadId}: ${clampError(error)}`);
+  });
+
+  state.timer = setInterval(() => {
+    void syncIssueChatCommentsOnce(deps).catch((error) => {
+      log.error(`[issue-chat-sync] poll failed for ${deps.threadId}: ${clampError(error)}`);
+    });
+  }, intervalMs);
+}
+
+export function stopIssueChatCommentSync(threadId: string): boolean {
+  const state = syncStates.get(threadId);
+  if (!state) return false;
+  if (state.timer) clearInterval(state.timer);
+  syncStates.delete(threadId);
+  return true;
+}

--- a/apps/desktop/src/main/issue-chat-session.test.ts
+++ b/apps/desktop/src/main/issue-chat-session.test.ts
@@ -195,6 +195,41 @@ describe('issue chat session', () => {
     );
   });
 
+  it('persists a GitHub-sourced prompt speaker for synced issue comments', async () => {
+    const h = makeHarness();
+    await startIssueChatSession({
+      args: { threadId: 'thread-1', provider: 'claude' },
+      queries: h.queries as never,
+    });
+
+    const resultPromise = sendIssueChatTurn({
+      args: {
+        threadId: 'thread-1',
+        text: 'GitHub issue comment from @octocat (untrusted user input):\n\nExplain this',
+        speaker: 'github:octocat',
+      },
+      queries: h.queries as never,
+      processManager: h.processManager as never,
+      mainWindow: h.mainWindow as never,
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    h.processManager.emit(
+      'output',
+      'proc-1',
+      `${JSON.stringify({ type: 'result', result: 'Explained.' })}\n`,
+    );
+    h.processManager.emit('exit', 'proc-1', 0);
+
+    await expect(resultPromise).resolves.toMatchObject({ content: 'Explained.' });
+    expect(h.conversations.at(0)).toMatchObject({
+      phase: 'issue_chat',
+      speaker: 'github:octocat',
+      role: 'prompt',
+      content: 'GitHub issue comment from @octocat (untrusted user input):\n\nExplain this',
+    });
+  });
+
   it('persists a synthetic error response when a turn exits non-zero', async () => {
     const h = makeHarness();
     await startIssueChatSession({

--- a/apps/desktop/src/main/issue-chat-session.ts
+++ b/apps/desktop/src/main/issue-chat-session.ts
@@ -35,6 +35,7 @@ export interface StartIssueChatResult {
 export interface SendIssueChatTurnArgs {
   threadId: string;
   text: string;
+  speaker?: string;
 }
 
 export interface SendIssueChatTurnResult {
@@ -72,6 +73,11 @@ function providerLabel(provider: IssueChatProvider): 'claude-cli' | 'codex-cli' 
 function ensureIssueChatProvider(provider: string): IssueChatProvider {
   if (provider === 'claude' || provider === 'codex') return provider;
   throw new Error(`Issue chat provider must be claude or codex, got ${provider}`);
+}
+
+function normalizeSpeaker(input: string | undefined): string {
+  const trimmed = input?.trim();
+  return trimmed ? trimmed.slice(0, 80) : 'user';
 }
 
 function buildClaudeThinkingArgs(
@@ -325,7 +331,7 @@ export async function sendIssueChatTurn({
     threadId: args.threadId,
     phase: ISSUE_CHAT_PHASE,
     round,
-    speaker: 'user',
+    speaker: normalizeSpeaker(args.speaker),
     role: 'prompt',
     provider: providerLabel(session.provider),
     model: session.modelId,
@@ -477,4 +483,8 @@ export function stopIssueChatSessionIfLive(
   if (session.activeProcessId) processManager.kill(session.activeProcessId);
   sessions.delete(threadId);
   return true;
+}
+
+export function isIssueChatSessionLive(threadId: string): boolean {
+  return sessions.has(threadId);
 }

--- a/apps/desktop/src/renderer/components/issue-detail/ConversationsTab.test.tsx
+++ b/apps/desktop/src/renderer/components/issue-detail/ConversationsTab.test.tsx
@@ -16,7 +16,7 @@ function renderWithClient(threadId = 'thread-1') {
 
   return render(
     <QueryClientProvider client={queryClient}>
-      <ConversationsTab threadId={threadId} />
+      <ConversationsTab threadId={threadId} projectId="project-1" issueNumber={42} />
     </QueryClientProvider>,
   );
 }
@@ -49,6 +49,7 @@ describe('ConversationsTab', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     window.shipcode.invoke = invokeMock as unknown as typeof window.shipcode.invoke;
+    window.confirm = vi.fn(() => true);
     Object.defineProperty(navigator, 'clipboard', {
       configurable: true,
       value: {
@@ -149,5 +150,36 @@ describe('ConversationsTab', () => {
     });
     vi.advanceTimersByTime(1500);
     vi.useRealTimers();
+  });
+
+  it('posts issue chat response turns to GitHub after confirmation', async () => {
+    invokeMock.mockImplementation(async (channel: string) => {
+      if (channel === 'agent-conversations:list-by-thread') {
+        return [
+          makeConversation({
+            id: 'chat-response-1',
+            phase: 'issue_chat',
+            speaker: 'claude',
+            role: 'response',
+            content: 'Here is the answer.',
+          }),
+        ];
+      }
+      if (channel === 'github:add-comment') return { ok: true };
+      return null;
+    });
+
+    renderWithClient();
+
+    fireEvent.click(await screen.findByRole('button', { name: /Post/i }));
+
+    await waitFor(() => {
+      expect(window.confirm).toHaveBeenCalledWith('Post this issue chat reply to GitHub?');
+      expect(invokeMock).toHaveBeenCalledWith('github:add-comment', {
+        projectId: 'project-1',
+        issueNumber: 42,
+        body: '### ShipCode issue chat reply\n\nHere is the answer.',
+      });
+    });
   });
 });

--- a/apps/desktop/src/renderer/components/issue-detail/ConversationsTab.tsx
+++ b/apps/desktop/src/renderer/components/issue-detail/ConversationsTab.tsx
@@ -1,7 +1,8 @@
 import type { AgentConversationRecord } from '@shipcode/shared';
 import { Badge, Button, Skeleton } from '@shipshitdev/ui';
-import { useQuery } from '@tanstack/react-query';
-import { CheckIcon, CopyIcon } from 'lucide-react';
+import { LoadingButtonContent } from '@shipshitdev/ui/common';
+import { useMutation, useQuery } from '@tanstack/react-query';
+import { CheckIcon, CopyIcon, MessageSquarePlusIcon } from 'lucide-react';
 import { useCallback, useMemo, useState } from 'react';
 
 const PHASE_COLORS: Record<string, string> = {
@@ -10,6 +11,7 @@ const PHASE_COLORS: Record<string, string> = {
   revision: 'bg-purple-500/15 text-purple-400',
   execute: 'bg-green-500/15 text-green-400',
   verify: 'bg-cyan-500/15 text-cyan-400',
+  issue_chat: 'bg-sky-500/15 text-sky-400',
 };
 
 const SPEAKER_COLORS: Record<string, string> = {
@@ -19,17 +21,20 @@ const SPEAKER_COLORS: Record<string, string> = {
   openrouter: 'bg-violet-500/15 text-violet-400',
 };
 
-const ALL_PHASES = ['plan', 'review', 'revision', 'execute', 'verify'] as const;
+const ALL_PHASES = ['plan', 'review', 'revision', 'execute', 'verify', 'issue_chat'] as const;
 const COLLAPSE_LINE_THRESHOLD = 30;
 
 interface ConversationsTabProps {
   threadId: string;
+  projectId: string;
+  issueNumber: number;
 }
 
-export function ConversationsTab({ threadId }: ConversationsTabProps) {
+export function ConversationsTab({ threadId, projectId, issueNumber }: ConversationsTabProps) {
   const [selectedPhases, setSelectedPhases] = useState<Set<string>>(new Set(ALL_PHASES));
   const [expandedTurns, setExpandedTurns] = useState<Set<string>>(new Set());
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  const [postedId, setPostedId] = useState<string | null>(null);
 
   const { data: conversations = [], isLoading } = useQuery<AgentConversationRecord[]>({
     queryKey: ['agent-conversations', threadId],
@@ -92,6 +97,28 @@ export function ConversationsTab({ threadId }: ConversationsTabProps) {
     setTimeout(() => setCopiedId(null), 1500);
   }, [filtered]);
 
+  const postTurn = useMutation({
+    mutationFn: (conv: AgentConversationRecord) =>
+      window.shipcode.invoke('github:add-comment', {
+        projectId,
+        issueNumber,
+        body: `### ShipCode issue chat reply\n\n${conv.content}`,
+      }),
+    onSuccess: (_result, conv) => {
+      setPostedId(conv.id);
+      setTimeout(() => setPostedId(null), 1500);
+    },
+  });
+
+  const confirmAndPostTurn = useCallback(
+    (conv: AgentConversationRecord) => {
+      const confirmed = window.confirm('Post this issue chat reply to GitHub?');
+      if (!confirmed) return;
+      postTurn.mutate(conv);
+    },
+    [postTurn],
+  );
+
   if (isLoading) {
     return (
       <div className="space-y-3 p-1">
@@ -153,6 +180,13 @@ export function ConversationsTab({ threadId }: ConversationsTabProps) {
               isCopied={copiedId === conv.id}
               onToggleExpand={() => toggleExpand(conv.id)}
               onCopy={() => copyTurn(conv)}
+              onPostToGithub={
+                conv.phase === 'issue_chat' && conv.role === 'response'
+                  ? () => confirmAndPostTurn(conv)
+                  : undefined
+              }
+              isPostingToGithub={postTurn.isPending && postTurn.variables?.id === conv.id}
+              isPostedToGithub={postedId === conv.id}
             />
           ))}
         </div>
@@ -167,12 +201,18 @@ function ConversationTurn({
   isCopied,
   onToggleExpand,
   onCopy,
+  onPostToGithub,
+  isPostingToGithub,
+  isPostedToGithub,
 }: {
   conv: AgentConversationRecord;
   isExpanded: boolean;
   isCopied: boolean;
   onToggleExpand: () => void;
   onCopy: () => void;
+  onPostToGithub?: () => void;
+  isPostingToGithub?: boolean;
+  isPostedToGithub?: boolean;
 }) {
   const lines = conv.content.split('\n');
   const isLong = lines.length > COLLAPSE_LINE_THRESHOLD;
@@ -185,7 +225,7 @@ function ConversationTurn({
     SPEAKER_COLORS[conv.speaker] ??
     SPEAKER_COLORS[conv.provider ?? ''] ??
     'bg-zinc-500/15 text-zinc-400';
-  const phaseColor = PHASE_COLORS[conv.phase];
+  const phaseColor = PHASE_COLORS[conv.phase] ?? 'bg-zinc-500/15 text-zinc-400';
 
   return (
     <div className="border-border/50 rounded-lg border p-3 space-y-2">
@@ -205,6 +245,21 @@ function ConversationTurn({
           )}
           {conv.costUsd != null && conv.costUsd > 0 && (
             <span className="text-muted-foreground text-[10px]">${conv.costUsd.toFixed(4)}</span>
+          )}
+          {onPostToGithub && (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onPostToGithub}
+              disabled={isPostingToGithub}
+              className="h-6 gap-1 px-1.5 text-[10px] text-muted-foreground hover:text-foreground"
+            >
+              <MessageSquarePlusIcon className="size-3" />
+              <LoadingButtonContent loading={!!isPostingToGithub}>
+                {isPostedToGithub ? 'Posted' : 'Post'}
+              </LoadingButtonContent>
+            </Button>
           )}
           <Button
             type="button"

--- a/apps/desktop/src/renderer/components/issue-detail/IssueDetailTabs.tsx
+++ b/apps/desktop/src/renderer/components/issue-detail/IssueDetailTabs.tsx
@@ -243,7 +243,11 @@ export function IssueDetailTabs(props: IssueDetailTabsProps) {
 
       {activeThreadId && (
         <TabsContent value="conversations" className={'mt-0'}>
-          <ConversationsTab threadId={activeThreadId} />
+          <ConversationsTab
+            threadId={activeThreadId}
+            projectId={projectId}
+            issueNumber={activeIssue.issueNumber}
+          />
         </TabsContent>
       )}
 


### PR DESCRIPTION
Closes https://github.com/shipshitdev/shipcode/issues/197.

## Summary
- poll live issue-chat sessions for new GitHub comments gated by `/ask` or `@shipcode`
- persist GitHub-sourced turns with `github:<author>` speakers and untrusted-input framing
- add an explicit Conversations tab action to post issue-chat agent responses back to GitHub comments

## Verification
- bunx turbo run build --filter=@shipcode/shared --filter=@shipcode/git --filter=@shipcode/agents --filter=@shipcode/db --filter=@shipcode/ui
- bunx turbo run build --filter=@shipcode/pipeline
- bun --cwd apps/desktop test src/main/issue-chat-comment-sync.test.ts src/main/issue-chat-session.test.ts src/renderer/components/issue-detail/ConversationsTab.test.tsx
- bun --cwd apps/desktop typecheck
- bunx biome check apps/desktop/src/main/issue-chat-comment-sync.ts apps/desktop/src/main/issue-chat-comment-sync.test.ts apps/desktop/src/main/issue-chat-session.ts apps/desktop/src/main/issue-chat-session.test.ts apps/desktop/src/main/ipc/register-issue-chat-handlers.ts apps/desktop/src/renderer/components/issue-detail/ConversationsTab.tsx apps/desktop/src/renderer/components/issue-detail/ConversationsTab.test.tsx apps/desktop/src/renderer/components/issue-detail/IssueDetailTabs.tsx --files-ignore-unknown=true
- git diff --check