### PR TITLE
feat(pipeline): hot-reload WORKFLOW.md on change (#71)

### DIFF
--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -124,6 +124,7 @@ import { PipelineScheduler } from './pipeline-scheduler';
 import { ResourceMonitor } from './resource-monitor';
 import { SplashScreen } from './splash-screen';
 import { UpdateService } from './update-service';
+import { WorkflowWatchManager } from './workflow-watch-manager';
 
 let mainWindow: BrowserWindow | null = null;
 let processManager: ProcessManager | null = null;
@@ -357,6 +358,25 @@ function createWindow() {
   });
   reconciliationLoop.start();
 
+  // Hot-reload WORKFLOW.md: watch each project's workflow file and refresh the
+  // shared policy cache on change so prompt/concurrency edits apply to the next
+  // pipeline without an app restart. In-flight pipelines keep their snapshot.
+  const workflowWatchManager = new WorkflowWatchManager({
+    onReload: (event) => {
+      if (event.ok) {
+        log.info(`[workflow-watch] reloaded ${event.path ?? '(none)'}`);
+      } else {
+        log.warn(`[workflow-watch] reload failed: ${event.warning?.message ?? 'unknown error'}`);
+      }
+      mainWindow?.webContents.send('workflow:reloaded', {
+        path: event.path,
+        ok: event.ok,
+        warning: event.warning?.message ?? null,
+      });
+    },
+  });
+  workflowWatchManager.sync(queries.projects.listVisible().map((project) => project.path));
+
   // Queue promotion: start the next queued issue when a pipeline slot opens.
   onPipelineTerminal = (event) => {
     try {
@@ -512,6 +532,7 @@ function createWindow() {
   mainWindow.on('closed', () => {
     clearInterval(watchdogTimer);
     reconciliationLoop.stop();
+    workflowWatchManager.dispose();
     updateService?.stop();
     updateService = null;
     mainWindow = null;

--- a/apps/desktop/src/main/workflow-watch-manager.test.ts
+++ b/apps/desktop/src/main/workflow-watch-manager.test.ts
@@ -1,0 +1,72 @@
+import type { CreateWorkflowWatcherOptions, WorkflowWatcher } from '@shipcode/pipeline';
+import { describe, expect, it, vi } from 'vitest';
+import { WorkflowWatchManager } from './workflow-watch-manager';
+
+function setup() {
+  const created: Array<{ repoPath: string; close: ReturnType<typeof vi.fn> }> = [];
+  const createWatcher = vi.fn((options: CreateWorkflowWatcherOptions): WorkflowWatcher => {
+    const close = vi.fn();
+    created.push({ repoPath: options.repoPath, close });
+    return { close };
+  });
+  const onReload = vi.fn();
+  const manager = new WorkflowWatchManager({ onReload, createWatcher });
+  return { manager, createWatcher, created, onReload };
+}
+
+describe('WorkflowWatchManager', () => {
+  it('creates one watcher per project path', () => {
+    const { manager, createWatcher, created, onReload } = setup();
+
+    manager.sync(['/a', '/b']);
+
+    expect(created.map((w) => w.repoPath)).toEqual(['/a', '/b']);
+    expect(createWatcher).toHaveBeenCalledWith(
+      expect.objectContaining({ repoPath: '/a', onReload }),
+    );
+  });
+
+  it('is idempotent — re-syncing the same paths creates no new watchers', () => {
+    const { manager, createWatcher, created } = setup();
+
+    manager.sync(['/a', '/b']);
+    manager.sync(['/a', '/b']);
+
+    expect(createWatcher).toHaveBeenCalledTimes(2);
+    expect(created.every((w) => !w.close.mock.calls.length)).toBe(true);
+  });
+
+  it('closes watchers for paths that disappear and keeps the rest', () => {
+    const { manager, created } = setup();
+
+    manager.sync(['/a', '/b']);
+    manager.sync(['/a']);
+
+    const a = created.find((w) => w.repoPath === '/a');
+    const b = created.find((w) => w.repoPath === '/b');
+    expect(b?.close).toHaveBeenCalledTimes(1);
+    expect(a?.close).not.toHaveBeenCalled();
+  });
+
+  it('adds a watcher for a newly-appearing path', () => {
+    const { manager, created } = setup();
+
+    manager.sync(['/a']);
+    manager.sync(['/a', '/c']);
+
+    expect(created.map((w) => w.repoPath)).toEqual(['/a', '/c']);
+  });
+
+  it('dispose() closes every watcher and clears state', () => {
+    const { manager, created } = setup();
+
+    manager.sync(['/a', '/b']);
+    manager.dispose();
+
+    expect(created.every((w) => w.close.mock.calls.length === 1)).toBe(true);
+
+    // After dispose, a fresh sync re-creates watchers rather than reusing closed ones.
+    manager.sync(['/a']);
+    expect(created.filter((w) => w.repoPath === '/a')).toHaveLength(2);
+  });
+});

--- a/apps/desktop/src/main/workflow-watch-manager.ts
+++ b/apps/desktop/src/main/workflow-watch-manager.ts
@@ -1,0 +1,52 @@
+import {
+  type CreateWorkflowWatcherOptions,
+  createWorkflowWatcher,
+  type WorkflowReloadEvent,
+  type WorkflowWatcher,
+} from '@shipcode/pipeline';
+
+interface WorkflowWatchManagerDeps {
+  /** Invoked for every reload (success or failure) across all watched projects. */
+  onReload: (event: WorkflowReloadEvent) => void;
+  /** Injectable for tests; defaults to the real pipeline watcher. */
+  createWatcher?: (options: CreateWorkflowWatcherOptions) => WorkflowWatcher;
+}
+
+/**
+ * Owns one WORKFLOW.md watcher per project repo path. The app lifecycle calls
+ * {@link sync} with the current set of project paths (at startup, and whenever
+ * the project list changes) and {@link dispose} on teardown. Reloads invalidate
+ * the shared workflow-policy cache so the next dispatch/reconcile tick picks up
+ * edits without an app restart.
+ */
+export class WorkflowWatchManager {
+  private readonly watchers = new Map<string, WorkflowWatcher>();
+  private readonly createWatcher: (options: CreateWorkflowWatcherOptions) => WorkflowWatcher;
+
+  constructor(private readonly deps: WorkflowWatchManagerDeps) {
+    this.createWatcher = deps.createWatcher ?? createWorkflowWatcher;
+  }
+
+  /** Add watchers for new paths and remove watchers for paths no longer present. */
+  sync(projectPaths: readonly string[]): void {
+    const desired = new Set(projectPaths);
+
+    for (const [repoPath, watcher] of this.watchers) {
+      if (!desired.has(repoPath)) {
+        watcher.close();
+        this.watchers.delete(repoPath);
+      }
+    }
+
+    for (const repoPath of desired) {
+      if (this.watchers.has(repoPath)) continue;
+      this.watchers.set(repoPath, this.createWatcher({ repoPath, onReload: this.deps.onReload }));
+    }
+  }
+
+  /** Stop and forget every watcher. Idempotent. */
+  dispose(): void {
+    for (const watcher of this.watchers.values()) watcher.close();
+    this.watchers.clear();
+  }
+}

--- a/apps/desktop/src/renderer/hooks/useIpc.ts
+++ b/apps/desktop/src/renderer/hooks/useIpc.ts
@@ -11,6 +11,7 @@ import {
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { useAppStore } from '../stores/app-store';
+import { toast } from '../stores/toast-store';
 
 const TERMINAL_EVENT_BATCH_MS = 50;
 const LAST_ACTIVITY_THROTTLE_MS = 500;
@@ -253,6 +254,16 @@ export function useIpc() {
             activeIssue: refreshed,
             activeThreadId: refreshed?.threadId ?? state.activeThreadId,
           }));
+        }
+      }),
+    );
+
+    unsubscribers.push(
+      window.shipcode.on('workflow:reloaded', (data) => {
+        if (data.ok) {
+          toast.info('WORKFLOW.md reloaded', 'New config applies to the next pipeline.');
+        } else {
+          toast.error('WORKFLOW.md reload failed', data.warning ?? 'Kept the previous config.');
         }
       }),
     );

