### PR TITLE
ci(full): register full.yml on develop

### DIFF
--- a/.agents/memory/e2e-ci.md
+++ b/.agents/memory/e2e-ci.md
@@ -71,13 +71,21 @@ indexes `workflow_dispatch`-only (and `schedule`) workflows **only from the
 default branch (master)**. A pure dispatch-only full.yml would therefore 404 on
 develop (`gh workflow run full.yml` → "not found on the default branch") — the
 same default-branch rule that gates the weekly cron. `pull_request`/`push`
-triggers, by contrast, are indexed from **any** branch (that's why e2e.yml is
-dispatchable on develop — its `pull_request` trigger forces indexing).
+triggers, by contrast, get a workflow indexed from **any** branch — **but only
+once that trigger actually FIRES**. Pushing a file that carries a `pull_request`
+trigger to a non-default branch does **not** register it; the workflow stays 404
+(`gh api .../actions/workflows/full.yml` → Not Found) until a real event fires
+it. e2e.yml was registered because PR #227 fired its `pull_request`; full.yml
+stayed 404 after 3f26a36f pushed the bare trigger, and only registered when
+PR #229 edited full.yml and fired its paths-filtered self-test (gotcha proven
+2026-06-07).
 
 Chosen fix (2026-06-07): full.yml carries a **paths-filtered `pull_request`
-trigger** (`paths: ['.github/workflows/full.yml']`) purely to get indexed from
-develop → it's now dispatchable there (`gh workflow run full.yml --ref develop`)
-**without promoting to master**. Filtered to its own file so it never auto-runs
+trigger** (`paths: ['.github/workflows/full.yml']`) so editing the file in a PR
+fires it. That first firing (PR #229) registered the workflow (id 290778929) →
+it's now dispatchable on develop (`gh workflow run full.yml --ref develop`)
+**without promoting to master**. Registration persists after the PR closes;
+re-firing is not needed. Filtered to its own file so it never auto-runs
 the orchestrator on normal PRs; it self-tests only when full.yml itself changes,
 and on that `pull_request` event the children run their light PR-path jobs
 (ci → `fast-qa`, e2e → `web-smoke`) — `github.event_name` inside a

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -21,6 +21,11 @@ name: Full (CI → E2E)
 # changes in a PR; on that PR event the children run their light PR-path jobs
 # (ci → fast-qa, e2e → web-smoke), never the heavy macOS suite. Same trick e2e.yml
 # uses. Remove the pull_request trigger once the suite is promoted to master.
+#
+# (A workflow with only a pull_request/push trigger is registered the first time
+# that trigger actually FIRES — pushing the file is not enough. This PR, which
+# edits full.yml, is that first firing event and registers the workflow on the
+# repo so `gh workflow run full.yml --ref develop` works thereafter.)
 
 run-name: "Full CI→E2E · ${{ github.ref_name }}"
 


### PR DESCRIPTION
Registers the `Full (CI → E2E)` orchestrator on the repo so it can be dispatched on `develop` without promoting the suite to master.

## Why
A workflow whose only event triggers are `pull_request`/`push` is **not indexed** by GitHub until one of those triggers actually **fires once**. Pushing the file (3f26a36f) was insufficient — `full.yml` stayed 404 and `gh workflow run full.yml --ref develop` could not find it.

## What
This PR edits `.github/workflows/full.yml`, firing its paths-filtered `pull_request` self-test for the first time. That registers the workflow. After this, `gh workflow run full.yml --ref develop` works.

The self-test runs only the **light PR-path jobs** (ci → fast-qa, e2e → web-smoke) — never the heavy macOS desktop suite — because the children gate the macOS job on `workflow_dispatch`/`schedule` events only.

## After merge
`full.yml` stays registered. The `pull_request` trigger is removed once the suite is promoted to master (tracked in `.agents/memory/e2e-ci.md`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal workflow documentation to clarify indexing behavior for GitHub Actions.

---

**Note:** This release contains internal infrastructure updates with no end-user visible changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->