### PR TITLE
feat(pipeline): add mid-execution steering

### DIFF
--- a/apps/desktop/src/main/ipc/register-pipeline-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/register-pipeline-handlers.test.ts
@@ -232,6 +232,11 @@ describe('registerPipelineHandlers', () => {
   let emitter: {
     emit: ReturnType<typeof vi.fn>;
   };
+  let processManager: {
+    get: ReturnType<typeof vi.fn>;
+    listActive: ReturnType<typeof vi.fn>;
+    write: ReturnType<typeof vi.fn>;
+  };
 
   beforeEach(() => {
     handlers.clear();
@@ -402,6 +407,11 @@ describe('registerPipelineHandlers', () => {
     emitter = {
       emit: vi.fn(),
     };
+    processManager = {
+      get: vi.fn(() => null),
+      listActive: vi.fn(() => []),
+      write: vi.fn(() => true),
+    };
 
     registerPipelineHandlers({
       ipcMain,
@@ -411,7 +421,7 @@ describe('registerPipelineHandlers', () => {
       emitter: emitter as never,
       notificationService: notificationService as never,
       chatNotificationService: {} as never,
-      processManager: {} as never,
+      processManager: processManager as never,
       resourceMonitor: {} as never,
     });
   });
@@ -2008,6 +2018,102 @@ describe('registerPipelineHandlers', () => {
           reasoningEffort: 'none',
         }),
       ]);
+    });
+  });
+
+  describe('pipeline:steer-execution', () => {
+    it('delivers steering input to the live Claude executor and emits a USER event', () => {
+      const createdEvent = {
+        id: 'terminal-event-1',
+        threadId: 'thread-1',
+        event: { kind: 'user_input' as const, content: 'Use the shared helper.' },
+        createdAt: new Date().toISOString(),
+      };
+      queries.threads.getById.mockReturnValue(makeThread({ status: 'executing' }));
+      queries.terminalEvents.create.mockReturnValue(createdEvent);
+      pipeline.listActive.mockReturnValue([
+        {
+          threadId: 'thread-1',
+          projectPath: '/tmp/project',
+          phase: 'executing',
+          startedAt: Date.now(),
+          activeProcessId: 'proc-1',
+        },
+      ]);
+      processManager.get.mockReturnValue({
+        id: 'proc-1',
+        type: 'claude',
+        state: 'running',
+        threadId: 'thread-1',
+      });
+
+      const handler = handlers.get('pipeline:steer-execution');
+      if (!handler) throw new Error('pipeline:steer-execution handler not registered');
+
+      expect(
+        handler(undefined, { threadId: 'thread-1', instruction: 'Use the shared helper.' }),
+      ).toEqual({
+        threadId: 'thread-1',
+        status: 'delivered',
+        message: 'Instruction delivered to the running executor transport.',
+        processId: 'proc-1',
+      });
+      expect(processManager.write).toHaveBeenCalledWith(
+        'proc-1',
+        '\n\n[USER INSTRUCTION]: Use the shared helper.\n\n',
+      );
+      expect(queries.terminalEvents.create).toHaveBeenCalledWith('thread-1', {
+        kind: 'user_input',
+        content: 'Use the shared helper.',
+      });
+      expect(mainWindow.webContents.send).toHaveBeenCalledWith('terminal:event', createdEvent);
+    });
+
+    it('returns stale when the thread is no longer executing', () => {
+      queries.threads.getById.mockReturnValue(makeThread({ status: 'reviewing' }));
+      pipeline.listActive.mockReturnValue([]);
+
+      const handler = handlers.get('pipeline:steer-execution');
+      if (!handler) throw new Error('pipeline:steer-execution handler not registered');
+
+      expect(handler(undefined, { threadId: 'thread-1', instruction: 'Try this' })).toEqual({
+        threadId: 'thread-1',
+        status: 'stale',
+        message: 'Task is not currently executing. Current phase: reviewing.',
+        processId: null,
+      });
+      expect(processManager.write).not.toHaveBeenCalled();
+      expect(queries.terminalEvents.create).not.toHaveBeenCalled();
+    });
+
+    it('rejects steering for non-Claude executor transports', () => {
+      queries.threads.getById.mockReturnValue(makeThread({ status: 'executing' }));
+      pipeline.listActive.mockReturnValue([
+        {
+          threadId: 'thread-1',
+          projectPath: '/tmp/project',
+          phase: 'executing',
+          startedAt: Date.now(),
+          activeProcessId: 'proc-1',
+        },
+      ]);
+      processManager.get.mockReturnValue({
+        id: 'proc-1',
+        type: 'codex',
+        state: 'running',
+        threadId: 'thread-1',
+      });
+
+      const handler = handlers.get('pipeline:steer-execution');
+      if (!handler) throw new Error('pipeline:steer-execution handler not registered');
+
+      expect(handler(undefined, { threadId: 'thread-1', instruction: 'Try this' })).toEqual({
+        threadId: 'thread-1',
+        status: 'rejected',
+        message: 'Mid-execution steering currently supports Claude executor sessions only.',
+        processId: 'proc-1',
+      });
+      expect(processManager.write).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/desktop/src/main/ipc/register-pipeline-handlers.ts
+++ b/apps/desktop/src/main/ipc/register-pipeline-handlers.ts
@@ -39,6 +39,7 @@ const EXECUTION_RESUME_PROMPT_MAX = 24_000;
 const EXECUTION_RESUME_GIT_OUTPUT_MAX = 12_000;
 const EXECUTION_RESUME_TERMINAL_LIMIT = 120;
 const RUN_TIMELINE_TERMINAL_LIMIT = 40;
+const STEERING_INSTRUCTION_MAX = 4_000;
 const INTERRUPTED_EXECUTION_MARKERS = [
   'interrupted while ShipCode was closed',
   'interrupted by an app refresh',
@@ -81,6 +82,8 @@ function isInterruptedExecutionThread(thread: Thread): boolean {
 function formatTerminalResumeLine(record: TerminalEventRecord): string | null {
   const event = record.event;
   switch (event.kind) {
+    case 'user_input':
+      return `[user] ${event.content}`;
     case 'text':
     case 'raw':
     case 'thinking':
@@ -202,6 +205,7 @@ export function registerPipelineHandlers({
   ipcMain,
   mainWindow,
   queries,
+  processManager,
   pipeline,
   emitter,
   notificationService,
@@ -648,6 +652,82 @@ export function registerPipelineHandlers({
     }
     return record;
   };
+
+  ipcMain.handle(
+    'pipeline:steer-execution',
+    (
+      _event,
+      { threadId, instruction }: { threadId: string; instruction: string },
+    ): {
+      threadId: string;
+      status: 'delivered' | 'stale' | 'rejected';
+      message: string;
+      processId: string | null;
+    } => {
+      const text = clampResumeText(instruction, STEERING_INSTRUCTION_MAX, 'steering instruction');
+      if (!text) {
+        return {
+          threadId,
+          status: 'rejected',
+          message: 'Instruction text is required.',
+          processId: null,
+        };
+      }
+
+      const thread = queries.threads.getById(threadId);
+      if (!thread) throw new Error(`Thread ${threadId} not found`);
+
+      const active = pipeline.listActive().find((summary) => summary.threadId === threadId);
+      if (!active || active.phase !== PIPELINE_PHASE.executing) {
+        return {
+          threadId,
+          status: 'stale',
+          message: `Task is not currently executing. Current phase: ${thread.status}.`,
+          processId: null,
+        };
+      }
+
+      const liveProcess =
+        (active.activeProcessId ? processManager.get(active.activeProcessId) : undefined) ??
+        processManager.listActive().find((process) => process.threadId === threadId);
+
+      if (!liveProcess || liveProcess.state !== 'running') {
+        return {
+          threadId,
+          status: 'stale',
+          message: 'Executor process is no longer running.',
+          processId: liveProcess?.id ?? active.activeProcessId ?? null,
+        };
+      }
+
+      if (liveProcess.type !== 'claude') {
+        return {
+          threadId,
+          status: 'rejected',
+          message: 'Mid-execution steering currently supports Claude executor sessions only.',
+          processId: liveProcess.id,
+        };
+      }
+
+      const delivered = processManager.write(liveProcess.id, `\n\n[USER INSTRUCTION]: ${text}\n\n`);
+      if (!delivered) {
+        return {
+          threadId,
+          status: 'rejected',
+          message: 'Executor stdin is no longer writable.',
+          processId: liveProcess.id,
+        };
+      }
+
+      emitTerminalEvent(threadId, { kind: 'user_input', content: text });
+      return {
+        threadId,
+        status: 'delivered',
+        message: 'Instruction delivered to the running executor transport.',
+        processId: liveProcess.id,
+      };
+    },
+  );
 
   ipcMain.handle('pipeline:pause', (_event, { threadId }: { threadId: string }) => {
     const thread = queries.threads.getById(threadId);

--- a/apps/desktop/src/renderer/components/issue-detail/ConsoleTab.test.tsx
+++ b/apps/desktop/src/renderer/components/issue-detail/ConsoleTab.test.tsx
@@ -1,0 +1,74 @@
+// @vitest-environment jsdom
+
+import '@testing-library/jest-dom/vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConsoleTab } from './ConsoleTab';
+
+vi.mock('../terminal-transcript/ThreadConsoleTranscript', () => ({
+  ThreadConsoleTranscript: () => <div data-testid="thread-console-transcript" />,
+}));
+
+const invokeMock = vi.fn<(channel: string, args?: unknown) => Promise<unknown>>();
+
+beforeEach(() => {
+  window.shipcode ??= {} as typeof window.shipcode;
+  window.shipcode.invoke = invokeMock as unknown as typeof window.shipcode.invoke;
+  invokeMock.mockResolvedValue({
+    threadId: 'thread-1',
+    status: 'delivered',
+    message: 'Instruction delivered to the running executor transport.',
+    processId: 'proc-1',
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  invokeMock.mockReset();
+});
+
+describe('ConsoleTab steering', () => {
+  it('shows the steering input only while the thread is executing', () => {
+    const { rerender } = render(
+      <ConsoleTab
+        activeThreadId="thread-1"
+        approvedAwaitingExecution={false}
+        threadPhase="reviewing"
+      />,
+    );
+
+    expect(screen.queryByRole('textbox', { name: 'Steer executor' })).not.toBeInTheDocument();
+
+    rerender(
+      <ConsoleTab
+        activeThreadId="thread-1"
+        approvedAwaitingExecution={false}
+        threadPhase="executing"
+      />,
+    );
+
+    expect(screen.getByRole('textbox', { name: 'Steer executor' })).toBeInTheDocument();
+  });
+
+  it('sends steering instructions to the running executor', async () => {
+    render(
+      <ConsoleTab
+        activeThreadId="thread-1"
+        approvedAwaitingExecution={false}
+        threadPhase="executing"
+      />,
+    );
+
+    fireEvent.change(screen.getByRole('textbox', { name: 'Steer executor' }), {
+      target: { value: 'Focus on the IPC receipt state.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Send steering instruction' }));
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith('pipeline:steer-execution', {
+        threadId: 'thread-1',
+        instruction: 'Focus on the IPC receipt state.',
+      });
+    });
+  });
+});

--- a/apps/desktop/src/renderer/components/issue-detail/ConsoleTab.tsx
+++ b/apps/desktop/src/renderer/components/issue-detail/ConsoleTab.tsx
@@ -1,4 +1,8 @@
 import type { PipelinePhase } from '@shipcode/shared';
+import { Button, Textarea } from '@shipshitdev/ui';
+import { SendHorizontal } from 'lucide-react';
+import { useCallback, useState } from 'react';
+import { toast } from '../../stores/toast-store';
 import { ThreadConsoleTranscript } from '../terminal-transcript/ThreadConsoleTranscript';
 
 interface ConsoleTabProps {
@@ -12,6 +16,40 @@ export function ConsoleTab({
   approvedAwaitingExecution,
   threadPhase,
 }: ConsoleTabProps) {
+  const [instruction, setInstruction] = useState('');
+  const [isSending, setIsSending] = useState(false);
+  const canSteer = activeThreadId !== null && threadPhase === 'executing';
+
+  const handleSubmit = useCallback(async () => {
+    if (!activeThreadId || isSending) return;
+    const text = instruction.trim();
+    if (!text) return;
+
+    setIsSending(true);
+    try {
+      const result = await window.shipcode.invoke<{
+        status: 'delivered' | 'stale' | 'rejected';
+        message: string;
+      }>('pipeline:steer-execution', {
+        threadId: activeThreadId,
+        instruction: text,
+      });
+      if (result.status === 'delivered') {
+        setInstruction('');
+        toast.success('Instruction delivered');
+      } else {
+        toast.error(
+          result.status === 'stale' ? 'Instruction stale' : 'Instruction rejected',
+          result.message,
+        );
+      }
+    } catch (error) {
+      toast.error('Instruction failed', error instanceof Error ? error.message : undefined);
+    } finally {
+      setIsSending(false);
+    }
+  }, [activeThreadId, instruction, isSending]);
+
   if (!activeThreadId) {
     return (
       <div className="rounded-lg border border-border bg-secondary/40 p-6 text-sm text-muted-foreground">
@@ -21,13 +59,43 @@ export function ConsoleTab({
   }
 
   return (
-    <div className="flex h-[calc(100vh-220px)] min-h-[360px] overflow-hidden rounded-lg border border-border bg-secondary">
+    <div className="flex h-[calc(100vh-220px)] min-h-[360px] flex-col overflow-hidden rounded-lg border border-border bg-secondary">
       <ThreadConsoleTranscript
         threadId={activeThreadId}
         phase={threadPhase}
         approvedAwaitingExecution={approvedAwaitingExecution}
         className="flex-1"
       />
+      {canSteer ? (
+        <div className="border-t border-border bg-elevated/95 p-3">
+          <div className="flex items-end gap-2">
+            <Textarea
+              aria-label="Steer executor"
+              value={instruction}
+              rows={2}
+              className="min-h-[44px] flex-1 resize-none font-mono text-[12px]"
+              placeholder="Inject an instruction into the running executor..."
+              disabled={isSending}
+              onChange={(event) => setInstruction(event.target.value)}
+              onKeyDown={(event) => {
+                if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+                  event.preventDefault();
+                  void handleSubmit();
+                }
+              }}
+            />
+            <Button
+              type="button"
+              size="icon"
+              aria-label="Send steering instruction"
+              disabled={isSending || instruction.trim().length === 0}
+              onClick={() => void handleSubmit()}
+            >
+              <SendHorizontal size={16} />
+            </Button>
+          </div>
+        </div>
+      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/renderer/components/terminal-transcript/TerminalTranscript.test.tsx
+++ b/apps/desktop/src/renderer/components/terminal-transcript/TerminalTranscript.test.tsx
@@ -103,6 +103,22 @@ describe('TerminalTranscript', () => {
     ).toBeInTheDocument();
   });
 
+  it('renders user steering input as a distinct user block', () => {
+    renderTranscript(
+      <TerminalTranscript
+        events={[
+          makeTextEvent({
+            id: 'event-user-1',
+            event: { kind: 'user_input', content: 'Use the existing helper.' },
+          }),
+        ]}
+      />,
+    );
+
+    expect(screen.getByText('User')).toBeInTheDocument();
+    expect(screen.getByText('Use the existing helper.')).toBeInTheDocument();
+  });
+
   it('offers auto fix on failed console output and passes the captured failure text', () => {
     const event = makeRawErrorEvent();
     const onAutoFix = vi.fn();

--- a/apps/desktop/src/renderer/components/terminal-transcript/TerminalTranscript.tsx
+++ b/apps/desktop/src/renderer/components/terminal-transcript/TerminalTranscript.tsx
@@ -501,6 +501,24 @@ function transcriptRow({
           <div className="h-px flex-1 bg-border/50" />
         </div>
       );
+    case 'user_input': {
+      const textContent = stripAnsi(event.content);
+      return (
+        <div className="group/msg mb-3 rounded-lg border border-agent/35 bg-agent/10 px-4 py-3 shadow-[0_1px_3px_rgba(0,0,0,0.16)]">
+          <TranscriptMeta createdAt={record.createdAt} compact={compact}>
+            <span className="tracking-normal text-agent normal-case font-medium">User</span>
+          </TranscriptMeta>
+          <pre
+            className={cn(
+              'mt-2 whitespace-pre-wrap break-words font-mono text-primary',
+              compact ? 'text-[12px] leading-[1.6]' : 'text-[13px] leading-[1.65]',
+            )}
+          >
+            {textContent}
+          </pre>
+        </div>
+      );
+    }
     case 'turn_end': {
       const summary = formatTokens(event.tokensUsed, event.costUsd);
       if (!summary) return null;

--- a/packages/agents/src/process-manager.test.ts
+++ b/packages/agents/src/process-manager.test.ts
@@ -198,6 +198,20 @@ describe('ProcessManager registry hygiene', () => {
     expect(manager.get(proc.id)).toBeUndefined();
   });
 
+  it('keeps piped stdin open when requested for steerable processes', () => {
+    const child = createMockChild();
+    mockChildSpawn.mockReturnValueOnce(child);
+
+    const proc = manager.spawnWithStdin('claude', 'claude', ['-p', '-'], '/tmp', 'PROMPT', 't1', {
+      keepStdinOpen: true,
+    });
+
+    expect(child.stdin.write).toHaveBeenCalledWith('PROMPT');
+    expect(child.stdin.end).not.toHaveBeenCalled();
+    expect(manager.write(proc.id, 'next')).toBe(true);
+    expect(child.stdin.write).toHaveBeenCalledWith('next');
+  });
+
   it('sanitizes extra environment and resolves agent commands through trusted shells', () => {
     const previousShell = process.env.SHELL;
     process.env.SHELL = '/bin/zsh';
@@ -437,7 +451,7 @@ describe('ProcessManager registry hygiene', () => {
     mockChildSpawn.mockReturnValueOnce(child);
     const proc = manager.spawnWithStdin('codex', 'codex', ['exec', '-'], '/tmp', '');
 
-    manager.write(proc.id, 'next');
+    expect(manager.write(proc.id, 'next')).toBe(true);
 
     expect(child.stdin.write).toHaveBeenCalledWith('next');
   });
@@ -449,12 +463,12 @@ describe('ProcessManager registry hygiene', () => {
     const proc = manager.spawnWithStdin('codex', 'codex', ['exec', '-'], '/tmp', '');
     child.stdin.write.mockClear();
 
-    manager.write(proc.id, 'next');
+    expect(manager.write(proc.id, 'next')).toBe(false);
     expect(child.stdin.write).not.toHaveBeenCalled();
 
     child.stdin.writable = true;
     proc.state = 'exited';
-    manager.write(proc.id, 'after-exit');
+    expect(manager.write(proc.id, 'after-exit')).toBe(false);
     expect(child.stdin.write).not.toHaveBeenCalled();
   });
 

--- a/packages/agents/src/process-manager.ts
+++ b/packages/agents/src/process-manager.ts
@@ -164,6 +164,11 @@ export type ManagedProcessOutputMode = 'normalized' | 'raw';
 export interface ManagedProcessSpawnOptions {
   outputMode?: ManagedProcessOutputMode;
   /**
+   * Keep piped stdin writable after the initial prompt is written. Used by
+   * long-running executor transports that can accept explicit steering input.
+   */
+  keepStdinOpen?: boolean;
+  /**
    * When provided, the spawn site asserts `cwd` is a safe agent workspace
    * (absolute, basename matches `[A-Za-z0-9._-]+`, lives under the configured
    * workspaceRoot). Defense-in-depth — see `assertWorkspaceSafe`. Pipeline
@@ -513,7 +518,10 @@ export class ProcessManager extends EventEmitter {
       // The close/error handlers above own the final lifecycle event.
     });
 
-    const finishStdin = () => child.stdin.end();
+    const shouldKeepStdinOpen = options.keepStdinOpen === true;
+    const finishStdin = () => {
+      if (!shouldKeepStdinOpen) child.stdin.end();
+    };
     const handleStdinError = (err: Error) => {
       child.stdin.off('drain', finishStdin);
       emitOutput(`\x1b[31mError writing prompt to ${command}: ${err.message}\x1b[0m\r\n`);
@@ -523,6 +531,10 @@ export class ProcessManager extends EventEmitter {
     child.stdin.once('error', handleStdinError);
     try {
       if (child.stdin.write(input) !== false) {
+        if (shouldKeepStdinOpen) {
+          child.stdin.off('error', handleStdinError);
+          return managed;
+        }
         child.stdin.end();
       } else {
         child.stdin.once('drain', finishStdin);
@@ -542,15 +554,22 @@ export class ProcessManager extends EventEmitter {
     }
   }
 
-  write(processId: string, data: string): void {
+  write(processId: string, data: string): boolean {
     const process = this.processes.get(processId);
     if (process && process.state === 'running') {
       if (process.pty) {
         process.pty.write(data);
+        return true;
       } else if (process.child?.stdin.writable) {
-        process.child.stdin.write(data);
+        try {
+          process.child.stdin.write(data);
+          return true;
+        } catch {
+          return false;
+        }
       }
     }
+    return false;
   }
 
   resize(processId: string, cols: number, rows: number): void {

--- a/packages/agents/src/providers/cli-provider.test.ts
+++ b/packages/agents/src/providers/cli-provider.test.ts
@@ -598,6 +598,20 @@ describe('createClaudeCliProvider', () => {
     expect(result.resolvedModel).toBe('claude');
   });
 
+  it('notifies callers when the managed Claude process starts', async () => {
+    const { trigger, pm } = createMockProcessManager();
+    const provider = createClaudeCliProvider(pm);
+    const onProcessStart = vi.fn();
+
+    const promise = provider.generate(req({ phase: 'plan', onProcessStart }));
+    await new Promise((r) => setImmediate(r));
+
+    expect(onProcessStart).toHaveBeenCalledWith('proc-1');
+
+    await trigger('exit', 'proc-1', 0);
+    await promise;
+  });
+
   it('ignores output and exit events for other process IDs', async () => {
     const { trigger, spawnCalls, pm } = createMockProcessManager();
     const provider = createClaudeCliProvider(pm);

--- a/packages/agents/src/providers/cli-provider.ts
+++ b/packages/agents/src/providers/cli-provider.ts
@@ -78,6 +78,7 @@ async function runCli(
   threadId?: string,
   workspaceRoot?: string | null,
   options?: Parameters<ProcessManager['spawn']>[5],
+  onProcessStart?: (processId: string) => void,
 ): Promise<CliRunResult> {
   if (signal.aborted) {
     return { rawOutput: '', exitCode: 130 };
@@ -118,6 +119,7 @@ async function runCli(
       exitCode: 127,
     };
   }
+  onProcessStart?.(process.id);
 
   return new Promise<CliRunResult>((resolve) => {
     let rawOutput = '';
@@ -227,7 +229,7 @@ function buildClaudeCommand(req: ProviderRequest): CliCommand {
       if (disallowedTools) execArgs.push('--disallowedTools', disallowedTools.join(','));
       execArgs.push('--dangerously-skip-permissions');
       injectThinkingTokens(execArgs, req);
-      return { args: execArgs, stdin: req.prompt };
+      return { args: execArgs, stdin: req.prompt, options: { keepStdinOpen: true } };
     }
     case 'review': // Claude does not review in the current pipeline (codex does).
       // Kept for symmetry; always 1 turn (structural, not configurable).
@@ -436,6 +438,7 @@ export function createClaudeCliProvider(processManager: ProcessManager): AgentPr
         req.threadId,
         req.workspaceRoot,
         { ...(command.options ?? {}), envKeyAllowlist: [...CLAUDE_ENV_KEYS] },
+        req.onProcessStart,
       );
       const parser = new StreamParser();
       parser.feed(result.rawOutput);
@@ -503,6 +506,7 @@ export function createCodexCliProvider(processManager: ProcessManager): AgentPro
         req.threadId,
         req.workspaceRoot,
         { ...(command.options ?? {}), envKeyAllowlist: [...CODEX_ENV_KEYS] },
+        req.onProcessStart,
       );
       const rawOutput = stripCodexProtocol(result.rawOutput, {
         includeCommandOutput: req.phase === 'execute',

--- a/packages/agents/src/providers/types.ts
+++ b/packages/agents/src/providers/types.ts
@@ -185,6 +185,8 @@ export interface ProviderRequest {
    * Providers may log against this ID but must not read thread state.
    */
   threadId: string;
+  /** Notifies the orchestrator which managed process owns this provider run. */
+  onProcessStart?: (processId: string) => void;
   /**
    * Optional callback for streaming canonical terminal events.
    * Providers emit TerminalEvents through this so the terminal drawer

--- a/packages/pipeline/src/pipeline/runtime.test.ts
+++ b/packages/pipeline/src/pipeline/runtime.test.ts
@@ -982,6 +982,31 @@ describe('createPipelineRuntime', () => {
     );
   });
 
+  it('sets activeProcessId only while a provider phase is running', async () => {
+    let activeDuringProvider: string | null = null;
+    const provider: AgentProvider = {
+      id: 'claude-cli',
+      supports: new Set(['plan']),
+      generate: vi.fn(async (request) => {
+        request.onProcessStart?.('proc-1');
+        activeDuringProvider = context.activeProcessId;
+        return {
+          rawOutput: 'done',
+          exitCode: 0,
+        };
+      }),
+      healthCheck: vi.fn(async () => ({ ok: true })),
+    };
+    const { deps } = makeDeps(provider);
+    const runtime = createPipelineRuntime(deps, {} as never);
+    const context = makeContext();
+
+    await runtime.runProviderPhase(context, buildPhasePayload(context, 'plan'), 'prompt', [], {});
+
+    expect(activeDuringProvider).toBe('proc-1');
+    expect(context.activeProcessId).toBeNull();
+  });
+
   it('passes executor model overrides and omits workspace roots outside worktrees', async () => {
     const provider: AgentProvider = {
       id: 'claude-cli',

--- a/packages/pipeline/src/pipeline/runtime.ts
+++ b/packages/pipeline/src/pipeline/runtime.ts
@@ -570,6 +570,7 @@ export function createPipelineRuntime(
     prompt: string,
     promptMaterials: PromptMaterial[],
     phaseHints: ProviderRequest['phaseHints'],
+    lifecycle?: { onProcessStart?: (processId: string) => void },
   ): Promise<{
     rawOutput: string;
     exitCode: number;
@@ -658,6 +659,7 @@ export function createPipelineRuntime(
         promptMaterialSummary: input.promptMaterialSummary,
         modelHint: modelHint ?? undefined,
         threadId: input.threadId,
+        onProcessStart: lifecycle?.onProcessStart,
         ...(workspaceRoot !== undefined ? { workspaceRoot } : {}),
         githubGraphql: {
           // Token read happens at tool-call time, not now — captures
@@ -864,17 +866,30 @@ export function createPipelineRuntime(
     promptTelemetry?: import('@shipcode/agents/source').PhasePromptTelemetry;
     clarificationRequest?: import('@shipcode/shared').ClarificationRequest;
   }> {
-    const { deltas, ...response } = await runProviderPhaseCore(
-      payload,
-      prompt,
-      promptMaterials,
-      phaseHints,
-    );
-    context.promptTelemetry.push(deltas.promptTelemetry);
-    if (deltas.diagnosticEntry !== null) {
-      context.promptTelemetryDiagnostics.push(deltas.diagnosticEntry);
+    let phaseProcessId: string | null = null;
+    try {
+      const { deltas, ...response } = await runProviderPhaseCore(
+        payload,
+        prompt,
+        promptMaterials,
+        phaseHints,
+        {
+          onProcessStart: (processId) => {
+            phaseProcessId = processId;
+            context.activeProcessId = processId;
+          },
+        },
+      );
+      context.promptTelemetry.push(deltas.promptTelemetry);
+      if (deltas.diagnosticEntry !== null) {
+        context.promptTelemetryDiagnostics.push(deltas.diagnosticEntry);
+      }
+      return response;
+    } finally {
+      if (phaseProcessId !== null && context.activeProcessId === phaseProcessId) {
+        context.activeProcessId = null;
+      }
     }
-    return response;
   }
 
   /** Perform the actual GH write for a single state snapshot. */

--- a/packages/shared/src/ipc-channels.ts
+++ b/packages/shared/src/ipc-channels.ts
@@ -212,6 +212,15 @@ export interface IpcInvokeChannels {
   'pipeline:reject': { args: { threadId: string; feedback: string }; result: undefined };
   'pipeline:stabilize-pr': { args: { threadId: string }; result: undefined };
   'pipeline:pause': { args: { threadId: string }; result: undefined };
+  'pipeline:steer-execution': {
+    args: { threadId: string; instruction: string };
+    result: {
+      threadId: string;
+      status: 'delivered' | 'stale' | 'rejected';
+      message: string;
+      processId: string | null;
+    };
+  };
   'pipeline:resume': { args: { threadId: string }; result: undefined };
   'pipeline:cancel': { args: { threadId: string }; result: undefined };
   'pipeline:skip-review': { args: { threadId: string }; result: undefined };

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -639,6 +639,7 @@ export interface AnsweredClarification {
 
 export type CanonicalTerminalEvent =
   | { kind: 'text'; content: string }
+  | { kind: 'user_input'; content: string }
   | { kind: 'thinking'; content: string }
   | {
       kind: 'tool_start';


### PR DESCRIPTION
## Summary
- add `pipeline:steer-execution` IPC for EXECUTING-phase instructions with delivered/stale/rejected receipt states
- expose the active provider process id while provider phases run, then clear it after completion
- add an executing-only console input and render submitted instructions as distinct USER terminal events

Closes #152

## Verification
- `bunx turbo run build --filter='./packages/*'`
- `bunx vitest run packages/agents/src/process-manager.test.ts packages/agents/src/providers/cli-provider.test.ts`
- `bunx vitest run apps/desktop/src/main/ipc/register-pipeline-handlers.test.ts apps/desktop/src/renderer/components/terminal-transcript/TerminalTranscript.test.tsx apps/desktop/src/renderer/components/issue-detail/ConsoleTab.test.tsx`
- `bunx vitest run packages/agents/src/providers/cli-provider.test.ts packages/pipeline/src/pipeline/runtime.test.ts apps/desktop/src/main/ipc/register-pipeline-handlers.test.ts apps/desktop/src/renderer/components/terminal-transcript/TerminalTranscript.test.tsx apps/desktop/src/renderer/components/issue-detail/ConsoleTab.test.tsx packages/agents/src/process-manager.test.ts`
- `bunx turbo run typecheck --filter=@shipcode/shared --filter=@shipcode/agents --filter=@shipcode/pipeline --filter=@shipcode/desktop`
- `bunx biome check packages/shared/src/types.ts packages/shared/src/ipc-channels.ts packages/agents/src/process-manager.ts packages/agents/src/process-manager.test.ts packages/agents/src/providers/types.ts packages/agents/src/providers/cli-provider.ts packages/agents/src/providers/cli-provider.test.ts packages/pipeline/src/pipeline/runtime.ts packages/pipeline/src/pipeline/runtime.test.ts apps/desktop/src/main/ipc/register-pipeline-handlers.ts apps/desktop/src/main/ipc/register-pipeline-handlers.test.ts apps/desktop/src/renderer/components/terminal-transcript/TerminalTranscript.tsx apps/desktop/src/renderer/components/terminal-transcript/TerminalTranscript.test.tsx apps/desktop/src/renderer/components/issue-detail/ConsoleTab.tsx apps/desktop/src/renderer/components/issue-detail/ConsoleTab.test.tsx`
