### PR TITLE
Refactor normalizer line parsing

### DIFF
--- a/packages/agents/src/providers/normalizers/claude-normalizer.ts
+++ b/packages/agents/src/providers/normalizers/claude-normalizer.ts
@@ -12,6 +12,7 @@
 
 import type { TerminalEvent } from '../../terminal-events';
 import { FenceStateMachine } from './fence-suppression';
+import { LineBufferedJsonNormalizer } from './line-buffered-json-normalizer';
 
 interface ToolCallResult {
   summary: string;
@@ -54,48 +55,26 @@ function formatToolCall(name: string, input: Record<string, unknown>): ToolCallR
 }
 
 export class ClaudeNormalizer {
-  private lineBuffer = '';
   private readonly fence: FenceStateMachine;
+  private readonly lines: LineBufferedJsonNormalizer;
   private readonly onEvent: (event: TerminalEvent) => void;
 
   constructor(onEvent: (event: TerminalEvent) => void) {
     this.onEvent = onEvent;
     this.fence = new FenceStateMachine(onEvent);
+    this.lines = new LineBufferedJsonNormalizer(
+      onEvent,
+      this.fence,
+      (line) => JSON.parse(line),
+      (event) => this.processEvent(event),
+    );
   }
 
   /**
    * Feed a raw PTY chunk. Lines may be split across chunks.
    */
   feed(chunk: string): void {
-    this.lineBuffer += chunk;
-
-    let newlineIdx = this.lineBuffer.indexOf('\n');
-    while (newlineIdx !== -1) {
-      const line = this.lineBuffer.slice(0, newlineIdx).trim();
-      this.lineBuffer = this.lineBuffer.slice(newlineIdx + 1);
-
-      if (!line) {
-        newlineIdx = this.lineBuffer.indexOf('\n');
-        continue;
-      }
-
-      // Try to parse as JSON
-      let event: Record<string, unknown>;
-      try {
-        event = JSON.parse(line);
-      } catch {
-        // Not JSON — could be ANSI escape or raw text leaking from PTY.
-        // Forward as raw so it's not lost.
-        if (!this.fence.isSuppressing) {
-          this.onEvent({ kind: 'raw', content: line });
-        }
-        newlineIdx = this.lineBuffer.indexOf('\n');
-        continue;
-      }
-
-      this.processEvent(event);
-      newlineIdx = this.lineBuffer.indexOf('\n');
-    }
+    this.lines.feed(chunk);
   }
 
   private processEvent(event: Record<string, unknown>): void {

--- a/packages/agents/src/providers/normalizers/codex-normalizer.ts
+++ b/packages/agents/src/providers/normalizers/codex-normalizer.ts
@@ -15,10 +15,11 @@
 import type { TerminalEvent } from '../../terminal-events';
 import { stripAnsi, summarizeTerminalText } from '../output-summary';
 import { FenceStateMachine } from './fence-suppression';
+import { LineBufferedJsonNormalizer } from './line-buffered-json-normalizer';
 
 export class CodexNormalizer {
-  private lineBuffer = '';
   private readonly fence: FenceStateMachine;
+  private readonly lines: LineBufferedJsonNormalizer;
   /** Track item IDs that received delta events (for dedup). */
   private deltaItemIds = new Set<string>();
   private readonly onEvent: (event: TerminalEvent) => void;
@@ -26,38 +27,19 @@ export class CodexNormalizer {
   constructor(onEvent: (event: TerminalEvent) => void) {
     this.onEvent = onEvent;
     this.fence = new FenceStateMachine(onEvent);
+    this.lines = new LineBufferedJsonNormalizer(
+      onEvent,
+      this.fence,
+      (line) => JSON.parse(stripAnsi(line)),
+      (event) => this.processEvent(event),
+    );
   }
 
   /**
    * Feed a raw PTY chunk. Lines may be split across chunks.
    */
   feed(chunk: string): void {
-    this.lineBuffer += chunk;
-
-    let newlineIdx = this.lineBuffer.indexOf('\n');
-    while (newlineIdx !== -1) {
-      const line = this.lineBuffer.slice(0, newlineIdx).trim();
-      this.lineBuffer = this.lineBuffer.slice(newlineIdx + 1);
-
-      if (!line) {
-        newlineIdx = this.lineBuffer.indexOf('\n');
-        continue;
-      }
-
-      let event: Record<string, unknown>;
-      try {
-        event = JSON.parse(stripAnsi(line));
-      } catch {
-        if (!this.fence.isSuppressing) {
-          this.onEvent({ kind: 'raw', content: line });
-        }
-        newlineIdx = this.lineBuffer.indexOf('\n');
-        continue;
-      }
-
-      this.processEvent(event);
-      newlineIdx = this.lineBuffer.indexOf('\n');
-    }
+    this.lines.feed(chunk);
   }
 
   private processEvent(event: Record<string, unknown>): void {

--- a/packages/agents/src/providers/normalizers/line-buffered-json-normalizer.ts
+++ b/packages/agents/src/providers/normalizers/line-buffered-json-normalizer.ts
@@ -1,0 +1,45 @@
+import type { TerminalEvent } from '../../terminal-events';
+import type { FenceStateMachine } from './fence-suppression';
+
+type ParseJsonLine = (line: string) => Record<string, unknown>;
+type ProcessJsonEvent = (event: Record<string, unknown>) => void;
+
+export class LineBufferedJsonNormalizer {
+  private lineBuffer = '';
+
+  constructor(
+    private readonly onEvent: (event: TerminalEvent) => void,
+    private readonly fence: FenceStateMachine,
+    private readonly parseJsonLine: ParseJsonLine,
+    private readonly processEvent: ProcessJsonEvent,
+  ) {}
+
+  feed(chunk: string): void {
+    this.lineBuffer += chunk;
+
+    let newlineIdx = this.lineBuffer.indexOf('\n');
+    while (newlineIdx !== -1) {
+      const line = this.lineBuffer.slice(0, newlineIdx).trim();
+      this.lineBuffer = this.lineBuffer.slice(newlineIdx + 1);
+
+      if (!line) {
+        newlineIdx = this.lineBuffer.indexOf('\n');
+        continue;
+      }
+
+      let event: Record<string, unknown>;
+      try {
+        event = this.parseJsonLine(line);
+      } catch {
+        if (!this.fence.isSuppressing) {
+          this.onEvent({ kind: 'raw', content: line });
+        }
+        newlineIdx = this.lineBuffer.indexOf('\n');
+        continue;
+      }
+
+      this.processEvent(event);
+      newlineIdx = this.lineBuffer.indexOf('\n');
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add a shared line-buffered JSON normalizer helper for Claude and Codex terminal normalizers.
- Preserve provider-specific parsing, ANSI stripping, fence suppression, and protocol event handling.

## Checks
- PASS: bun run --cwd packages/shared build
- PASS: bun test packages/agents/src/providers/normalizers/claude-normalizer.test.ts packages/agents/src/providers/normalizers/codex-normalizer.test.ts
- PASS: bunx biome check packages/agents/src/providers/normalizers/claude-normalizer.ts packages/agents/src/providers/normalizers/codex-normalizer.ts packages/agents/src/providers/normalizers/line-buffered-json-normalizer.ts packages/agents/src/providers/normalizers/claude-normalizer.test.ts packages/agents/src/providers/normalizers/codex-normalizer.test.ts
- PASS: bun run --cwd packages/agents typecheck