### PR TITLE
fix(security): harden Electron navigation + GitHub project URL handling (deepsec)

### DIFF
--- a/apps/desktop/src/main/index-helpers.test.ts
+++ b/apps/desktop/src/main/index-helpers.test.ts
@@ -7,6 +7,8 @@ import {
   buildRendererLoadTarget,
   formatActivePipelineNames,
   formatStalledProcessMessage,
+  isAllowedNavigationTarget,
+  isExternalWebUrl,
   loadLocalEnvFiles,
   shouldQuitWhenAllWindowsClosed,
 } from './index-helpers';
@@ -212,5 +214,39 @@ describe('main window and renderer bootstrap helpers', () => {
       'Agent process stalled — no output for 120s. Killed by watchdog.',
     );
     expect(formatStalledProcessMessage(1_499)).toContain('1s');
+  });
+});
+
+describe('isAllowedNavigationTarget', () => {
+  it('allows only the dev-server origin in development', () => {
+    const dev = 'http://localhost:5173';
+    expect(isAllowedNavigationTarget('http://localhost:5173/index.html', dev)).toBe(true);
+    expect(isAllowedNavigationTarget('http://localhost:5173/some/route', dev)).toBe(true);
+    expect(isAllowedNavigationTarget('https://evil.example.com/', dev)).toBe(false);
+    expect(isAllowedNavigationTarget('http://localhost:6006/', dev)).toBe(false);
+    expect(isAllowedNavigationTarget('file:///tmp/x.html', dev)).toBe(false);
+  });
+
+  it('allows only file: URLs in a packaged build (no dev server)', () => {
+    expect(
+      isAllowedNavigationTarget('file:///Applications/ShipCode.app/index.html', undefined),
+    ).toBe(true);
+    expect(isAllowedNavigationTarget('https://evil.example.com/', undefined)).toBe(false);
+    expect(isAllowedNavigationTarget('http://localhost:5173/', undefined)).toBe(false);
+  });
+
+  it('rejects unparseable targets', () => {
+    expect(isAllowedNavigationTarget('not a url', undefined)).toBe(false);
+    expect(isAllowedNavigationTarget('', 'http://localhost:5173')).toBe(false);
+  });
+});
+
+describe('isExternalWebUrl', () => {
+  it('is true for http(s) URLs and false for everything else', () => {
+    expect(isExternalWebUrl('https://github.com/shipshitdev')).toBe(true);
+    expect(isExternalWebUrl('http://example.com')).toBe(true);
+    expect(isExternalWebUrl('file:///etc/passwd')).toBe(false);
+    expect(isExternalWebUrl('javascript:alert(1)')).toBe(false);
+    expect(isExternalWebUrl('not a url')).toBe(false);
   });
 });

--- a/apps/desktop/src/main/index-helpers.ts
+++ b/apps/desktop/src/main/index-helpers.ts
@@ -193,6 +193,47 @@ export function buildRendererLoadTarget(
     : { kind: 'file', filePath: rendererHtml, openDevTools: false };
 }
 
+/**
+ * Decide whether an in-window navigation to `target` may proceed.
+ *
+ * The renderer holds the privileged `window.shipcode` preload bridge (IPC →
+ * shell spawn, settings, process control). Navigating the main window to an
+ * attacker origin would carry that bridge into untrusted JavaScript — and the
+ * production CSP (`script-src 'self'`) still permits same-origin scripts on
+ * that page. So only the bundled renderer is allowed to load: the Vite
+ * dev-server origin in development, or `file:` URLs in a packaged build. Every
+ * other navigation must be blocked; external web links open in the OS browser.
+ */
+export function isAllowedNavigationTarget(
+  target: string,
+  rendererUrl: string | undefined,
+): boolean {
+  let url: URL;
+  try {
+    url = new URL(target);
+  } catch {
+    return false;
+  }
+  if (rendererUrl) {
+    try {
+      return url.origin === new URL(rendererUrl).origin;
+    } catch {
+      return false;
+    }
+  }
+  return url.protocol === 'file:';
+}
+
+/** True when `target` is an http(s) URL safe to hand to `shell.openExternal`. */
+export function isExternalWebUrl(target: string): boolean {
+  try {
+    const { protocol } = new URL(target);
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
 export function shouldQuitWhenAllWindowsClosed(platform = process.platform): boolean {
   return platform !== 'darwin';
 }

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -112,6 +112,8 @@ import {
   buildRendererLoadTarget,
   formatActivePipelineNames,
   formatStalledProcessMessage,
+  isAllowedNavigationTarget,
+  isExternalWebUrl,
   loadLocalEnvFiles,
   shouldQuitWhenAllWindowsClosed,
 } from './index-helpers';
@@ -480,6 +482,22 @@ function createWindow() {
         'Content-Security-Policy': [buildContentSecurityPolicy(RENDERER_URL)],
       },
     });