--- a/packages/pipeline/src/index.ts
+++ b/packages/pipeline/src/index.ts
@@ -53,3 +53,11 @@ export {
   parseWorkflowPolicy,
   resolveWorkflowPath,
 } from './workflow-loader';
+export type {
+  CreateWorkflowWatcherOptions,
+  WorkflowReloadEvent,
+  WorkflowWatcher,
+  WorkflowWatchFactory,
+  WorkflowWatchHandle,
+} from './workflow-watcher';
+export { createWorkflowWatcher, DEFAULT_WORKFLOW_RELOAD_DEBOUNCE_MS } from './workflow-watcher';

--- a/packages/pipeline/src/workflow-loader.ts
+++ b/packages/pipeline/src/workflow-loader.ts
@@ -239,6 +239,41 @@ function _loadWorkflowPolicyUncached(repoPath: string): WorkflowPolicy {
 }
 
 /**
+ * Reload a repo's WORKFLOW policy from disk WITHOUT touching the cache.
+ *
+ * The workflow watcher uses this to compute a *candidate* policy on a file
+ * change so it can decide whether to commit it (valid) or preserve the
+ * last-known-good (invalid) — a plain `loadWorkflowPolicy` would otherwise
+ * cache an invalid result.
+ */
+export function loadWorkflowPolicyUncached(repoPath: string): WorkflowPolicy {
+  return _loadWorkflowPolicyUncached(repoPath);
+}
+
+/**
+ * Return the currently cached policy for a repo without extending its TTL, or
+ * null when nothing is cached. The watcher captures this as the last-known-good
+ * policy before attempting a reload.
+ */
+export function peekWorkflowPolicyCache(repoPath: string): WorkflowPolicy | null {
+  return _policyCache.get(repoPath)?.policy ?? null;
+}
+
+/**
+ * Overwrite the cached policy for a repo and reset its TTL. The watcher uses
+ * this to apply a fresh policy immediately — so the next dispatch/reconcile tick
+ * sees the edit without waiting out the 30s TTL — or to re-assert the prior
+ * policy after a failed reload.
+ */
+export function setWorkflowPolicyCache(
+  repoPath: string,
+  policy: WorkflowPolicy,
+  now: number = Date.now(),
+): void {
+  _policyCache.set(repoPath, { policy, expiresAt: now + POLICY_CACHE_TTL_MS });
+}
+
+/**
  * Exported for cache eviction tests.
  *
  * @knipignore

--- a/packages/pipeline/src/workflow-watcher.test.ts
+++ b/packages/pipeline/src/workflow-watcher.test.ts
@@ -1,0 +1,253 @@
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import { DEFAULT_WORKFLOW_POLICY, type WorkflowPolicy } from './workflow-loader';
+import {
+  createWorkflowWatcher,
+  type WorkflowReloadEvent,
+  type WorkflowWatchFactory,
+} from './workflow-watcher';
+
+const REPO = '/repo';
+
+function validPolicy(overrides: Partial<WorkflowPolicy> = {}): WorkflowPolicy {
+  return {
+    ...DEFAULT_WORKFLOW_POLICY,
+    path: path.join(REPO, '.shipcode', 'WORKFLOW.md'),
+    promptTemplate: 'do the thing',
+    ...overrides,
+  };
+}
+
+function invalidPolicy(): WorkflowPolicy {
+  const sourcePath = path.join(REPO, '.shipcode', 'WORKFLOW.md');
+  return {
+    ...DEFAULT_WORKFLOW_POLICY,
+    path: sourcePath,
+    warning: {
+      code: 'workflow_parse_error',
+      message: 'bad yaml',
+      path: sourcePath,
+    },
+  };
+}
+
+/** A controllable fake clock for the debounce timer. */
+function fakeTimers() {
+  let nextId = 1;
+  const timers = new Map<number, () => void>();
+  return {
+    setTimeoutFn: ((handler: () => void) => {
+      const id = nextId++;
+      timers.set(id, handler);
+      return id as unknown as ReturnType<typeof setTimeout>;
+    }) as (handler: () => void, ms: number) => ReturnType<typeof setTimeout>,
+    clearTimeoutFn: (handle: ReturnType<typeof setTimeout>) => {
+      timers.delete(handle as unknown as number);
+    },
+    /** Fire all currently-scheduled timers (in scheduling order). */
+    flush: () => {
+      const handlers = [...timers.values()];
+      timers.clear();
+      for (const handler of handlers) handler();
+    },
+    pendingCount: () => timers.size,
+  };
+}
+
+/** A fake watch factory that records watched dirs and lets a test trigger changes. */
+function fakeWatch() {
+  const watchedDirs: string[] = [];
+  const closedDirs: string[] = [];
+  let changeHandler: (() => void) | null = null;
+  const factory: WorkflowWatchFactory = (dir, onChange) => {
+    watchedDirs.push(dir);
+    changeHandler = onChange;
+    return { close: () => closedDirs.push(dir) };
+  };
+  return {
+    factory,
+    watchedDirs,
+    closedDirs,
+    trigger: () => changeHandler?.(),
+  };
+}
+
+describe('createWorkflowWatcher', () => {
+  it('watches the repo root and the .shipcode directory', () => {
+    const watch = fakeWatch();
+    const timers = fakeTimers();
+
+    createWorkflowWatcher({
+      repoPath: REPO,
+      onReload: vi.fn(),
+      watchFactory: watch.factory,
+      loadUncached: vi.fn(() => validPolicy()),
+      peekCache: vi.fn(() => null),
+      setCache: vi.fn(),
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+
+    expect(watch.watchedDirs).toEqual([REPO, path.join(REPO, '.shipcode')]);
+  });
+
+  it('applies a valid reload to the cache and emits ok', () => {
+    const watch = fakeWatch();
+    const timers = fakeTimers();
+    const onReload = vi.fn<(event: WorkflowReloadEvent) => void>();
+    const setCache = vi.fn();
+    const fresh = validPolicy({ promptTemplate: 'updated prompt' });
+
+    createWorkflowWatcher({
+      repoPath: REPO,
+      onReload,
+      watchFactory: watch.factory,
+      loadUncached: vi.fn(() => fresh),
+      peekCache: vi.fn(() => validPolicy()),
+      setCache,
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+
+    watch.trigger();
+    timers.flush();
+
+    expect(setCache).toHaveBeenCalledWith(REPO, fresh);
+    expect(onReload).toHaveBeenCalledTimes(1);
+    expect(onReload.mock.calls[0]?.[0]).toMatchObject({
+      repoPath: REPO,
+      ok: true,
+      policy: fresh,
+      warning: null,
+    });
+  });
+
+  it('coalesces rapid changes into a single debounced reload', () => {
+    const watch = fakeWatch();
+    const timers = fakeTimers();
+    const onReload = vi.fn();
+    const loadUncached = vi.fn(() => validPolicy());
+
+    createWorkflowWatcher({
+      repoPath: REPO,
+      onReload,
+      watchFactory: watch.factory,
+      loadUncached,
+      peekCache: vi.fn(() => null),
+      setCache: vi.fn(),
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+
+    watch.trigger();
+    watch.trigger();
+    watch.trigger();
+    // Only the last timer should remain scheduled (earlier ones cleared).
+    expect(timers.pendingCount()).toBe(1);
+
+    timers.flush();
+
+    expect(loadUncached).toHaveBeenCalledTimes(1);
+    expect(onReload).toHaveBeenCalledTimes(1);
+  });
+
+  it('preserves the prior policy on an invalid reload', () => {
+    const watch = fakeWatch();
+    const timers = fakeTimers();
+    const onReload = vi.fn<(event: WorkflowReloadEvent) => void>();
+    const setCache = vi.fn();
+    const prior = validPolicy({ promptTemplate: 'known good' });
+
+    createWorkflowWatcher({
+      repoPath: REPO,
+      onReload,
+      watchFactory: watch.factory,
+      loadUncached: vi.fn(() => invalidPolicy()),
+      peekCache: vi.fn(() => prior),
+      setCache,
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+
+    watch.trigger();
+    timers.flush();
+
+    // The known-good policy is re-asserted; the invalid candidate is discarded.
+    expect(setCache).toHaveBeenCalledWith(REPO, prior);
+    const event = onReload.mock.calls[0]?.[0];
+    expect(event).toMatchObject({ ok: false, policy: prior });
+    expect(event?.warning?.code).toBe('workflow_parse_error');
+  });
+
+  it('does not write to the cache on an invalid reload when nothing is cached', () => {
+    const watch = fakeWatch();
+    const timers = fakeTimers();
+    const onReload = vi.fn<(event: WorkflowReloadEvent) => void>();
+    const setCache = vi.fn();
+
+    createWorkflowWatcher({
+      repoPath: REPO,
+      onReload,
+      watchFactory: watch.factory,
+      loadUncached: vi.fn(() => invalidPolicy()),
+      peekCache: vi.fn(() => null),
+      setCache,
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+
+    watch.trigger();
+    timers.flush();
+
+    expect(setCache).not.toHaveBeenCalled();
+    expect(onReload.mock.calls[0]?.[0]).toMatchObject({ ok: false });
+  });
+
+  it('close() stops watchers and cancels a pending reload', () => {
+    const watch = fakeWatch();
+    const timers = fakeTimers();
+    const onReload = vi.fn();
+
+    const watcher = createWorkflowWatcher({
+      repoPath: REPO,
+      onReload,
+      watchFactory: watch.factory,
+      loadUncached: vi.fn(() => validPolicy()),
+      peekCache: vi.fn(() => null),
+      setCache: vi.fn(),
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+
+    watch.trigger(); // schedule a reload
+    watcher.close();
+
+    expect(watch.closedDirs).toEqual([REPO, path.join(REPO, '.shipcode')]);
+    expect(timers.pendingCount()).toBe(0);
+
+    timers.flush(); // nothing should run
+    expect(onReload).not.toHaveBeenCalled();
+  });
+
+  it('close() is idempotent', () => {
+    const watch = fakeWatch();
+    const timers = fakeTimers();
+
+    const watcher = createWorkflowWatcher({
+      repoPath: REPO,
+      onReload: vi.fn(),
+      watchFactory: watch.factory,
+      loadUncached: vi.fn(() => validPolicy()),
+      peekCache: vi.fn(() => null),
+      setCache: vi.fn(),
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+
+    watcher.close();
+    watcher.close();
+
+    // Each watched dir closed exactly once despite the second close() call.
+    expect(watch.closedDirs).toEqual([REPO, path.join(REPO, '.shipcode')]);
+  });
+});

--- a/packages/pipeline/src/workflow-watcher.ts
+++ b/packages/pipeline/src/workflow-watcher.ts
@@ -95,8 +95,8 @@ export function createWorkflowWatcher(options: CreateWorkflowWatcherOptions): Wo
     loadUncached = loadWorkflowPolicyUncached,
     peekCache = peekWorkflowPolicyCache,
     setCache = setWorkflowPolicyCache,
-    setTimeoutFn = setTimeout,
-    clearTimeoutFn = clearTimeout,
+    setTimeoutFn = setTimeout as NonNullable<CreateWorkflowWatcherOptions['setTimeoutFn']>,
+    clearTimeoutFn = clearTimeout as NonNullable<CreateWorkflowWatcherOptions['clearTimeoutFn']>,
   } = options;
 
   // Watch both candidate locations: the repo root catches a top-level

--- a/packages/pipeline/src/workflow-watcher.ts
+++ b/packages/pipeline/src/workflow-watcher.ts
@@ -1,0 +1,163 @@
+import { watch as fsWatch } from 'node:fs';
+import path from 'node:path';
+import {
+  loadWorkflowPolicyUncached,
+  peekWorkflowPolicyCache,
+  setWorkflowPolicyCache,
+  type WorkflowLoadWarning,
+  type WorkflowPolicy,
+} from './workflow-loader';
+
+/**
+ * Default debounce window for coalescing rapid file-system events (e.g. an
+ * editor's write-then-rename save) into a single reload. Symphony §6.2 uses the
+ * same 200ms figure.
+ */
+export const DEFAULT_WORKFLOW_RELOAD_DEBOUNCE_MS = 200;
+
+export interface WorkflowReloadEvent {
+  repoPath: string;
+  /** Resolved WORKFLOW.md path at reload time, or null when none exists. */
+  path: string | null;
+  /** True when the file parsed cleanly and the new policy was applied. */
+  ok: boolean;
+  /**
+   * Effective policy after the reload: the freshly-parsed policy on success, or
+   * the preserved last-known-good policy on failure.
+   */
+  policy: WorkflowPolicy;
+  /** Parse/read warning when `ok` is false; null on success. */
+  warning: WorkflowLoadWarning | null;
+}
+
+export interface WorkflowWatcher {
+  /** Stop watching and cancel any pending debounced reload. Idempotent. */
+  close(): void;
+}
+
+/** Minimal handle returned by a watch factory; `close()` must stop the watch. */
+export interface WorkflowWatchHandle {
+  close(): void;
+}
+
+/**
+ * Starts watching a single directory, invoking `onChange` on any entry change.
+ * Returns null when the directory cannot be watched (e.g. it does not exist).
+ */
+export type WorkflowWatchFactory = (
+  dir: string,
+  onChange: () => void,
+) => WorkflowWatchHandle | null;
+
+export interface CreateWorkflowWatcherOptions {
+  /** Absolute path to the project repo root. */
+  repoPath: string;
+  /** Invoked after each debounced reload with the outcome. */
+  onReload: (event: WorkflowReloadEvent) => void;
+  /** Debounce window in ms. Defaults to {@link DEFAULT_WORKFLOW_RELOAD_DEBOUNCE_MS}. */
+  debounceMs?: number;
+  // --- Injectable seams (tests) ---
+  watchFactory?: WorkflowWatchFactory;
+  loadUncached?: (repoPath: string) => WorkflowPolicy;
+  peekCache?: (repoPath: string) => WorkflowPolicy | null;
+  setCache?: (repoPath: string, policy: WorkflowPolicy) => void;
+  setTimeoutFn?: (handler: () => void, ms: number) => ReturnType<typeof setTimeout>;
+  clearTimeoutFn?: (handle: ReturnType<typeof setTimeout>) => void;
+}
+
+const defaultWatchFactory: WorkflowWatchFactory = (dir, onChange) => {
+  try {
+    const watcher = fsWatch(dir, { persistent: false }, () => onChange());
+    // A watched dir can be removed out from under us (e.g. `.shipcode` deleted);
+    // swallow the resulting error rather than crashing the main process.
+    watcher.on('error', () => {});
+    return { close: () => watcher.close() };
+  } catch {
+    // Directory not watchable (most commonly: it does not exist yet).
+    return null;
+  }
+};
+
+/**
+ * Watch a project's WORKFLOW.md (in `.shipcode/` and the repo root) and reload
+ * its policy on change. A valid reload is committed to the loader cache
+ * immediately so the next dispatch tick observes it without waiting out the 30s
+ * TTL; an invalid reload preserves the last-known-good policy and reports the
+ * warning. In-flight pipelines are unaffected — they snapshot their policy at
+ * start (see `pipeline/context.ts`).
+ */
+export function createWorkflowWatcher(options: CreateWorkflowWatcherOptions): WorkflowWatcher {
+  const {
+    repoPath,
+    onReload,
+    debounceMs = DEFAULT_WORKFLOW_RELOAD_DEBOUNCE_MS,
+    watchFactory = defaultWatchFactory,
+    loadUncached = loadWorkflowPolicyUncached,
+    peekCache = peekWorkflowPolicyCache,
+    setCache = setWorkflowPolicyCache,
+    setTimeoutFn = setTimeout,
+    clearTimeoutFn = clearTimeout,
+  } = options;
+
+  // Watch both candidate locations: the repo root catches a top-level
+  // `WORKFLOW.md` (and creation/removal of `.shipcode`), while the `.shipcode`
+  // dir catches the preferred `.shipcode/WORKFLOW.md` (fs.watch is not recursive).
+  const watchDirs = [repoPath, path.join(repoPath, '.shipcode')];
+  const handles: WorkflowWatchHandle[] = [];
+  let pending: ReturnType<typeof setTimeout> | null = null;
+  let closed = false;
+
+  const runReload = (): void => {
+    pending = null;
+    if (closed) return;
+
+    const prior = peekCache(repoPath);
+    const candidate = loadUncached(repoPath);
+
+    if (candidate.warning) {
+      // Invalid reload: keep the last-known-good policy so dispatch is unaffected.
+      if (prior) setCache(repoPath, prior);
+      onReload({
+        repoPath,
+        path: candidate.path,
+        ok: false,
+        policy: prior ?? candidate,
+        warning: candidate.warning,
+      });
+      return;
+    }
+
+    setCache(repoPath, candidate);
+    onReload({ repoPath, path: candidate.path, ok: true, policy: candidate, warning: null });
+  };
+
+  const onChange = (): void => {
+    if (closed) return;
+    if (pending) clearTimeoutFn(pending);
+    pending = setTimeoutFn(runReload, debounceMs);
+  };
+
+  for (const dir of watchDirs) {
+    const handle = watchFactory(dir, onChange);
+    if (handle) handles.push(handle);
+  }
+
+  return {
+    close(): void {
+      if (closed) return;
+      closed = true;
+      if (pending) {
+        clearTimeoutFn(pending);
+        pending = null;
+      }
+      for (const handle of handles) {
+        try {
+          handle.close();
+        } catch {
+          // Best-effort teardown — a handle may already be invalid.
+        }
+      }
+      handles.length = 0;
+    },
+  };
+}

--- a/packages/shared/src/ipc-channels.ts
+++ b/packages/shared/src/ipc-channels.ts
@@ -880,6 +880,7 @@ export interface IpcStreamChannels {
   'activity:appended': ActivityEntry;
   'dashboard:invalidate': { kinds: Array<'stats' | 'activity' | 'running' | 'recent'> };
   'update:status-changed': UpdateStatus;
+  'workflow:reloaded': { path: string | null; ok: boolean; warning: string | null };
 }
 
 export type IpcInvokeChannel = keyof IpcInvokeChannels;


### PR DESCRIPTION
Closes #71.

## What

Watch each project's `WORKFLOW.md` and refresh the shared workflow-policy cache the moment it changes, so prompt / concurrency edits apply to the **next** pipeline without restarting the app. Previously an edit waited out the 30s policy-cache TTL.

## How

**`packages/pipeline`**
- `createWorkflowWatcher` — `fs.watch` on `.shipcode/` and the repo root (200ms debounce to coalesce editor save bursts). On change it re-resolves + re-parses the workflow:
  - **valid** → commits the new policy to the loader cache immediately (next dispatch/reconcile tick sees it).
  - **invalid** (parse/read error) → keeps the last-known-good policy and reports the warning.
- New loader seams: `loadWorkflowPolicyUncached`, `peekWorkflowPolicyCache`, `setWorkflowPolicyCache`.

**`apps/desktop`**
- `WorkflowWatchManager` owns one watcher per *visible* project. Wired into the main-window lifecycle: `sync()` at startup, `dispose()` on window close.
- Emits the typed `workflow:reloaded` IPC event (added to `IpcStreamChannels`); `useIpc` shows a toast (`info` on success, `error` on a kept-prior failure).

**In-flight pipelines are unaffected** — they snapshot their policy at start (`pipeline/context.ts`), per the PRD's in-flight requirement.

## Tests

- `packages/pipeline/src/workflow-watcher.test.ts` — debounce coalescing, valid swap → cache + ok event, invalid → prior preserved (and no-op when nothing cached), `close()` teardown + idempotency, both dirs watched.
- `apps/desktop/src/main/workflow-watch-manager.test.ts` — sync add/remove/idempotent, dispose closes all.

## Verification

- ✅ Biome clean on all touched files (also enforced by the pre-commit hook).
- ✅ `workflow-watcher.test.ts` green locally (7/7).
- ⏭️ `workflow-watch-manager.test.ts`, full typecheck/knip/suite deferred to CI: they need a built monorepo (`@shipcode/pipeline` resolves to `dist/`), which this isolated worktree doesn't build locally per the repo's no-CPU-heavy-on-laptop policy. The manager is straightforward Map add/remove logic.

## Notes / scope decisions

- Watches `listVisible()` projects at startup; new projects added at runtime are still covered by the existing 30s TTL (the watcher only removes the wait). `sync()` is exposed for callers that want to re-sync on project-list changes.
- No new dependency added — uses built-in `node:fs` watch (PRD allowed `chokidar` *or* `fs.watch`; chose the zero-dep path).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Workflow configuration files are now automatically monitored for changes and reloaded in real-time
  * Desktop app displays notifications when workflow files reload successfully or encounter errors

* **Tests**
  * Added comprehensive test coverage for workflow monitoring and reload functionality

<!-- end of auto-generated comment: release notes by coderabbit.ai -->