### PR TITLE
refactor: share package vitest config

### DIFF
--- a/apps/cli/vitest.config.ts
+++ b/apps/cli/vitest.config.ts
@@ -1,13 +1,6 @@
-import { defineConfig } from 'vitest/config';
-import { withCoverage } from '../../vitest.coverage';
+import { definePackageVitestConfig } from '../../vitest.package-config';
 
-export default defineConfig({
-  test: withCoverage(
-    {
-      environment: 'node',
-      include: ['src/**/*.test.ts'],
-      exclude: ['dist/**'],
-    },
-    ['src/**/*.{ts,tsx}'],
-  ),
+export default definePackageVitestConfig({
+  environment: 'node',
+  exclude: ['dist/**'],
 });

--- a/packages/agents/vitest.config.ts
+++ b/packages/agents/vitest.config.ts
@@ -1,11 +1,3 @@
-import { defineConfig } from 'vitest/config';
-import { withCoverage } from '../../vitest.coverage';
+import { definePackageVitestConfig } from '../../vitest.package-config';
 
-export default defineConfig({
-  test: withCoverage(
-    {
-      include: ['src/**/*.test.ts'],
-    },
-    ['src/**/*.{ts,tsx}'],
-  ),
-});
+export default definePackageVitestConfig();

--- a/packages/db/vitest.config.ts
+++ b/packages/db/vitest.config.ts
@@ -1,11 +1,3 @@
-import { defineConfig } from 'vitest/config';
-import { withCoverage } from '../../vitest.coverage';
+import { definePackageVitestConfig } from '../../vitest.package-config';
 
-export default defineConfig({
-  test: withCoverage(
-    {
-      include: ['src/**/*.test.ts'],
-    },
-    ['src/**/*.{ts,tsx}'],
-  ),
-});
+export default definePackageVitestConfig();

--- a/packages/git/vitest.config.ts
+++ b/packages/git/vitest.config.ts
@@ -1,13 +1,6 @@
-import { defineConfig } from 'vitest/config';
-import { withCoverage } from '../../vitest.coverage';
+import { definePackageVitestConfig } from '../../vitest.package-config';
 
-export default defineConfig({
-  test: withCoverage(
-    {
-      environment: 'node',
-      include: ['src/**/*.test.ts'],
-      exclude: ['dist/**'],
-    },
-    ['src/**/*.{ts,tsx}'],
-  ),
+export default definePackageVitestConfig({
+  environment: 'node',
+  exclude: ['dist/**'],
 });

--- a/packages/pipeline/vitest.config.ts
+++ b/packages/pipeline/vitest.config.ts
@@ -1,11 +1,3 @@
-import { defineConfig } from 'vitest/config';
-import { withCoverage } from '../../vitest.coverage';
+import { definePackageVitestConfig } from '../../vitest.package-config';
 
-export default defineConfig({
-  test: withCoverage(
-    {
-      include: ['src/**/*.test.ts'],
-    },
-    ['src/**/*.{ts,tsx}'],
-  ),
-});
+export default definePackageVitestConfig();

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,11 +1,3 @@
-import { defineConfig } from 'vitest/config';
-import { withCoverage } from '../../vitest.coverage';
+import { definePackageVitestConfig } from '../../vitest.package-config';
 
-export default defineConfig({
-  test: withCoverage(
-    {
-      include: ['src/**/*.test.ts'],
-    },
-    ['src/**/*.{ts,tsx}'],
-  ),
-});
+export default definePackageVitestConfig();

--- a/vitest.package-config.ts
+++ b/vitest.package-config.ts
@@ -1,0 +1,16 @@
+import { defineConfig, type ViteUserConfig } from 'vitest/config';
+import { withCoverage } from './vitest.coverage';
+
+type TestConfig = NonNullable<ViteUserConfig['test']>;
+
+export function definePackageVitestConfig(test: Partial<TestConfig> = {}) {
+  return defineConfig({
+    test: withCoverage(
+      {
+        include: ['src/**/*.test.ts'],
+        ...test,
+      },
+      ['src/**/*.{ts,tsx}'],
+    ),
+  });
+}


### PR DESCRIPTION
## Summary\n- add a shared package Vitest config helper for covered src tests\n- replace six duplicated package config bodies with the helper\n\n## Verification\n- bunx biome check vitest.package-config.ts apps/cli/vitest.config.ts packages/agents/vitest.config.ts packages/db/vitest.config.ts packages/git/vitest.config.ts packages/pipeline/vitest.config.ts packages/shared/vitest.config.ts\n- (from packages/shared) bunx vitest --config vitest.config.ts run\n- bunx tsc --noEmit --project tsconfig.json\n- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Unified test configuration infrastructure across packages through a shared configuration helper, streamlining consistency in test setup management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->