+  });
+
+  // Lock down navigation before any content loads. The renderer exposes the
+  // privileged `window.shipcode` IPC bridge, so the window must never navigate
+  // away from the bundled renderer (e.g. via a markdown link in an untrusted
+  // GitHub issue body) to an attacker origin that would inherit that bridge,
+  // and must never spawn child windows. External web links open in the OS
+  // browser instead.
+  mainWindow.webContents.on('will-navigate', (event, url) => {
+    if (isAllowedNavigationTarget(url, RENDERER_URL)) return;
+    event.preventDefault();
+    if (isExternalWebUrl(url)) void shell.openExternal(url);
+  });
+  mainWindow.webContents.setWindowOpenHandler(({ url }) => {
+    if (isExternalWebUrl(url)) void shell.openExternal(url);
+    return { action: 'deny' };
   });
 
   // Load renderer

--- a/packages/agents/src/github/gh-cli.ts
+++ b/packages/agents/src/github/gh-cli.ts
@@ -575,7 +575,12 @@ export class GhCli {
         `repoName=${repoName}`,
         '-F',
         `issueNumber=${opts.issueNumber}`,
-        '-F',
+        // `-f` (raw string) not `-F`: issueType is a GraphQL `String!` and is
+        // renderer-supplied. `-F` reads `@path` values from disk (file
+        // disclosure) and coerces numeric/boolean-looking strings to the wrong
+        // GraphQL type. projectOwner stays `-F` — parseGithubProjectUrl
+        // validates it as a GitHub login, so it can never start with `@`.
+        '-f',
         `issueType=${opts.metadata.issueType ?? ''}`,
         '-F',
         `projectOwner=${parsedProject.owner}`,

--- a/packages/shared/src/github-url.test.ts
+++ b/packages/shared/src/github-url.test.ts
@@ -5,6 +5,7 @@ import {
   githubIssuesUrl,
   githubProjectsUrl,
   githubRepoUrl,
+  isValidGithubLogin,
   parseGithubProjectUrl,
   parseGithubRemote,
   validateGithubProjectUrl,
@@ -233,6 +234,18 @@ describe('validateGithubProjectUrl', () => {
     const r = validateGithubProjectUrl('not a url');
     expect(r.ok).toBe(false);
   });
+
+  it('rejects owners that are not valid GitHub logins (gh @file disclosure)', () => {
+    // `gh api -F login=@.env` reads .env from the project cwd; the owner must
+    // be a real GitHub login so it can never start with `@`.
+    expect(validateGithubProjectUrl('https://github.com/orgs/@.env/projects/1')).toEqual({
+      ok: false,
+      reason: 'Invalid GitHub owner in project URL',
+    });
+    expect(validateGithubProjectUrl('https://github.com/users/..%2F..%2Fetc/projects/1').ok).toBe(
+      false,
+    );
+  });
 });
 
 describe('parseGithubProjectUrl', () => {
@@ -301,5 +314,35 @@ describe('parseGithubProjectUrl', () => {
     expect(parseGithubProjectUrl(undefined)).toBeNull();
     expect(parseGithubProjectUrl('')).toBeNull();
     expect(parseGithubProjectUrl('   ')).toBeNull();
+  });
+
+  it('returns null when the owner is not a valid GitHub login (gh @file disclosure)', () => {
+    // A stored URL like this would otherwise reach `gh api -F login=@.env`,
+    // which the GitHub CLI expands into a read of `.env` from the project cwd.
+    expect(parseGithubProjectUrl('https://github.com/orgs/@.env/projects/1')).toBeNull();
+    expect(parseGithubProjectUrl('https://github.com/users/@-/projects/1')).toBeNull();
+    expect(parseGithubProjectUrl('https://github.com/orgs/a.b/projects/1')).toBeNull();
+  });
+});
+
+describe('isValidGithubLogin', () => {
+  it('accepts valid GitHub logins', () => {
+    expect(isValidGithubLogin('acme')).toBe(true);
+    expect(isValidGithubLogin('Acme-Co')).toBe(true);
+    expect(isValidGithubLogin('a')).toBe(true);
+    expect(isValidGithubLogin('a1b2c3')).toBe(true);
+  });
+
+  it('rejects logins that could trigger gh @file expansion or path traversal', () => {
+    expect(isValidGithubLogin('@.env')).toBe(false);
+    expect(isValidGithubLogin('@/etc/passwd')).toBe(false);
+    expect(isValidGithubLogin('a.b')).toBe(false);
+    expect(isValidGithubLogin('-acme')).toBe(false);
+    expect(isValidGithubLogin('acme-')).toBe(false);
+    expect(isValidGithubLogin('ac--me')).toBe(false);
+    expect(isValidGithubLogin('')).toBe(false);
+    expect(isValidGithubLogin(null)).toBe(false);
+    expect(isValidGithubLogin(undefined)).toBe(false);
+    expect(isValidGithubLogin('a'.repeat(40))).toBe(false);
   });
 });

