### PR TITLE
fix: address bot review comments from merged PRs #213/#216/#221/#222/#223

### DIFF
--- a/apps/desktop/src/main/index-helpers.test.ts
+++ b/apps/desktop/src/main/index-helpers.test.ts
@@ -227,12 +227,19 @@ describe('isAllowedNavigationTarget', () => {
     expect(isAllowedNavigationTarget('file:///tmp/x.html', dev)).toBe(false);
   });
 
-  it('allows only file: URLs in a packaged build (no dev server)', () => {
-    expect(
-      isAllowedNavigationTarget('file:///Applications/ShipCode.app/index.html', undefined),
-    ).toBe(true);
-    expect(isAllowedNavigationTarget('https://evil.example.com/', undefined)).toBe(false);
-    expect(isAllowedNavigationTarget('http://localhost:5173/', undefined)).toBe(false);
+  it('allows only the exact bundled index.html in a packaged build (no dev server)', () => {
+    const html = '/dist/index.html';
+    expect(isAllowedNavigationTarget('file:///dist/index.html', undefined, html)).toBe(true);
+    // SPA hash/query suffixes on the same file still resolve to the bundled page.
+    expect(isAllowedNavigationTarget('file:///dist/index.html#/board', undefined, html)).toBe(true);
+    expect(isAllowedNavigationTarget('file:///dist/index.html?x=1', undefined, html)).toBe(true);
+    // Any other local file must be rejected — it must not inherit the preload bridge.
+    expect(isAllowedNavigationTarget('file:///tmp/evil.html', undefined, html)).toBe(false);
+    expect(isAllowedNavigationTarget('file:///dist/other.html', undefined, html)).toBe(false);
+    expect(isAllowedNavigationTarget('https://evil.example.com/', undefined, html)).toBe(false);
+    expect(isAllowedNavigationTarget('http://localhost:5173/', undefined, html)).toBe(false);
+    // With no renderer-html reference, no file: navigation is allowed.
+    expect(isAllowedNavigationTarget('file:///dist/index.html', undefined)).toBe(false);
   });
 
   it('rejects unparseable targets', () => {

--- a/apps/desktop/src/main/index-helpers.ts
+++ b/apps/desktop/src/main/index-helpers.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs';
 import path from 'node:path';
+import { pathToFileURL } from 'node:url';
 import type {
   AboutPanelOptionsOptions,
   BrowserWindowConstructorOptions,
@@ -201,12 +202,16 @@ export function buildRendererLoadTarget(
  * attacker origin would carry that bridge into untrusted JavaScript — and the
  * production CSP (`script-src 'self'`) still permits same-origin scripts on
  * that page. So only the bundled renderer is allowed to load: the Vite
- * dev-server origin in development, or `file:` URLs in a packaged build. Every
- * other navigation must be blocked; external web links open in the OS browser.
+ * dev-server origin in development, or the exact bundled `index.html` file in a
+ * packaged build. Allowing the whole `file:` scheme would let any local HTML
+ * file (a dropped/opened artifact, a `file://` link) carry the preload bridge,
+ * so packaged builds compare against `rendererHtml` by path. Every other
+ * navigation must be blocked; external web links open in the OS browser.
  */
 export function isAllowedNavigationTarget(
   target: string,
   rendererUrl: string | undefined,
+  rendererHtml?: string,
 ): boolean {
   let url: URL;
   try {
@@ -221,7 +226,17 @@ export function isAllowedNavigationTarget(
       return false;
     }
   }
-  return url.protocol === 'file:';
+  // Packaged build: permit only the exact bundled index.html. Compare by
+  // pathname so SPA hash/query suffixes on the same file still match, while a
+  // different local file (e.g. file:///tmp/evil.html) is rejected.
+  if (rendererHtml && url.protocol === 'file:') {
+    try {
+      return url.pathname === pathToFileURL(rendererHtml).pathname;
+    } catch {
+      return false;
+    }
+  }
+  return false;
 }
 
 /** True when `target` is an http(s) URL safe to hand to `shell.openExternal`. */

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -377,7 +377,15 @@ function createWindow() {
       });
     },
   });
-  workflowWatchManager.sync(queries.projects.listVisible().map((project) => project.path));
+  // Sync watchers to the current project set: once now at startup, and again
+  // whenever a project is added/relinked/removed/archived (wired through the IPC
+  // handlers below). Without the re-sync, hot reload silently breaks for any
+  // project list change made during the session and removed projects leak a
+  // watcher until restart.
+  const resyncWorkflowWatchers = (): void => {
+    workflowWatchManager.sync(queries.projects.listVisible().map((project) => project.path));
+  };
+  resyncWorkflowWatchers();
 
   // Queue promotion: start the next queued issue when a pipeline slot opens.
   onPipelineTerminal = (event) => {
@@ -454,6 +462,7 @@ function createWindow() {
     updateService,
     automationScheduler,
     resourceMonitor,
+    resyncWorkflowWatchers,
   );
 
   // Watchdog: reset threads stuck in active phases (handles renderer refresh + crash scenarios).
@@ -511,7 +520,7 @@ function createWindow() {
   // and must never spawn child windows. External web links open in the OS
   // browser instead.
   mainWindow.webContents.on('will-navigate', (event, url) => {
-    if (isAllowedNavigationTarget(url, RENDERER_URL)) return;
+    if (isAllowedNavigationTarget(url, RENDERER_URL, RENDERER_HTML)) return;
     event.preventDefault();
     if (isExternalWebUrl(url)) void shell.openExternal(url);
   });

--- a/apps/desktop/src/main/ipc.ts
+++ b/apps/desktop/src/main/ipc.ts
@@ -39,6 +39,7 @@ export function registerIpcHandlers(
   updateService: UpdateService,
   automationScheduler: AutomationSchedulerLike,
   resourceMonitor: ResourceMonitor,
+  onProjectsChanged: () => void = () => {},
 ): void {
   for (const thread of queries.threads.getOrphaned()) {
     transitionThreadPhase(mainWindow, queries, emitter, {
@@ -90,6 +91,7 @@ export function registerIpcHandlers(
     notificationService,
     chatNotificationService,
     resourceMonitor,
+    onProjectsChanged,
   } as const;
 
   ipcMain.on('diagnostics:renderer-ipc', (_event, payload: unknown) => {

--- a/apps/desktop/src/main/ipc/register-project-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/register-project-handlers.test.ts
@@ -460,6 +460,31 @@ describe('registerProjectHandlers', () => {
     expect(onProjectsChanged).toHaveBeenCalledTimes(1);
   });
 
+  it('re-syncs WORKFLOW.md watchers after a project unarchive', () => {
+    const onProjectsChanged = vi.fn();
+    const queries = { projects: { unarchive: vi.fn() } };
+
+    registerProjectHandlers({
+      ipcMain,
+      mainWindow: mainWindow as never,
+      queries: queries as never,
+      pipeline: {} as never,
+      chatNotificationService: {} as never,
+      processManager: {} as never,
+      emitter: {} as never,
+      notificationService: {} as never,
+      onProjectsChanged,
+    });
+
+    const unarchive = handlers.get('project:unarchive');
+    if (!unarchive) throw new Error('project:unarchive handler not registered');
+
+    unarchive(undefined, { projectId: 'project-1' });
+
+    expect(queries.projects.unarchive).toHaveBeenCalledWith('project-1');
+    expect(onProjectsChanged).toHaveBeenCalledTimes(1);
+  });
+
   it('clears managed worktree paths that are missing after a project relink', async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'shipcode-relink-missing-'));
     const oldProjectPath = path.join(tmp, 'old-repo');

--- a/apps/desktop/src/main/ipc/register-project-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/register-project-handlers.test.ts
@@ -417,6 +417,49 @@ describe('registerProjectHandlers', () => {
     expect(queries.projects.updatePath).toHaveBeenCalledWith('project-1', nextProjectPath);
   });
 
+  it('re-syncs WORKFLOW.md watchers after a project relink', async () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'shipcode-relink-resync-'));
+    const nextProjectPath = path.join(tmp, 'new-repo');
+    fs.mkdirSync(nextProjectPath, { recursive: true });
+
+    let project = { ...baseProject, path: path.join(tmp, 'old-repo') };
+    const onProjectsChanged = vi.fn();
+    const queries = {
+      projects: {
+        getById: vi.fn(() => project),
+        getByPath: vi.fn(() => null),
+        updatePath: vi.fn((_id: string, projectPath: string) => {
+          project = { ...project, path: projectPath };
+        }),
+        updateGitInfo: vi.fn(),
+      },
+      settings: {
+        get: vi.fn(() => ({ projectOpenTarget: 'cursor', worktreeRoot: path.join(tmp, 'wt') })),
+      },
+      threads: { list: vi.fn(() => []), setWorktree: vi.fn(), clearWorktree: vi.fn() },
+    };
+
+    registerProjectHandlers({
+      ipcMain,
+      mainWindow: mainWindow as never,
+      queries: queries as never,
+      pipeline: {} as never,
+      chatNotificationService: {} as never,
+      processManager: {} as never,
+      emitter: {} as never,
+      notificationService: {} as never,
+      onProjectsChanged,
+    });
+
+    const relinkPath = handlers.get('project:relink-path');
+    if (!relinkPath) throw new Error('project:relink-path handler not registered');
+
+    await relinkPath(undefined, { projectId: 'project-1', path: nextProjectPath });
+
+    expect(queries.projects.updatePath).toHaveBeenCalledWith('project-1', nextProjectPath);
+    expect(onProjectsChanged).toHaveBeenCalledTimes(1);
+  });
+
   it('clears managed worktree paths that are missing after a project relink', async () => {
     const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'shipcode-relink-missing-'));
     const oldProjectPath = path.join(tmp, 'old-repo');

--- a/apps/desktop/src/main/ipc/register-project-handlers.ts
+++ b/apps/desktop/src/main/ipc/register-project-handlers.ts
@@ -522,6 +522,7 @@ export function registerProjectHandlers({
   queries,
   pipeline,
   chatNotificationService,
+  onProjectsChanged,
 }: IpcHandlerDeps): void {
   const cleanupTrackedWorktrees = async (project: Project): Promise<void> => {
     const appSettings = queries.settings.get();
@@ -578,6 +579,8 @@ export function registerProjectHandlers({
         githubRepoId: repo?.id ?? null,
         githubRepoFullName: repo?.name ?? null,
       });
+      // The new project may carry a WORKFLOW.md; attach its watcher now.
+      onProjectsChanged?.();
 
       try {
         const git = new GitService(projectPath);
@@ -664,6 +667,8 @@ export function registerProjectHandlers({
 
       await repairProjectWorktreesAfterRelink(project, projectPath, queries);
       queries.projects.updatePath(projectId, projectPath);
+      // Watch the relinked path and drop the watcher on the stale one.
+      onProjectsChanged?.();
 
       try {
         const git = new GitService(projectPath);
@@ -715,6 +720,8 @@ export function registerProjectHandlers({
           : 'New work appeared during cleanup. Project not removed. Retry after stopping pipelines.',
       );
     }
+    // Stop watching the removed project's WORKFLOW.md.
+    onProjectsChanged?.();
   });
 
   ipcMain.handle(
@@ -760,6 +767,8 @@ export function registerProjectHandlers({
           : 'Cannot archive a project with active work. Stop running pipelines and dismiss notifications first.',
       );
     }
+    // Archived projects drop out of listVisible(); stop watching this one.
+    onProjectsChanged?.();
   });
 
   ipcMain.handle('project:unarchive', (_event, { projectId }: { projectId: string }) => {

--- a/apps/desktop/src/main/ipc/register-project-handlers.ts
+++ b/apps/desktop/src/main/ipc/register-project-handlers.ts
@@ -773,6 +773,8 @@ export function registerProjectHandlers({
 
   ipcMain.handle('project:unarchive', (_event, { projectId }: { projectId: string }) => {
     queries.projects.unarchive(projectId);
+    // Unarchived projects re-enter listVisible(); attach their watcher again.
+    onProjectsChanged?.();
   });
 
   ipcMain.handle(

--- a/apps/desktop/src/main/ipc/types.ts
+++ b/apps/desktop/src/main/ipc/types.ts
@@ -84,4 +84,10 @@ export interface IpcHandlerDeps {
   notificationService: NotificationService;
   chatNotificationService: ChatNotificationService;
   resourceMonitor?: ResourceMonitor;
+  /**
+   * Invoked after a project is added, relinked, removed, or archived so the
+   * main process can re-sync per-project resources (e.g. WORKFLOW.md watchers)
+   * to the new project set. Optional: defaults to a no-op in tests.
+   */
+  onProjectsChanged?: () => void;
 }

--- a/apps/desktop/src/renderer/components/settings-panel/IntegrationsSettingsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings-panel/IntegrationsSettingsSection.tsx
@@ -24,6 +24,39 @@ import { FolderGit, Sparkles, Terminal } from 'lucide-react';
 import type { ReactNode } from 'react';
 import { useState } from 'react';
 
+// Render-invariant statics — hoisted to module scope so they are not recreated
+// on every render of the settings view.
+const getCliVersionLine = (version: string | null): string | null =>
+  version?.split('\n')[0]?.trim() ?? null;
+
+const missingCli = {
+  available: false,
+  version: null,
+  path: null,
+  error: null,
+  authenticated: false,
+};
+
+const projectOpenTargets: ProjectOpenTarget[] = [
+  'cursor',
+  'finder',
+  'terminal',
+  'ghostty',
+  'vscode',
+  't3code',
+];
+
+const projectOpenTargetLabels: Record<ProjectOpenTarget, string> = {
+  cursor: 'Cursor',
+  finder: 'Finder',
+  terminal: 'Terminal',
+  ghostty: 'Ghostty',
+  vscode: 'Visual Studio Code',
+  t3code: 'T3 Code',
+};
+
+const terminalOpenTargets: AppSettings['terminalOpenTarget'][] = ['terminal', 'ghostty'];
+
 function StatusPill({
   tone,
   children,
@@ -108,31 +141,6 @@ function useIntegrationsSettingsSectionView({
     } as const;
   };
 
-  const getCliVersionLine = (version: string | null) => version?.split('\n')[0]?.trim() ?? null;
-  const missingCli = {
-    available: false,
-    version: null,
-    path: null,
-    error: null,
-    authenticated: false,
-  };
-  const projectOpenTargets: ProjectOpenTarget[] = [
-    'cursor',
-    'finder',
-    'terminal',
-    'ghostty',
-    'vscode',
-    't3code',
-  ];
-  const projectOpenTargetLabels: Record<ProjectOpenTarget, string> = {
-    cursor: 'Cursor',
-    finder: 'Finder',
-    terminal: 'Terminal',
-    ghostty: 'Ghostty',
-    vscode: 'Visual Studio Code',
-    t3code: 'T3 Code',
-  };
-  const terminalOpenTargets: AppSettings['terminalOpenTarget'][] = ['terminal', 'ghostty'];
   const getDesktopApp = (target: ProjectOpenTarget): DesktopAppHealth =>
     integrationStatus?.desktopApps?.[target] ?? {
       key: target,

--- a/packages/agents/src/fenced-json.test.ts
+++ b/packages/agents/src/fenced-json.test.ts
@@ -27,6 +27,13 @@ describe('extractFencedJson', () => {
     );
   });
 
+  it('treats a whitespace-only fenced block as empty', () => {
+    const text = '```shipcode-prd\n   \n```';
+    expect(() => extractFencedJson({ text, tag: 'shipcode-prd', label: 'PRD' })).toThrow(
+      'Empty `shipcode-prd` fenced block in AI response',
+    );
+  });
+
   it('wraps JSON parse failures with the label and tag', () => {
     const text = '```shipcode-prd\nnot json\n```';
     expect(() => extractFencedJson({ text, tag: 'shipcode-prd', label: 'PRD' })).toThrow(

--- a/packages/agents/src/fenced-json.test.ts
+++ b/packages/agents/src/fenced-json.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { extractFencedJson } from './fenced-json';
+
+describe('extractFencedJson', () => {
+  it('parses JSON inside a fenced block', () => {
+    const text = 'preamble\n```shipcode-prd\n{"title":"x"}\n```\ntrailer';
+    expect(extractFencedJson({ text, tag: 'shipcode-prd', label: 'PRD' })).toEqual({ title: 'x' });
+  });
+
+  it('parses a fence opened with a trailing info string', () => {
+    const text = '```shipcode-prd json\n{"a":1}\n```';
+    expect(extractFencedJson({ text, tag: 'shipcode-prd', label: 'PRD' })).toEqual({ a: 1 });
+  });
+
+  it('throws a "no fence" error when the tag is absent', () => {
+    expect(() =>
+      extractFencedJson({ text: 'just prose, no fence', tag: 'shipcode-prd', label: 'PRD' }),
+    ).toThrow('No `shipcode-prd` fenced block found in AI response');
+  });
+
+  it('throws a distinct "empty fence" error when the fence is present but empty', () => {
+    // A loose `!captured.length` check used to misreport this as a missing
+    // fence, hiding the real failure mode (model emitted an empty envelope).
+    const text = '```shipcode-prd\n```';
+    expect(() => extractFencedJson({ text, tag: 'shipcode-prd', label: 'PRD' })).toThrow(
+      'Empty `shipcode-prd` fenced block in AI response',
+    );
+  });
+
+  it('wraps JSON parse failures with the label and tag', () => {
+    const text = '```shipcode-prd\nnot json\n```';
+    expect(() => extractFencedJson({ text, tag: 'shipcode-prd', label: 'PRD' })).toThrow(
+      /Failed to parse PRD JSON inside `shipcode-prd` block/,
+    );
+  });
+});

--- a/packages/agents/src/fenced-json.ts
+++ b/packages/agents/src/fenced-json.ts
@@ -3,12 +3,15 @@ export function extractFencedJson(options: { text: string; tag: string; label: s
   if (captured === null) {
     throw new Error(`No \`${options.tag}\` fenced block found in AI response`);
   }
-  if (captured.length === 0) {
+  // Trim before the empty check so a whitespace-only fence is reported as empty
+  // rather than falling through to a confusing JSON parse error.
+  const payload = captured.join('\n').trim();
+  if (payload.length === 0) {
     throw new Error(`Empty \`${options.tag}\` fenced block in AI response`);
   }
 
   try {
-    return JSON.parse(captured.join('\n').trim()) as unknown;
+    return JSON.parse(payload) as unknown;
   } catch (err) {
     throw new Error(
       `Failed to parse ${options.label} JSON inside \`${options.tag}\` block: ${formatCaughtError(

--- a/packages/agents/src/fenced-json.ts
+++ b/packages/agents/src/fenced-json.ts
@@ -1,7 +1,10 @@
 export function extractFencedJson(options: { text: string; tag: string; label: string }): unknown {
   const captured = extractFencedBlock(options.text, options.tag);
-  if (!captured.length) {
+  if (captured === null) {
     throw new Error(`No \`${options.tag}\` fenced block found in AI response`);
+  }
+  if (captured.length === 0) {
+    throw new Error(`Empty \`${options.tag}\` fenced block in AI response`);
   }
 
   try {
@@ -15,7 +18,12 @@ export function extractFencedJson(options: { text: string; tag: string; label: s
   }
 }
 
-function extractFencedBlock(text: string, tag: string): string[] {
+/**
+ * Returns the lines inside the first ```<tag> fence, or `null` when no such
+ * fence is present. A present-but-empty fence returns `[]` — distinct from
+ * `null` so callers can tell a missing envelope from an empty one.
+ */
+function extractFencedBlock(text: string, tag: string): string[] | null {
   const openTag = `\`\`\`${tag}`;
   const lines = text.split('\n');
   let collecting = false;
@@ -33,7 +41,7 @@ function extractFencedBlock(text: string, tag: string): string[] {
     captured.push(line);
   }
 
-  return captured;
+  return collecting ? captured : null;
 }
 
 function formatCaughtError(err: unknown): string {

--- a/packages/pipeline/src/workflow-watcher.test.ts
+++ b/packages/pipeline/src/workflow-watcher.test.ts
@@ -212,6 +212,7 @@ describe('createWorkflowWatcher', () => {
       repoPath: REPO,
       onReload,
       watchFactory: watch.factory,
+      pathExists: () => true,
       loadUncached: vi.fn(() => validPolicy()),
       peekCache: vi.fn(() => null),
       setCache: vi.fn(),
@@ -255,6 +256,7 @@ describe('createWorkflowWatcher', () => {
       repoPath: REPO,
       onReload,
       watchFactory: factory,
+      pathExists: () => true,
       loadUncached,
       peekCache: vi.fn(() => null),
       setCache: vi.fn(),
@@ -276,6 +278,53 @@ describe('createWorkflowWatcher', () => {
     expect(watchedDirs).toEqual([REPO, shipcodeDir, shipcodeDir]);
     timers.flush();
     expect(loadUncached).toHaveBeenCalledTimes(2);
+  });
+
+  it('drops a stale .shipcode handle and re-attaches after the dir is recreated', () => {
+    const timers = fakeTimers();
+    const shipcodeDir = path.join(REPO, '.shipcode');
+    let shipcodeExists = true;
+    let shipcodeAttaches = 0;
+    const root: { change: (() => void) | null } = { change: null };
+
+    const factory: WorkflowWatchFactory = (dir, onChange) => {
+      if (dir === shipcodeDir) {
+        if (!shipcodeExists) return null;
+        shipcodeAttaches += 1;
+        return { close: () => {} };
+      }
+      root.change = onChange;
+      return { close: () => {} };
+    };
+
+    createWorkflowWatcher({
+      repoPath: REPO,
+      onReload: vi.fn(),
+      watchFactory: factory,
+      pathExists: (dir) => (dir === shipcodeDir ? shipcodeExists : true),
+      loadUncached: vi.fn(() => validPolicy()),
+      peekCache: vi.fn(() => null),
+      setCache: vi.fn(),
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+
+    // Startup attaches the .shipcode watcher once.
+    expect(shipcodeAttaches).toBe(1);
+
+    // .shipcode removed: the next root event drops the stale handle; the attach
+    // retry returns null while the dir is absent, so no new handle is held.
+    shipcodeExists = false;
+    root.change?.();
+    timers.flush();
+    expect(shipcodeAttaches).toBe(1);
+
+    // .shipcode recreated: because the stale handle was cleared, the next root
+    // event re-attaches (without the drop, the !shipcodeHandle gate would skip).
+    shipcodeExists = true;
+    root.change?.();
+    timers.flush();
+    expect(shipcodeAttaches).toBe(2);
   });
 
   it('close() is idempotent', () => {

--- a/packages/pipeline/src/workflow-watcher.test.ts
+++ b/packages/pipeline/src/workflow-watcher.test.ts
@@ -229,6 +229,55 @@ describe('createWorkflowWatcher', () => {
     expect(onReload).not.toHaveBeenCalled();
   });
 
+  it('lazily attaches the .shipcode watcher once the directory appears', () => {
+    const timers = fakeTimers();
+    const onReload = vi.fn();
+    const loadUncached = vi.fn(() => validPolicy());
+    const shipcodeDir = path.join(REPO, '.shipcode');
+    const watchedDirs: string[] = [];
+    let shipcodeAttempts = 0;
+    // Held in an object so TS doesn't narrow it to `null` across the callback.
+    const root: { change: (() => void) | null } = { change: null };
+
+    // `.shipcode` is missing at startup (factory returns null), then present on
+    // the retry triggered by the root watcher firing.
+    const factory: WorkflowWatchFactory = (dir, onChange) => {
+      watchedDirs.push(dir);
+      if (dir === shipcodeDir) {
+        shipcodeAttempts += 1;
+        return shipcodeAttempts === 1 ? null : { close: () => {} };
+      }
+      root.change = onChange;
+      return { close: () => {} };
+    };
+
+    createWorkflowWatcher({
+      repoPath: REPO,
+      onReload,
+      watchFactory: factory,
+      loadUncached,
+      peekCache: vi.fn(() => null),
+      setCache: vi.fn(),
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+
+    // Startup: root watched, .shipcode attempted but absent.
+    expect(watchedDirs).toEqual([REPO, shipcodeDir]);
+
+    // Root watcher fires (e.g. .shipcode was just created) → lazy re-attach.
+    root.change?.();
+    expect(watchedDirs).toEqual([REPO, shipcodeDir, shipcodeDir]);
+    timers.flush();
+    expect(loadUncached).toHaveBeenCalledTimes(1);
+
+    // A later edit reloads without attempting yet another attach (already held).
+    root.change?.();
+    expect(watchedDirs).toEqual([REPO, shipcodeDir, shipcodeDir]);
+    timers.flush();
+    expect(loadUncached).toHaveBeenCalledTimes(2);
+  });
+
   it('close() is idempotent', () => {
     const watch = fakeWatch();
     const timers = fakeTimers();

--- a/packages/pipeline/src/workflow-watcher.ts
+++ b/packages/pipeline/src/workflow-watcher.ts
@@ -102,8 +102,12 @@ export function createWorkflowWatcher(options: CreateWorkflowWatcherOptions): Wo
   // Watch both candidate locations: the repo root catches a top-level
   // `WORKFLOW.md` (and creation/removal of `.shipcode`), while the `.shipcode`
   // dir catches the preferred `.shipcode/WORKFLOW.md` (fs.watch is not recursive).
-  const watchDirs = [repoPath, path.join(repoPath, '.shipcode')];
+  const shipcodeDir = path.join(repoPath, '.shipcode');
   const handles: WorkflowWatchHandle[] = [];
+  // Tracked separately so it can be lazily attached: when `.shipcode` does not
+  // exist at startup the factory returns null, and without this the directory
+  // would never be watched even after the user later creates it.
+  let shipcodeHandle: WorkflowWatchHandle | null = null;
   let pending: ReturnType<typeof setTimeout> | null = null;
   let closed = false;
 
@@ -133,14 +137,25 @@ export function createWorkflowWatcher(options: CreateWorkflowWatcherOptions): Wo
 
   const onChange = (): void => {
     if (closed) return;
+    // Lazily attach the `.shipcode` watcher once the directory appears. The
+    // root watcher fires when `.shipcode` is first created; without this retry
+    // the non-recursive watch would never observe later edits to
+    // `.shipcode/WORKFLOW.md` until the app restarts.
+    if (!shipcodeHandle) {
+      const handle = watchFactory(shipcodeDir, onChange);
+      if (handle) {
+        shipcodeHandle = handle;
+        handles.push(handle);
+      }
+    }
     if (pending) clearTimeoutFn(pending);
     pending = setTimeoutFn(runReload, debounceMs);
   };
 
-  for (const dir of watchDirs) {
-    const handle = watchFactory(dir, onChange);
-    if (handle) handles.push(handle);
-  }
+  const rootHandle = watchFactory(repoPath, onChange);
+  if (rootHandle) handles.push(rootHandle);
+  shipcodeHandle = watchFactory(shipcodeDir, onChange);
+  if (shipcodeHandle) handles.push(shipcodeHandle);
 
   return {
     close(): void {
@@ -158,6 +173,7 @@ export function createWorkflowWatcher(options: CreateWorkflowWatcherOptions): Wo
         }
       }
       handles.length = 0;
+      shipcodeHandle = null;
     },
   };
 }

--- a/packages/pipeline/src/workflow-watcher.ts
+++ b/packages/pipeline/src/workflow-watcher.ts
@@ -1,4 +1,4 @@
-import { watch as fsWatch } from 'node:fs';
+import { existsSync, watch as fsWatch } from 'node:fs';
 import path from 'node:path';
 import {
   loadWorkflowPolicyUncached,
@@ -58,6 +58,8 @@ export interface CreateWorkflowWatcherOptions {
   debounceMs?: number;
   // --- Injectable seams (tests) ---
   watchFactory?: WorkflowWatchFactory;
+  /** Existence check for the `.shipcode` dir; defaults to `fs.existsSync`. */
+  pathExists?: (dir: string) => boolean;
   loadUncached?: (repoPath: string) => WorkflowPolicy;
   peekCache?: (repoPath: string) => WorkflowPolicy | null;
   setCache?: (repoPath: string, policy: WorkflowPolicy) => void;
@@ -92,6 +94,7 @@ export function createWorkflowWatcher(options: CreateWorkflowWatcherOptions): Wo
     onReload,
     debounceMs = DEFAULT_WORKFLOW_RELOAD_DEBOUNCE_MS,
     watchFactory = defaultWatchFactory,
+    pathExists = existsSync,
     loadUncached = loadWorkflowPolicyUncached,
     peekCache = peekWorkflowPolicyCache,
     setCache = setWorkflowPolicyCache,
@@ -137,6 +140,19 @@ export function createWorkflowWatcher(options: CreateWorkflowWatcherOptions): Wo
 
   const onChange = (): void => {
     if (closed) return;
+    // If `.shipcode` was removed, drop the now-stale handle (and stop tracking
+    // it) so a later recreation can re-attach on the next root-watcher event —
+    // otherwise the `!shipcodeHandle` gate below would skip the re-attach.
+    if (shipcodeHandle && !pathExists(shipcodeDir)) {
+      try {
+        shipcodeHandle.close();
+      } catch {
+        // Best-effort — the underlying watch may already be invalid.
+      }
+      const index = handles.indexOf(shipcodeHandle);
+      if (index !== -1) handles.splice(index, 1);
+      shipcodeHandle = null;
+    }
     // Lazily attach the `.shipcode` watcher once the directory appears. The
     // root watcher fires when `.shipcode` is first created; without this retry
     // the non-recursive watch would never observe later edits to

--- a/packages/shared/src/github-url.test.ts
+++ b/packages/shared/src/github-url.test.ts
@@ -246,6 +246,18 @@ describe('validateGithubProjectUrl', () => {
       false,
     );
   });
+
+  it('rejects project URLs with extra trailing segments (e.g. /settings)', () => {
+    // A loose `>= 4` length check previously accepted these and stored them
+    // verbatim, so the quick-link button opened the settings sub-page instead
+    // of the board. Only the exact `/projects/<n>` shape is accepted.
+    expect(validateGithubProjectUrl('https://github.com/orgs/acme/projects/3/settings').ok).toBe(
+      false,
+    );
+    expect(validateGithubProjectUrl('https://github.com/acme/repo/projects/1/views/2').ok).toBe(
+      false,
+    );
+  });
 });
 
 describe('parseGithubProjectUrl', () => {
@@ -299,6 +311,10 @@ describe('parseGithubProjectUrl', () => {
 
   it('returns null when the trailing /<n> segment is missing', () => {
     expect(parseGithubProjectUrl('https://github.com/orgs/acme/projects')).toBeNull();
+  });
+
+  it('returns null for extra trailing segments after the project number', () => {
+    expect(parseGithubProjectUrl('https://github.com/orgs/acme/projects/3/settings')).toBeNull();
   });
 
   it('returns null for http (non-https)', () => {

--- a/packages/shared/src/github-url.ts
+++ b/packages/shared/src/github-url.ts
@@ -150,7 +150,7 @@ export function validateGithubProjectUrl(
   const parts = githubPathParts(u);
   // orgs/<org>/projects/<n>
   if (
-    parts.length >= 4 &&
+    parts.length === 4 &&
     (parts[0] === 'orgs' || parts[0] === 'users') &&
     parts[2] === 'projects'
   ) {
@@ -163,7 +163,7 @@ export function validateGithubProjectUrl(
     return { ok: true, value: trimmed };
   }
   // <owner>/<repo>/projects/<n> (classic repo-scoped project)
-  if (parts.length >= 4 && parts[2] === 'projects') {
+  if (parts.length === 4 && parts[2] === 'projects') {
     if (!/^\d+$/.test(parts[3])) {
       return { ok: false, reason: 'Project number must be numeric' };
     }
@@ -240,7 +240,7 @@ export function parseGithubProjectUrl(raw: string | null | undefined): ParsedGit
   const parts = githubPathParts(u);
   // orgs/<org>/projects/<n>  or  users/<user>/projects/<n>
   if (
-    parts.length >= 4 &&
+    parts.length === 4 &&
     (parts[0] === 'orgs' || parts[0] === 'users') &&
     parts[2] === 'projects' &&
     isValidGithubLogin(parts[1]) &&


### PR DESCRIPTION
Follow-up to five already-merged PRs whose CodeRabbit/Codex review comments were never addressed. Each finding was verified against current `develop` before fixing — bot dogma was skipped (see F5).

## Fixes

**F1 — security (Codex P1, #223).** `isAllowedNavigationTarget` returned `true` for *any* `file:` URL in packaged builds (`RENDERER_URL` undefined), so the privileged `window.shipcode` preload bridge would be injected into any local HTML page the window navigated to. Now compares the navigation target against the exact bundled `index.html` by pathname (SPA hash/query suffixes still match); every other local file is rejected.

**F2 — validation (CodeRabbit, #223).** `validateGithubProjectUrl` / `parseGithubProjectUrl` used `parts.length >= 4`, so `…/projects/3/settings` passed validation and was stored verbatim (wrong quick-link href). Tightened to `=== 4` (3 sites) — only the exact `/projects/<n>` shape is accepted.

**F3 — functional (Codex P2, #222).** `WorkflowWatchManager.sync()` ran only at startup, so projects added/relinked mid-session had no `WORKFLOW.md` watcher and removed ones leaked one until restart. Added an `onProjectsChanged` callback threaded `index.ts → ipc.ts → registerProjectHandlers`, fired after `project:add/relink-path/remove/archive`.

**F4 — functional (Codex P2, #222).** The non-recursive `.shipcode` watcher was never re-attached after a missing dir appeared, so edits to a mid-session-created `.shipcode/WORKFLOW.md` stopped hot-reloading. Added a lazy re-attach inside `onChange` (driven by the repo-root watcher firing when `.shipcode` is created).

**F5 — maintainability (CodeRabbit/React Doctor, #216).** Hoisted 5 render-invariant statics/pure fns to module scope in `IntegrationsSettingsSection`. **Skipped** the "extract `DesktopAppHealthCard` to `packages/ui`" suggestion: single use site, and the existing `Badge` primitive is visually incompatible — no reuse gain.

**F6 — diagnostics (CodeRabbit, #213).** `extractFencedBlock` conflated a missing fence with an empty one (both `[]`). Now returns `null` for a missing fence vs `[]` for present-but-empty, with a distinct "Empty fenced block" error.

## Validation
- Tests: shared 53 · agents 5 (new `fenced-json.test.ts`) · pipeline 8 · desktop 82 — all green
- `tsc` typecheck clean across all packages + desktop
- Biome clean (pre-commit hook)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved detection of workflow file changes, including when files are created after application startup

* **Bug Fixes**
  * Enhanced navigation security with stricter URL validation
  * Tightened GitHub Projects URL validation to reject paths with extra segments

* **Performance**
  * Improved settings panel rendering efficiency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->