### PR TITLE
Refactor fenced JSON extraction

### DIFF
--- a/packages/agents/src/automation-formatter.ts
+++ b/packages/agents/src/automation-formatter.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import type { AgentType, ReasoningEffort } from '@shipcode/shared';
 import { unwrapCliResultEnvelope } from './cli-result';
 import { runCliWithStdin } from './cli-stdin-runner';
+import { extractFencedJson } from './fenced-json';
 import { OpenRouterClient } from './providers/openrouter-http';
 import {
   mapReasoningEffortToClaudeThinkingTokens,
@@ -246,37 +247,11 @@ async function formatAutomationPromptViaOpenRouter(options: {
 }
 
 export function extractFormattedAutomation(text: string): FormattedAutomation {
-  const openTag = `\`\`\`${AUTOMATION_FENCE_TAG}`;
-  const lines = text.split('\n');
-  let collecting = false;
-  const captured: string[] = [];
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!collecting) {
-      if (trimmed === openTag || trimmed.startsWith(`${openTag} `)) {
-        collecting = true;
-      }
-      continue;
-    }
-    if (trimmed === '```') break;
-    captured.push(line);
-  }
-
-  if (!captured.length) {
-    throw new Error(`No \`${AUTOMATION_FENCE_TAG}\` fenced block found in AI response`);
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(captured.join('\n').trim());
-  } catch (err) {
-    throw new Error(
-      `Failed to parse automation JSON inside \`${AUTOMATION_FENCE_TAG}\` block: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
-  }
+  const parsed = extractFencedJson({
+    text,
+    tag: AUTOMATION_FENCE_TAG,
+    label: 'automation',
+  });
 
   if (
     !parsed ||

--- a/packages/agents/src/fenced-json.ts
+++ b/packages/agents/src/fenced-json.ts
@@ -1,0 +1,41 @@
+export function extractFencedJson(options: { text: string; tag: string; label: string }): unknown {
+  const captured = extractFencedBlock(options.text, options.tag);
+  if (!captured.length) {
+    throw new Error(`No \`${options.tag}\` fenced block found in AI response`);
+  }
+
+  try {
+    return JSON.parse(captured.join('\n').trim()) as unknown;
+  } catch (err) {
+    throw new Error(
+      `Failed to parse ${options.label} JSON inside \`${options.tag}\` block: ${formatCaughtError(
+        err,
+      )}`,
+    );
+  }
+}
+
+function extractFencedBlock(text: string, tag: string): string[] {
+  const openTag = `\`\`\`${tag}`;
+  const lines = text.split('\n');
+  let collecting = false;
+  const captured: string[] = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!collecting) {
+      if (trimmed === openTag || trimmed.startsWith(`${openTag} `)) {
+        collecting = true;
+      }
+      continue;
+    }
+    if (trimmed === '```') break;
+    captured.push(line);
+  }
+
+  return captured;
+}
+
+function formatCaughtError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/agents/src/memory-generator.ts
+++ b/packages/agents/src/memory-generator.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import type { GeneratorCli, MemoryFileInfo, RepoMemoryStatus } from '@shipcode/shared';
 import { unwrapCliResultEnvelope } from './cli-result';
 import { runCliWithStdin } from './cli-stdin-runner';
+import { extractFencedJson } from './fenced-json';
 
 const MEMORY_DIR = '.agents/memory';
 const OBSOLETE_CONTEXT_DIR = '.agents/context';
@@ -231,44 +232,12 @@ END_${delimiter}`;
 }
 
 function extractGeneratedMemoryFiles(text: string): Record<string, string> {
-  const openTag = `\`\`\`${MEMORY_FENCE_TAG}`;
-  const lines = text.split('\n');
-  let collecting = false;
-  const captured: string[] = [];
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!collecting) {
-      if (trimmed === openTag || trimmed.startsWith(`${openTag} `)) {
-        collecting = true;
-      }
-      continue;
-    }
-    if (trimmed === '```') break;
-    captured.push(line);
-  }
-
-  if (!captured.length) {
-    throw new Error(`No \`${MEMORY_FENCE_TAG}\` fenced block found in AI response`);
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(captured.join('\n').trim());
-  } catch (err) {
-    throw new Error(
-      `Failed to parse memory JSON inside \`${MEMORY_FENCE_TAG}\` block: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
-  }
+  const parsed = extractFencedJson({ text, tag: MEMORY_FENCE_TAG, label: 'memory' });
 
   for (const key of ['goal', 'architecture', 'constraints', 'doDont']) {
-    if (
-      !parsed ||
-      typeof (parsed as Record<string, unknown>)[key] !== 'string' ||
-      !(parsed as Record<string, string>)[key].trim()
-    ) {
+    const value =
+      parsed && typeof parsed === 'object' ? (parsed as Record<string, unknown>)[key] : null;
+    if (typeof value !== 'string' || !value.trim()) {
       throw new Error(`Memory JSON is missing or has empty \`${key}\` key`);
     }
   }

