### PR TITLE
ci: add Secret Scan gate

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,31 @@
+name: Secret Scan
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  secret-scan:
+    name: Secret Scan
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run gitleaks (filesystem scan, license-free)
+        run: |
+          set -euo pipefail
+          TAG=$(curl -sSL https://api.github.com/repos/gitleaks/gitleaks/releases/latest | jq -r .tag_name)
+          NUM=${TAG#v}
+          echo "Using gitleaks ${TAG}"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/${TAG}/gitleaks_${NUM}_linux_x64.tar.gz" -o /tmp/gitleaks.tar.gz
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          chmod +x /tmp/gitleaks
+          /tmp/gitleaks dir . --redact --no-banner --exit-code 1


### PR DESCRIPTION
Adds a license-free gitleaks filesystem secret scan as a required CI gate (org-standard rollout).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated security scanning in the CI/CD pipeline to detect potential secrets in code commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->