### PR TITLE
[codex] Sync linked PR review status

### DIFF
--- a/apps/desktop/src/main/ipc/helpers.test.ts
+++ b/apps/desktop/src/main/ipc/helpers.test.ts
@@ -9,6 +9,7 @@ import {
   enrichProjectPath,
   enrichProjectPaths,
   resolveIssuePhaseModels,
+  resolveLinkedPullRequestPipelineStatus,
   resolveProjectPhaseModels,
   sendGithubIssuesUpdated,
   syncLinkedPullRequestFeedback,
@@ -376,11 +377,27 @@ describe('syncLinkedPullRequestFeedback', () => {
       },
       githubIssues: {
         updatePullRequestFeedback: vi.fn(),
+        updatePipelineStatus: vi.fn(),
         setCachedLabelPresence: vi.fn(),
         reconcileCompletedFromEvidence: vi.fn(),
       },
       ...overrides,
     } as unknown as Queries;
+  }
+
+  function makeFeedback(overrides: Record<string, unknown> = {}) {
+    return {
+      number: 17,
+      url: 'https://github.com/acme/repo/pull/17',
+      isDraft: false,
+      state: 'OPEN',
+      reviewDecision: null,
+      reviewRequestCount: 0,
+      ciBlocked: false,
+      failingChecks: [],
+      unresolvedReviewComments: [],
+      ...overrides,
+    };
   }
 
   beforeEach(() => {
@@ -431,15 +448,45 @@ describe('syncLinkedPullRequestFeedback', () => {
     expect(queries.githubIssues.reconcileCompletedFromEvidence).toHaveBeenCalledWith('issue-1');
   });
 
+  it('clears stale PR review status labels when the linked PR disappears', async () => {
+    const queries = makeFeedbackQueries({
+      id: 'thread-1',
+      githubPrNumber: null,
+    });
+    const issue = makeIssue({
+      pipelineStatus: 'needs_review',
+      labels: ['shipcode:pipeline:needs_review'],
+      linkedPrNumber: 12,
+    });
+
+    await syncLinkedPullRequestFeedback(
+      makeProject() as never,
+      issue as never,
+      queries,
+      notificationService as never,
+      chatNotificationService as never,
+    );
+
+    expect(queries.githubIssues.updatePipelineStatus).toHaveBeenCalledWith('issue-1', 'completed');
+    expect(queries.githubIssues.setCachedLabelPresence).toHaveBeenCalledWith(
+      'issue-1',
+      'shipcode:pipeline:needs_review',
+      false,
+    );
+    expect(ghCliInstances[0]?.setIssueLabelPresence).toHaveBeenCalledWith(
+      42,
+      'shipcode:pipeline:needs_review',
+      false,
+    );
+  });
+
   it('syncs linked PR feedback and fires notifications when CI becomes blocked', async () => {
     const queries = makeFeedbackQueries({
       id: 'thread-1',
       githubPrNumber: 17,
     });
     ghCliGetPullRequestFeedbackMock.mockResolvedValueOnce({
-      number: 17,
-      url: 'https://github.com/acme/repo/pull/17',
-      isDraft: false,
+      ...makeFeedback(),
       ciBlocked: true,
       failingChecks: ['test'],
       unresolvedReviewComments: [{ id: 'comment-1' }],
@@ -492,9 +539,7 @@ describe('syncLinkedPullRequestFeedback', () => {
       },
     );
     ghCliGetPullRequestFeedbackMock.mockResolvedValueOnce({
-      number: 17,
-      url: 'https://github.com/acme/repo/pull/17',
-      isDraft: false,
+      ...makeFeedback(),
       ciBlocked: true,
       failingChecks: [
         {
@@ -553,9 +598,7 @@ describe('syncLinkedPullRequestFeedback', () => {
       githubPrNumber: 17,
     });
     ghCliGetPullRequestFeedbackMock.mockResolvedValueOnce({
-      number: 17,
-      url: 'https://github.com/acme/repo/pull/17',
-      isDraft: false,
+      ...makeFeedback(),
       ciBlocked: true,
       failingChecks: [],
       unresolvedReviewComments: [],
@@ -575,6 +618,135 @@ describe('syncLinkedPullRequestFeedback', () => {
       true,
     );
     expect(ghCliInstances[0]?.setIssueLabelPresence).not.toHaveBeenCalled();
+  });
+
+  it('moves linked issues to needs_review when a PR requires review', async () => {
+    const queries = makeFeedbackQueries({
+      id: 'thread-1',
+      githubPrNumber: 17,
+    });
+    ghCliGetPullRequestFeedbackMock.mockResolvedValueOnce(
+      makeFeedback({
+        reviewDecision: 'REVIEW_REQUIRED',
+        reviewRequestCount: 1,
+      }),
+    );
+
+    await syncLinkedPullRequestFeedback(
+      makeProject() as never,
+      makeIssue({ pipelineStatus: 'completed' }) as never,
+      queries,
+      notificationService as never,
+      chatNotificationService as never,
+    );
+
+    expect(queries.githubIssues.updatePipelineStatus).toHaveBeenCalledWith(
+      'issue-1',
+      'needs_review',
+    );
+    expect(queries.githubIssues.setCachedLabelPresence).toHaveBeenCalledWith(
+      'issue-1',
+      'shipcode:pipeline:needs_review',
+      true,
+    );
+    expect(ghCliInstances[0]?.setIssueLabelPresence).toHaveBeenCalledWith(
+      42,
+      'shipcode:pipeline:needs_review',
+      true,
+    );
+  });
+
+  it('moves approved linked PRs to ready_to_merge and removes stale review labels', async () => {
+    const queries = makeFeedbackQueries({
+      id: 'thread-1',
+      githubPrNumber: 17,
+    });
+    ghCliGetPullRequestFeedbackMock.mockResolvedValueOnce(
+      makeFeedback({
+        reviewDecision: 'APPROVED',
+      }),
+    );
+
+    await syncLinkedPullRequestFeedback(
+      makeProject() as never,
+      makeIssue({
+        pipelineStatus: 'needs_review',
+        labels: ['shipcode:pipeline:needs_review'],
+      }) as never,
+      queries,
+      notificationService as never,
+      chatNotificationService as never,
+    );
+
+    expect(queries.githubIssues.updatePipelineStatus).toHaveBeenCalledWith(
+      'issue-1',
+      'ready_to_merge',
+    );
+    expect(queries.githubIssues.setCachedLabelPresence).toHaveBeenCalledWith(
+      'issue-1',
+      'shipcode:pipeline:needs_review',
+      false,
+    );
+    expect(queries.githubIssues.setCachedLabelPresence).toHaveBeenCalledWith(
+      'issue-1',
+      'shipcode:pipeline:ready_to_merge',
+      true,
+    );
+    expect(ghCliInstances[0]?.setIssueLabelPresence).toHaveBeenCalledWith(
+      42,
+      'shipcode:pipeline:needs_review',
+      false,
+    );
+    expect(ghCliInstances[0]?.setIssueLabelPresence).toHaveBeenCalledWith(
+      42,
+      'shipcode:pipeline:ready_to_merge',
+      true,
+    );
+  });
+});
+
+describe('resolveLinkedPullRequestPipelineStatus', () => {
+  it('maps pull request review states to ShipCode issue statuses', () => {
+    expect(
+      resolveLinkedPullRequestPipelineStatus({
+        state: 'OPEN',
+        isDraft: true,
+        reviewDecision: null,
+        reviewRequestCount: 0,
+      }),
+    ).toBe('executing');
+    expect(
+      resolveLinkedPullRequestPipelineStatus({
+        state: 'OPEN',
+        isDraft: false,
+        reviewDecision: 'REVIEW_REQUIRED',
+        reviewRequestCount: 0,
+      }),
+    ).toBe('needs_review');
+    expect(
+      resolveLinkedPullRequestPipelineStatus({
+        state: 'OPEN',
+        isDraft: false,
+        reviewDecision: 'APPROVED',
+        reviewRequestCount: 0,
+      }),
+    ).toBe('ready_to_merge');
+    expect(
+      resolveLinkedPullRequestPipelineStatus({
+        state: 'MERGED',
+        isDraft: false,
+        reviewDecision: 'APPROVED',
+        reviewRequestCount: 0,
+      }),
+    ).toBe('completed');
+    expect(
+      resolveLinkedPullRequestPipelineStatus({
+        state: 'CLOSED',
+        isDraft: false,
+        reviewDecision: null,
+        reviewRequestCount: 0,
+      }),
+    ).toBe('executing');
   });
 });
 

--- a/apps/desktop/src/main/ipc/helpers.ts
+++ b/apps/desktop/src/main/ipc/helpers.ts
@@ -18,8 +18,12 @@ import {
   DEFAULT_SETTINGS,
   type ExecutorModel,
   type GeneratorCli,
+  type GitHubIssueCacheRecord,
+  ISSUE_PIPELINE_STATUS,
+  isPipelineStateLabel,
   type PipelinePhase,
   parseGithubProjectUrl,
+  pipelineLabelForStatus,
   type ReasoningEffort,
   resolveEffectivePhaseReasoningEffort,
   resolveEffectivePhaseReasoningEffortForIssue,
@@ -195,6 +199,55 @@ export function tryParsePlan(rawOutput: string): ShipCodePlan | null {
   return result.success ? result.data : null;
 }
 
+type LinkedPullRequestFeedback = Awaited<ReturnType<GhCli['getPullRequestFeedback']>>;
+const PR_REVIEW_PIPELINE_STATUSES = new Set<import('@shipcode/shared').IssuePipelineStatus>([
+  ISSUE_PIPELINE_STATUS.needsReview,
+  ISSUE_PIPELINE_STATUS.readyToMerge,
+]);
+
+export function resolveLinkedPullRequestPipelineStatus(
+  feedback: Pick<
+    LinkedPullRequestFeedback,
+    'isDraft' | 'state' | 'reviewDecision' | 'reviewRequestCount'
+  >,
+) {
+  if (feedback.state === 'MERGED') return ISSUE_PIPELINE_STATUS.completed;
+  if (feedback.state === 'CLOSED') return ISSUE_PIPELINE_STATUS.executing;
+  if (feedback.isDraft) return ISSUE_PIPELINE_STATUS.executing;
+  if (
+    feedback.reviewDecision === 'CHANGES_REQUESTED' ||
+    feedback.reviewDecision === 'REVIEW_REQUIRED' ||
+    feedback.reviewRequestCount > 0
+  ) {
+    return ISSUE_PIPELINE_STATUS.needsReview;
+  }
+  if (feedback.reviewDecision === 'APPROVED') return ISSUE_PIPELINE_STATUS.readyToMerge;
+  return ISSUE_PIPELINE_STATUS.completed;
+}
+
+async function syncCachedIssuePipelineLabel(
+  ghCli: GhCli,
+  issue: GitHubIssueCacheRecord,
+  queries: Queries,
+  status: import('@shipcode/shared').IssuePipelineStatus,
+): Promise<void> {
+  const targetLabel = pipelineLabelForStatus(status);
+  const staleLabels = new Set(issue.labels.filter(isPipelineStateLabel));
+  const currentStatusLabel = pipelineLabelForStatus(issue.pipelineStatus);
+  if (currentStatusLabel) staleLabels.add(currentStatusLabel);
+
+  for (const label of staleLabels) {
+    if (label === targetLabel) continue;
+    queries.githubIssues.setCachedLabelPresence(issue.id, label, false);
+    await ghCli.setIssueLabelPresence(issue.issueNumber, label, false);
+  }
+
+  if (targetLabel) {
+    queries.githubIssues.setCachedLabelPresence(issue.id, targetLabel, true);
+    await ghCli.setIssueLabelPresence(issue.issueNumber, targetLabel, true);
+  }
+}
+
 export async function syncLinkedPullRequestFeedback(
   project: import('@shipcode/shared').Project,
   issue: import('@shipcode/shared').GitHubIssueCacheRecord,
@@ -227,6 +280,10 @@ export async function syncLinkedPullRequestFeedback(
       queries.reviewFindings.supersedeOpen({ threadId: thread.id, source: 'pr_review' });
     }
     queries.githubIssues.reconcileCompletedFromEvidence(issue.id);
+    if (PR_REVIEW_PIPELINE_STATUSES.has(issue.pipelineStatus)) {
+      queries.githubIssues.updatePipelineStatus(issue.id, ISSUE_PIPELINE_STATUS.completed);
+      await syncCachedIssuePipelineLabel(ghCli, issue, queries, ISSUE_PIPELINE_STATUS.completed);
+    }
     return;
   }
 
@@ -240,6 +297,11 @@ export async function syncLinkedPullRequestFeedback(
     unresolvedReviewComments: feedback.unresolvedReviewComments,
   });
   queries.githubIssues.reconcileCompletedFromEvidence(issue.id);
+  const reviewStatus = resolveLinkedPullRequestPipelineStatus(feedback);
+  if (issue.pipelineStatus !== reviewStatus) {
+    queries.githubIssues.updatePipelineStatus(issue.id, reviewStatus);
+  }
+  await syncCachedIssuePipelineLabel(ghCli, issue, queries, reviewStatus);
   if (queries.reviewFindings) {
     const latestPlan = queries.plans.getLatest(thread.id);
     const findings = buildPullRequestFeedbackFindingInputs({

--- a/apps/desktop/src/renderer/features/project/issue-graph-node.tsx
+++ b/apps/desktop/src/renderer/features/project/issue-graph-node.tsx
@@ -12,6 +12,8 @@ const STATUS_STYLES: Record<IssuePipelineStatus, string> = {
   reviewing: 'border-agent/60 bg-elevated',
   revising: 'border-agent/60 bg-elevated',
   approval: 'border-warning/60 bg-elevated',
+  needs_review: 'border-warning/60 bg-elevated',
+  ready_to_merge: 'border-warning/60 bg-elevated',
   paused: 'border-warning/60 bg-elevated',
   executing: 'border-success/60 bg-elevated',
   testing: 'border-success/60 bg-elevated',

--- a/packages/shared/src/github-labels.test.ts
+++ b/packages/shared/src/github-labels.test.ts
@@ -119,6 +119,12 @@ describe('pipelineLabelForStatus', () => {
     expect(pipelineLabelForStatus(ISSUE_PIPELINE_STATUS.shipping)).toBe(
       'shipcode:pipeline:shipping',
     );
+    expect(pipelineLabelForStatus(ISSUE_PIPELINE_STATUS.needsReview)).toBe(
+      'shipcode:pipeline:needs_review',
+    );
+    expect(pipelineLabelForStatus(ISSUE_PIPELINE_STATUS.readyToMerge)).toBe(
+      'shipcode:pipeline:ready_to_merge',
+    );
     expect(pipelineLabelForStatus(ISSUE_PIPELINE_STATUS.clarifying)).toBe(
       'shipcode:pipeline:clarifying',
     );
@@ -204,6 +210,8 @@ describe('macroColumnForStatus', () => {
   it('maps human-review statuses → human_review', () => {
     expect(macroColumnForStatus(ISSUE_PIPELINE_STATUS.clarifying)).toBe('human_review');
     expect(macroColumnForStatus(ISSUE_PIPELINE_STATUS.approval)).toBe('human_review');
+    expect(macroColumnForStatus(ISSUE_PIPELINE_STATUS.needsReview)).toBe('human_review');
+    expect(macroColumnForStatus(ISSUE_PIPELINE_STATUS.readyToMerge)).toBe('human_review');
     expect(macroColumnForStatus(ISSUE_PIPELINE_STATUS.paused)).toBe('human_review');
     expect(macroColumnForStatus(ISSUE_PIPELINE_STATUS.failed)).toBe('human_review');
   });

--- a/packages/shared/src/github-labels.ts
+++ b/packages/shared/src/github-labels.ts
@@ -53,6 +53,8 @@ const PIPELINE_LABEL_STATUS_PRIORITY: readonly IssuePipelineStatus[] = [
   ISSUE_PIPELINE_STATUS.executing,
   ISSUE_PIPELINE_STATUS.revising,
   ISSUE_PIPELINE_STATUS.reviewing,
+  ISSUE_PIPELINE_STATUS.readyToMerge,
+  ISSUE_PIPELINE_STATUS.needsReview,
   ISSUE_PIPELINE_STATUS.clarifying,
   ISSUE_PIPELINE_STATUS.planning,
   ISSUE_PIPELINE_STATUS.queued,
@@ -190,6 +192,16 @@ export const SHIPCODE_PIPELINE_LABELS: readonly GitHubLabelDefinition[] = [
     description: 'Pipeline is paused and can be resumed.',
   },
   {
+    name: 'shipcode:pipeline:needs_review',
+    color: 'd4c5f9',
+    description: 'Linked PR is waiting on review attention.',
+  },
+  {
+    name: 'shipcode:pipeline:ready_to_merge',
+    color: '0e8a16',
+    description: 'Linked PR is approved and ready to merge.',
+  },
+  {
     name: 'shipcode:pipeline:failed',
     color: 'b60205',
     description: 'Pipeline encountered an error.',
@@ -226,6 +238,8 @@ const HUMAN_STATUSES = new Set<IssuePipelineStatus>([
   ISSUE_PIPELINE_STATUS.approval,
   ISSUE_PIPELINE_STATUS.paused,
   ISSUE_PIPELINE_STATUS.failed,
+  ISSUE_PIPELINE_STATUS.needsReview,
+  ISSUE_PIPELINE_STATUS.readyToMerge,
 ]);
 
 const DONE_STATUSES = new Set<IssuePipelineStatus>([
@@ -276,6 +290,10 @@ export function pipelineLabelForStatus(
       return 'shipcode:pipeline:shipping';
     case ISSUE_PIPELINE_STATUS.paused:
       return 'shipcode:pipeline:paused';
+    case ISSUE_PIPELINE_STATUS.needsReview:
+      return 'shipcode:pipeline:needs_review';
+    case ISSUE_PIPELINE_STATUS.readyToMerge:
+      return 'shipcode:pipeline:ready_to_merge';
     case ISSUE_PIPELINE_STATUS.failed:
       return 'shipcode:pipeline:failed';
     default:

--- a/packages/shared/src/pipeline-utils.ts
+++ b/packages/shared/src/pipeline-utils.ts
@@ -24,6 +24,8 @@ export function phaseToProgress(phase: PipelinePhase | IssuePipelineStatus): num
     [PIPELINE_PHASE.testing]: 82,
     [PIPELINE_PHASE.verifying]: 90,
     [PIPELINE_PHASE.shipping]: 96,
+    [ISSUE_PIPELINE_STATUS.needsReview]: 92,
+    [ISSUE_PIPELINE_STATUS.readyToMerge]: 96,
     [PIPELINE_PHASE.paused]: 72,
     [PIPELINE_PHASE.completed]: 92,
     [ISSUE_PIPELINE_STATUS.closed]: 100,

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -1674,6 +1674,8 @@ export const ISSUE_PIPELINE_STATUS = {
   testing: PIPELINE_PHASE.testing,
   verifying: PIPELINE_PHASE.verifying,
   shipping: PIPELINE_PHASE.shipping,
+  needsReview: 'needs_review',
+  readyToMerge: 'ready_to_merge',
   paused: PIPELINE_PHASE.paused,
   completed: PIPELINE_PHASE.completed,
   closed: 'closed',

--- a/packages/ui/src/kanban-board/constants.test.ts
+++ b/packages/ui/src/kanban-board/constants.test.ts
@@ -22,6 +22,20 @@ describe('kanban board phase constants', () => {
     expect(PHASE_ELAPSED_STATUSES).toContain('testing');
   });
 
+  it('groups PR review statuses under the attention column', () => {
+    const humanColumn = COLUMNS.find((column) => column.key === 'human');
+
+    expect(humanColumn?.statuses).toEqual(
+      expect.arrayContaining(['needs_review', 'ready_to_merge']),
+    );
+    expect(humanColumn?.sections).toContainEqual({
+      key: 'pr_review',
+      label: 'PR Review',
+      statuses: ['needs_review', 'ready_to_merge'],
+      droppable: false,
+    });
+  });
+
   it('only shows elapsed timers for agent-loop phases', () => {
     expect(PHASE_ELAPSED_STATUSES).toEqual(ACTIVE_STATUSES);
     expect(PHASE_ELAPSED_STATUSES).not.toContain('approval');

--- a/packages/ui/src/kanban-board/constants.ts
+++ b/packages/ui/src/kanban-board/constants.ts
@@ -72,6 +72,8 @@ export const COLUMNS: BoardColumn[] = [
     statuses: [
       ISSUE_PIPELINE_STATUS.clarifying,
       ISSUE_PIPELINE_STATUS.approval,
+      ISSUE_PIPELINE_STATUS.needsReview,
+      ISSUE_PIPELINE_STATUS.readyToMerge,
       ISSUE_PIPELINE_STATUS.paused,
       ISSUE_PIPELINE_STATUS.failed,
     ],
@@ -86,6 +88,12 @@ export const COLUMNS: BoardColumn[] = [
         key: 'approval',
         label: 'Approval',
         statuses: [ISSUE_PIPELINE_STATUS.approval],
+        droppable: false,
+      },
+      {
+        key: 'pr_review',
+        label: 'PR Review',
+        statuses: [ISSUE_PIPELINE_STATUS.needsReview, ISSUE_PIPELINE_STATUS.readyToMerge],
         droppable: false,
       },
       {


### PR DESCRIPTION
## Summary

Addresses #81 by adding ShipCode-native PR review pipeline states for linked pull requests.

- adds `needs_review` and `ready_to_merge` issue pipeline statuses plus `shipcode:pipeline:*` labels
- derives linked PR review status from existing PR feedback sync and updates cached issue state/labels idempotently
- groups PR review statuses under the Kanban Attention column and covers graph styling

## Validation

- `bunx biome check apps/desktop/src/main/ipc/helpers.ts apps/desktop/src/main/ipc/helpers.test.ts apps/desktop/src/renderer/features/project/issue-graph-node.tsx packages/shared/src/github-labels.ts packages/shared/src/github-labels.test.ts packages/shared/src/pipeline-utils.ts packages/shared/src/types.ts packages/ui/src/kanban-board/constants.ts packages/ui/src/kanban-board/constants.test.ts --assist-enabled=false --files-ignore-unknown=true`
- `bunx vitest run src/github-labels.test.ts` from `packages/shared`
- `bunx vitest run src/kanban-board/constants.test.ts` from `packages/ui`
- `bunx vitest run src/main/ipc/helpers.test.ts` from `apps/desktop`
- `bun --filter @shipcode/shared typecheck`
- `bun --filter @shipcode/ui typecheck`
- `bun --filter @shipcode/desktop typecheck`

Note: attempted Mac Studio validation, but that host has no ShipCode checkout at the expected path and no `shipcode` directory under `/Users/decod3rs`; the actual narrow checks were run locally.