### PR TITLE
refactor(agents): extract shared stdin CLI response builder

### DIFF
--- a/packages/agents/src/providers/cursor-cli-provider.ts
+++ b/packages/agents/src/providers/cursor-cli-provider.ts
@@ -1,7 +1,12 @@
 import type { ProcessManager } from '../process-manager';
-import { measurePromptPayload } from '../prompt-scope';
 import { firstString } from './output-summary';
-import { clampCliFailure, runStdinCli, type StdinCliCommand, stripAnsi } from './stdin-cli-runner';
+import {
+  buildStdinCliResponse,
+  clampCliFailure,
+  runStdinCli,
+  type StdinCliCommand,
+  stripAnsi,
+} from './stdin-cli-runner';
 import type { AgentProvider, ProviderPhase, ProviderRequest, ProviderResponse } from './types';
 
 const CURSOR_ENV_KEYS = [
@@ -107,46 +112,10 @@ export function createCursorCliProvider(processManager: ProcessManager): AgentPr
         lifecycleMessage: 'Cursor CLI started',
         unavailableMessage: 'Cursor CLI stdin execution is unavailable',
       });
-      const parsed = parseCursorOutput(result.rawOutput);
-      const promptTelemetry = {
-        phase: req.phase,
-        promptSize: measurePromptPayload(req.prompt),
-        ...(req.promptMaterialSummary ? { selectedMaterials: req.promptMaterialSummary } : {}),
-      };
-
-      return {
-        rawOutput: parsed.text,
-        exitCode: result.exitCode,
-        promptTelemetry,
-        ...(parsed.resolvedModel ? { resolvedModel: parsed.resolvedModel } : {}),
-        ...(result.exitCode === 127
-          ? {
-              providerError: {
-                kind: 'binary_missing' as const,
-                message: 'cursor-agent CLI not found on PATH',
-                retryable: false,
-              },
-            }
-          : result.exitCode === 130
-            ? { providerError: { kind: 'aborted' as const, message: 'aborted', retryable: false } }
-            : result.unavailable
-              ? {
-                  providerError: {
-                    kind: 'unknown' as const,
-                    message: clampCursorFailure(result.rawOutput, req.prompt),
-                    retryable: false,
-                  },
-                }
-              : result.exitCode !== 0
-                ? {
-                    providerError: {
-                      kind: 'unknown' as const,
-                      message: clampCursorFailure(result.rawOutput, req.prompt),
-                      retryable: true,
-                    },
-                  }
-                : {}),
-      };
+      return buildStdinCliResponse(req, result, parseCursorOutput(result.rawOutput), {
+        binaryMissingMessage: 'cursor-agent CLI not found on PATH',
+        clampFailure: clampCursorFailure,
+      });
     },
     async healthCheck() {
       return { ok: true };

--- a/packages/agents/src/providers/gemini-cli-provider.ts
+++ b/packages/agents/src/providers/gemini-cli-provider.ts
@@ -1,7 +1,12 @@
 import type { ProcessManager } from '../process-manager';
-import { measurePromptPayload } from '../prompt-scope';
 import { firstString } from './output-summary';
-import { clampCliFailure, runStdinCli, type StdinCliCommand, stripAnsi } from './stdin-cli-runner';
+import {
+  buildStdinCliResponse,
+  clampCliFailure,
+  runStdinCli,
+  type StdinCliCommand,
+  stripAnsi,
+} from './stdin-cli-runner';
 import type { AgentProvider, ProviderPhase, ProviderRequest, ProviderResponse } from './types';
 
 const GEMINI_ENV_KEYS = [
@@ -75,46 +80,10 @@ export function createGeminiCliProvider(processManager: ProcessManager): AgentPr
         lifecycleMessage: 'Gemini CLI started',
         unavailableMessage: 'Gemini CLI stdin execution is unavailable',
       });