--- a/packages/shared/src/github-url.ts
+++ b/packages/shared/src/github-url.ts
@@ -45,6 +45,24 @@ function githubPathParts(url: URL, options: { stripGitSuffix?: boolean } = {}): 
   return (options.stripGitSuffix ? path.replace(/\.git$/i, '') : path).split('/');
 }
 
+/**
+ * GitHub login grammar: alphanumeric or single internal hyphens, no leading or
+ * trailing hyphen, 1–39 characters.
+ *
+ * Owner segments parsed out of a Projects URL are later passed to
+ * `gh api graphql -F login=<owner>` / `-F projectOwner=<owner>`. The GitHub
+ * CLI reads `-F key=@path` values from the local filesystem, so an owner like
+ * `@.env` (which the shape-only checks below would otherwise accept) becomes a
+ * file-disclosure primitive that leaks files from the project working dir.
+ * Validating the owner against this grammar rejects every such value at parse
+ * time, before it can reach the CLI.
+ */
+const GITHUB_LOGIN_RE = /^[A-Za-z0-9](?:[A-Za-z0-9]|-(?=[A-Za-z0-9])){0,38}$/;
+
+export function isValidGithubLogin(login: string | null | undefined): boolean {
+  return typeof login === 'string' && GITHUB_LOGIN_RE.test(login);
+}
+
 export function parseGithubRemote(remote: string | null | undefined): GithubRepoRef | null {
   if (!remote) return null;
   const trimmed = remote.trim();
@@ -136,6 +154,9 @@ export function validateGithubProjectUrl(
     (parts[0] === 'orgs' || parts[0] === 'users') &&
     parts[2] === 'projects'
   ) {
+    if (!isValidGithubLogin(parts[1])) {
+      return { ok: false, reason: 'Invalid GitHub owner in project URL' };
+    }
     if (!/^\d+$/.test(parts[3])) {
       return { ok: false, reason: 'Project number must be numeric' };
     }
@@ -222,6 +243,7 @@ export function parseGithubProjectUrl(raw: string | null | undefined): ParsedGit
     parts.length >= 4 &&
     (parts[0] === 'orgs' || parts[0] === 'users') &&
     parts[2] === 'projects' &&
+    isValidGithubLogin(parts[1]) &&
     /^\d+$/.test(parts[3])
   ) {
     return {


### PR DESCRIPTION
## Summary

Automated **deepsec** security pass against `origin/develop` (deepsec 2.0.8, Codex/gpt-5.5 agent). The scan surfaced 46 findings; after revalidation (TP 43 / FP 2 / uncertain 1) most are accepted-risk design properties of an agent orchestrator (renderer drives local shells by design; prompt-injection into LLM routing). This PR fixes the three findings that are **clear, actionable, and closable with small root-cause changes** — and leaves the architectural ones for human review.

## Fixes

### 1. Missing Electron navigation guard — CRITICAL (`rce`)
`apps/desktop/src/main/index.ts`

The main `BrowserWindow` is created with the privileged `window.shipcode` preload bridge (IPC → shell spawn, settings, process control) but registered **no** `will-navigate` or `setWindowOpenHandler` guards. The renderer displays untrusted GitHub issue/comment markdown via ReactMarkdown with default anchor behavior, so clicking an attacker link could navigate the **privileged** window to an attacker HTTPS origin — which inherits the bridge, and whose same-origin scripts the production CSP (`script-src 'self'`) still permits. From there `instant:bare-shell` + `instant:shell-input` is a click-to-local-command-execution chain.

**Fix:** guard `will-navigate` and `setWindowOpenHandler` to allow only the bundled renderer (Vite dev-server origin in dev, `file:` in packaged builds), deny child windows, and route external web links to the OS browser via `shell.openExternal`. Predicates extracted as pure, unit-tested helpers (`isAllowedNavigationTarget`, `isExternalWebUrl`).

### 2. `gh` `@file` local-file disclosure via project owner — 4× MEDIUM (`other-local-file-disclosure`)
`packages/shared/src/github-url.ts`

`parseGithubProjectUrl` / `validateGithubProjectUrl` accepted arbitrary path text as the owner segment. A stored URL like `https://github.com/orgs/@.env/projects/1` reached `gh api graphql -F login=@.env` / `-F projectOwner=@.env`, and the GitHub CLI reads `-F key=@path` values from disk — leaking files from the project working directory during normal status/priority/readiness sync. Reachable from stored `project.githubProjectUrl` with no XSS required.

**Fix (root cause):** validate the owner against the GitHub login grammar (`isValidGithubLogin`) in both the parser and the save-time validator. Invalid owners are rejected before they can reach the CLI, which closes the vector across `project-priority.ts`, `project-status.ts`, `project-readiness.ts`, and `gh-cli.ts` in one place.

### 3. Renderer-controlled `issueType` raw-field — MEDIUM (`other-local-file-disclosure`)
`packages/agents/src/github/gh-cli.ts`

In `setIssueProjectMetadata`, the renderer-supplied `issueType` (GraphQL `String!`) was passed with `-F`, which both reads `@path` files and coerces numeric/boolean-looking strings to the wrong GraphQL type. Switched to `-f` (raw string). `projectOwner` stays `-F` since it is now login-validated. Other `-F` sites are intentionally untouched (e.g. typed `null`/`Int` fields that require `-F`).

## Tests
- `isValidGithubLogin` accept/reject (incl. `@.env`, `@/etc/passwd`, leading/trailing/double hyphen, dots, length cap)
- owner rejection in `parseGithubProjectUrl` + `validateGithubProjectUrl`
- `isAllowedNavigationTarget` (dev-origin-only / file-only / unparseable) and `isExternalWebUrl`
- `packages/shared` vitest: 51 passed · `apps/desktop` index-helpers: 16 passed · biome clean

> Worktree typecheck/full-suite were not run here (unbuilt monorepo deps; CPU-heavy build offloaded per automation policy) — CI runs them against the built workspace. The targeted typecheck showed zero errors attributable to these changes.

## Not addressed (flagged for human review)
Architectural / accepted-risk findings deepsec confirmed but out of scope for a small automated patch: renderer→shell IPC surface (`instant:*`, `process:kill`), `--dangerously-skip-permissions` tool policies, prompt-injection into agent routing/labels, settings IPC exposing Telegram/Discord tokens, and worktree symlink artifact paths.

🤖 Automated deepsec run — branch based directly on `origin/develop`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Improved desktop application security with enhanced URL and navigation validation to prevent unauthorized navigation and external link handling.
  * Enhanced GitHub URL validation to prevent malicious project URL patterns and path traversal attacks.

* **Bug Fixes**
  * Corrected GitHub CLI parameter handling when updating project metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->