--- a/packages/agents/src/prd-generator.ts
+++ b/packages/agents/src/prd-generator.ts
@@ -1,6 +1,7 @@
 import type { GeneratorCli, ReasoningEffort } from '@shipcode/shared';
 import { unwrapCliResultEnvelope } from './cli-result';
 import { runCliWithStdin } from './cli-stdin-runner';
+import { extractFencedJson } from './fenced-json';
 import { mapReasoningEffortToClaudeThinkingTokens } from './providers/reasoning';
 
 const PRD_FENCE_TAG = 'shipcode-prd';
@@ -172,37 +173,7 @@ function runPrdCliWithStdin(
  * appear as standalone lines.
  */
 export function extractPrd(text: string): GeneratedPrd {
-  const openTag = `\`\`\`${PRD_FENCE_TAG}`;
-  const lines = text.split('\n');
-  let collecting = false;
-  const captured: string[] = [];
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!collecting) {
-      // Match opening fence with optional trailing whitespace/indentation
-      if (trimmed === openTag || trimmed.startsWith(`${openTag} `)) {
-        collecting = true;
-      }
-      continue;
-    }
-    // Match closing fence (may be indented)
-    if (trimmed === '```') break;
-    captured.push(line);
-  }
-
-  if (!captured.length) {
-    throw new Error(`No \`${PRD_FENCE_TAG}\` fenced block found in AI response`);
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(captured.join('\n').trim());
-  } catch (err) {
-    throw new Error(
-      `Failed to parse PRD JSON inside \`${PRD_FENCE_TAG}\` block: ${(err as Error).message}`,
-    );
-  }
+  const parsed = extractFencedJson({ text, tag: PRD_FENCE_TAG, label: 'PRD' });
 
   if (
     !parsed ||

--- a/packages/agents/src/skill-rewriter.ts
+++ b/packages/agents/src/skill-rewriter.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import type { GeneratorCli, PhaseSkillKey, ReasoningEffort } from '@shipcode/shared';
 import { unwrapCliResultEnvelope } from './cli-result';
 import { runCliWithStdin } from './cli-stdin-runner';
+import { extractFencedJson } from './fenced-json';
 import { mapReasoningEffortToClaudeThinkingTokens } from './providers/reasoning';
 import { validateSkill } from './skills';
 
@@ -205,37 +206,7 @@ function runSkillCliWithStdin(
 }
 
 export function extractRewrittenSkill(text: string): RewrittenSkill {
-  const openTag = `\`\`\`${SKILL_FENCE_TAG}`;
-  const lines = text.split('\n');
-  let collecting = false;
-  const captured: string[] = [];
-
-  for (const line of lines) {
-    const trimmed = line.trim();
-    if (!collecting) {
-      if (trimmed === openTag || trimmed.startsWith(`${openTag} `)) {
-        collecting = true;
-      }
-      continue;
-    }
-    if (trimmed === '```') break;
-    captured.push(line);
-  }
-
-  if (!captured.length) {
-    throw new Error(`No \`${SKILL_FENCE_TAG}\` fenced block found in AI response`);
-  }
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(captured.join('\n').trim());
-  } catch (err) {
-    throw new Error(
-      `Failed to parse skill JSON inside \`${SKILL_FENCE_TAG}\` block: ${
-        err instanceof Error ? err.message : String(err)
-      }`,
-    );
-  }
+  const parsed = extractFencedJson({ text, tag: SKILL_FENCE_TAG, label: 'skill' });
 
   if (
     !parsed ||


### PR DESCRIPTION
## Summary
- add a shared fenced JSON extractor for model response envelopes
- reuse it in PRD, memory, automation, and skill extraction paths
- keep each caller's field validation and error messages local

## Verification
- bunx vitest run packages/agents/src/prd-generator.test.ts packages/agents/src/memory-generator.test.ts packages/agents/src/automation-formatter.test.ts packages/agents/src/skill-rewriter.test.ts
- bun --filter @shipcode/agents typecheck
- bunx biome check packages/agents/src/fenced-json.ts packages/agents/src/prd-generator.ts packages/agents/src/memory-generator.ts packages/agents/src/automation-formatter.ts packages/agents/src/skill-rewriter.ts --assist-enabled=false --files-ignore-unknown=true
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated shared JSON parsing logic across internal components into a reusable utility function, improving code maintainability and reducing code duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->