-      const parsed = parseGeminiOutput(result.rawOutput);
-      const promptTelemetry = {
-        phase: req.phase,
-        promptSize: measurePromptPayload(req.prompt),
-        ...(req.promptMaterialSummary ? { selectedMaterials: req.promptMaterialSummary } : {}),
-      };
-
-      return {
-        rawOutput: parsed.text,
-        exitCode: result.exitCode,
-        promptTelemetry,
-        ...(parsed.resolvedModel ? { resolvedModel: parsed.resolvedModel } : {}),
-        ...(result.exitCode === 127
-          ? {
-              providerError: {
-                kind: 'binary_missing' as const,
-                message: 'gemini CLI not found on PATH',
-                retryable: false,
-              },
-            }
-          : result.exitCode === 130
-            ? { providerError: { kind: 'aborted' as const, message: 'aborted', retryable: false } }
-            : result.unavailable
-              ? {
-                  providerError: {
-                    kind: 'unknown' as const,
-                    message: clampGeminiFailure(result.rawOutput, req.prompt),
-                    retryable: false,
-                  },
-                }
-              : result.exitCode !== 0
-                ? {
-                    providerError: {
-                      kind: 'unknown' as const,
-                      message: clampGeminiFailure(result.rawOutput, req.prompt),
-                      retryable: true,
-                    },
-                  }
-                : {}),
-      };
+      return buildStdinCliResponse(req, result, parseGeminiOutput(result.rawOutput), {
+        binaryMissingMessage: 'gemini CLI not found on PATH',
+        clampFailure: clampGeminiFailure,
+      });
     },
     async healthCheck() {
       return { ok: true };

--- a/packages/agents/src/providers/stdin-cli-runner.ts
+++ b/packages/agents/src/providers/stdin-cli-runner.ts
@@ -1,6 +1,7 @@
 import type { AgentType } from '@shipcode/shared';
 import type { ProcessManager } from '../process-manager';
-import type { ProviderRequest } from './types';
+import { measurePromptPayload } from '../prompt-scope';
+import type { ProviderRequest, ProviderResponse } from './types';
 
 export interface StdinCliCommand {
   args: string[];
@@ -127,4 +128,65 @@ export function clampCliFailure(rawOutput: string, prompt: string, fallback: str
     lines.find((entry) => /\b(error|failed|unauthorized|auth|permission|denied)\b/i.test(entry)) ??
     lines[0];
   return (line ?? fallback).slice(0, 280);
+}
+
+/**
+ * Assemble the canonical `ProviderResponse` shared by stdin-based CLI providers
+ * (gemini, cursor). They run identically through {@link runStdinCli} and differ
+ * only in how output is parsed plus their binary name / failure label, so the
+ * telemetry block, parsed-text/resolvedModel forwarding, and the exit-code →
+ * `providerError` cascade are factored out here:
+ *   - 127 → `binary_missing` (non-retryable)
+ *   - 130 → `aborted` (non-retryable)
+ *   - unavailable (no stdin spawn support) → `unknown` (non-retryable)
+ *   - any other non-zero → `unknown` (retryable)
+ */
+export function buildStdinCliResponse(
+  req: ProviderRequest,
+  result: StdinCliRunResult,
+  parsed: { text: string; resolvedModel?: string },
+  config: {
+    binaryMissingMessage: string;
+    clampFailure: (rawOutput: string, prompt: string) => string;
+  },
+): ProviderResponse {
+  const promptTelemetry = {
+    phase: req.phase,
+    promptSize: measurePromptPayload(req.prompt),
+    ...(req.promptMaterialSummary ? { selectedMaterials: req.promptMaterialSummary } : {}),
+  };
+
+  return {
+    rawOutput: parsed.text,
+    exitCode: result.exitCode,
+    promptTelemetry,
+    ...(parsed.resolvedModel ? { resolvedModel: parsed.resolvedModel } : {}),
+    ...(result.exitCode === 127
+      ? {
+          providerError: {
+            kind: 'binary_missing' as const,
+            message: config.binaryMissingMessage,
+            retryable: false,
+          },
+        }
+      : result.exitCode === 130
+        ? { providerError: { kind: 'aborted' as const, message: 'aborted', retryable: false } }
+        : result.unavailable
+          ? {
+              providerError: {
+                kind: 'unknown' as const,
+                message: config.clampFailure(result.rawOutput, req.prompt),
+                retryable: false,
+              },
+            }
+          : result.exitCode !== 0
+            ? {
+                providerError: {
+                  kind: 'unknown' as const,
+                  message: config.clampFailure(result.rawOutput, req.prompt),
+                  retryable: true,
+                },
+              }
+            : {}),
+  };
 }


### PR DESCRIPTION
## What

The gemini and cursor CLI providers run identically through \`runStdinCli\` and each duplicated the full \`ProviderResponse\` assembly in their \`generate()\`:

- prompt telemetry construction (\`phase\` / \`promptSize\` / conditional \`selectedMaterials\`)
- parsed \`text\` + optional \`resolvedModel\` forwarding
- the exit-code → \`providerError\` cascade: \`127\` binary_missing · \`130\` aborted · \`unavailable\` unknown(non-retryable) · other non-zero unknown(retryable)

Only the binary name and the failure label differed between them (~40 duplicated lines each).

## Change

Factor that block into \`buildStdinCliResponse()\` in \`stdin-cli-runner.ts\` — its natural home, right next to \`runStdinCli\`. Each provider's \`generate()\` now ends with a single call passing its own \`binaryMissingMessage\` and \`clampFailure\` wrapper.

Parsers, command builders, env-key allowlists, and the \`_internals\` test surface are untouched, so behavior is byte-for-byte identical.

## Verification (Mac Studio)

- \`biome check\` on touched files — clean
- \`@shipcode/agents\` typecheck — clean
- Provider tests: \`gemini-cli-provider\` (15), \`cursor-cli-provider\` (20), \`cli-provider\` (52) — **87 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization and consistency across provider implementations to reduce duplication and enhance maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->