### PR TITLE
ci: trunk-based backbone — single master, trust gate, affected scoping, CodeQL

### DIFF
--- a/.github/actions/setup-bun-env/action.yml
+++ b/.github/actions/setup-bun-env/action.yml
@@ -1,0 +1,60 @@
+name: Setup Bun environment
+description: >-
+  Install Bun + Node, restore the Bun module store and (optionally) the Turbo
+  cache, then `bun install --frozen-lockfile`. Shared by every CI job so the
+  setup block lives in one place instead of being copy-pasted per job.
+
+inputs:
+  bun-version:
+    description: Bun version to install.
+    required: false
+    default: "1.3.14"
+  node-version:
+    description: Node version to install (Electron/tooling parity).
+    required: false
+    default: "22"
+  cache-turbo:
+    description: Restore/save the .turbo cache. Disable for jobs that do no Turbo work.
+    required: false
+    default: "true"
+  turbo-key-prefix:
+    description: Per-job Turbo cache key prefix so jobs don't clobber each other's snapshots.
+    required: false
+    default: "ci"
+  install-ripgrep:
+    description: Install ripgrep (some repo scripts shell out to `rg`).
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - uses: oven-sh/setup-bun@v2
+      with:
+        bun-version: ${{ inputs.bun-version }}
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+    # Bun module store — avoids re-downloading deps every run.
+    - uses: actions/cache@v4
+      with:
+        path: ~/.bun/install/cache
+        key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
+        restore-keys: bun-${{ runner.os }}-
+    # Turbo cache — persists per-task outputs across runs. sha key + prefix
+    # restore-keys is Turborepo's official CI pattern: each run saves a fresh
+    # snapshot and restores the most recent one; content hashes (not the key)
+    # decide what re-runs.
+    - if: inputs.cache-turbo == 'true'
+      uses: actions/cache@v4
+      with:
+        path: .turbo
+        key: turbo-${{ runner.os }}-${{ inputs.turbo-key-prefix }}-${{ github.sha }}
+        restore-keys: |
+          turbo-${{ runner.os }}-${{ inputs.turbo-key-prefix }}-
+          turbo-${{ runner.os }}-
+    - if: inputs.install-ripgrep == 'true'
+      shell: bash
+      run: sudo apt-get update && sudo apt-get install -y ripgrep
+    - shell: bash
+      run: bun install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,127 +1,167 @@
 name: CI
 
+# Trunk-based: master is the single trunk. PRs target master; pushes to master
+# (post-merge) run the full suite. `workflow_call` lets the `full` orchestrator
+# (.github/workflows/full.yml) chain CI → E2E in one dispatch.
 on:
   push:
-    branches: [staging, master]
+    branches: [master]
   pull_request:
-    branches: [develop, staging, master]
+    branches: [master]
   schedule:
     - cron: '0 6 * * 0'
   workflow_dispatch:
-  # Reusable entry point so the `full` orchestrator (.github/workflows/full.yml)
-  # can run CI first, then E2E, in one dispatch. Additive — job logic unchanged.
-  # When called this way, github.event_name inside this file is the caller's
-  # event (workflow_dispatch), so `quality` + `coverage` run (full CI).
   workflow_call:
 
 env:
-  BUN_VERSION: "1.3.13"
+  BUN_VERSION: "1.3.14"
   NODE_VERSION: "22"
 
 permissions:
   contents: read
+  pull-requests: write
+  statuses: write
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
-  quality:
-    if: |
-      github.event_name != 'schedule' &&
-      (
-        github.event_name != 'pull_request' ||
-        github.base_ref != 'develop'
-      )
+  # Fork-PR gate: external contributors don't burn CI or touch secrets until a
+  # maintainer reviews the code and adds the `run-ci` label. Same-repo PRs and
+  # all non-PR events are trusted automatically.
+  trust:
+    name: Trust Check
     runs-on: ubuntu-latest
+    outputs:
+      is-trusted: ${{ steps.non_pr.outputs.trusted || steps.check.outputs.trusted }}
+    steps:
+      - name: Allow non-PR events
+        id: non_pr
+        if: github.event_name != 'pull_request'
+        run: echo "trusted=true" >> "$GITHUB_OUTPUT"
+
+      - name: Check contributor trust
+        id: check
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.issue.number
+            });
+
+            const trustedRoles = ['OWNER', 'MEMBER', 'COLLABORATOR'];
+            const isSameRepository =
+              pr.head.repo?.full_name === `${context.repo.owner}/${context.repo.repo}`;
+            const isTrusted = isSameRepository || trustedRoles.includes(pr.author_association);
+            const hasLabel = pr.labels.some(l => l.name === 'run-ci');
+
+            if (isTrusted) {
+              core.info(isSameRepository ? 'same-repo PR - CI allowed' : `trusted contributor (${pr.author_association}) - CI allowed`);
+              core.setOutput('trusted', 'true');
+            } else if (hasLabel) {
+              core.info('External contributor with run-ci label - CI allowed');
+              core.setOutput('trusted', 'true');
+            } else {
+              core.setOutput('trusted', 'false');
+              core.setFailed(
+                `External contributor (${pr.author_association}) - add the \`run-ci\` label to allow CI. ` +
+                'A maintainer must review the code and add the label.'
+              );
+            }
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    needs: trust
+    if: needs.trust.outputs.is-trusted == 'true'
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: ./.github/actions/setup-bun-env
         with:
           bun-version: ${{ env.BUN_VERSION }}
-      - uses: actions/setup-node@v4
-        with:
           node-version: ${{ env.NODE_VERSION }}
-      # Bun module store — avoids re-downloading deps every run.
-      - uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-      # Turbo cache — persists per-task build/lint/typecheck/test outputs across
-      # runs. After a fix, only the changed packages re-run; everything green
-      # before restores from cache (turbo validates content hashes, not the key).
-      # sha key + prefix restore-keys is Turborepo's official CI pattern: each run
-      # saves a fresh snapshot, restores the most recent one.
-      - uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-quality-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ runner.os }}-quality-
-            turbo-${{ runner.os }}-
-      - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
-      - run: bun install --frozen-lockfile
+          cache-turbo: 'false'
+      # Biome scans the whole repo in well under a minute — no affected scoping needed.
       - run: bun run lint
-      - run: bun run typecheck
-      - run: bun run test:ci
 
-  fast-qa:
-    if: github.event_name == 'pull_request' && github.base_ref == 'develop'
+  design:
+    name: Design System
     runs-on: ubuntu-latest
+    needs: trust
+    if: needs.trust.outputs.is-trusted == 'true'
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: ./.github/actions/setup-bun-env
         with:
           bun-version: ${{ env.BUN_VERSION }}
-      - uses: actions/setup-node@v4
-        with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-      - uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-fast-qa-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ runner.os }}-fast-qa-
-            turbo-${{ runner.os }}-
-      - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
-      - run: bun install --frozen-lockfile
-      - run: bun run lint
-      - run: bun run typecheck
+          cache-turbo: 'false'
+      - run: bun run lint:design
 
+  typecheck:
+    name: Typecheck
+    runs-on: ubuntu-latest
+    needs: trust
+    if: needs.trust.outputs.is-trusted == 'true'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-bun-env
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
+          turbo-key-prefix: typecheck
+      - name: Typecheck (affected on PRs, full otherwise)
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            TURBO_SCM_BASE="${{ github.event.pull_request.base.sha }}" bunx turbo run typecheck --affected
+          else
+            bun run typecheck
+          fi
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    needs: trust
+    if: needs.trust.outputs.is-trusted == 'true'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup-bun-env
+        with:
+          bun-version: ${{ env.BUN_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
+          turbo-key-prefix: test
+          install-ripgrep: 'true'
+      - name: Test (affected on PRs, full otherwise)
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            TURBO_SCM_BASE="${{ github.event.pull_request.base.sha }}" bunx turbo run test --affected -- --maxWorkers=2
+          else
+            bun run test:ci
+          fi
+
+  # Coverage is decoupled from the PR gate: it runs on a weekly cron, on demand,
+  # and on push to master — never blocking a PR. Threshold lives in COVERAGE_MIN.
   coverage:
+    name: Coverage
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/master')
     runs-on: ubuntu-latest
+    needs: trust
     steps:
       - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
+      - uses: ./.github/actions/setup-bun-env
         with:
           bun-version: ${{ env.BUN_VERSION }}
-      - uses: actions/setup-node@v4
-        with:
           node-version: ${{ env.NODE_VERSION }}
-      - uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: bun-${{ runner.os }}-${{ hashFiles('bun.lock') }}
-          restore-keys: bun-${{ runner.os }}-
-      - uses: actions/cache@v4
-        with:
-          path: .turbo
-          key: turbo-${{ runner.os }}-coverage-${{ github.sha }}
-          restore-keys: |
-            turbo-${{ runner.os }}-coverage-
-            turbo-${{ runner.os }}-
-      - name: Install ripgrep
-        run: sudo apt-get update && sudo apt-get install -y ripgrep
-      - run: bun install --frozen-lockfile
+          turbo-key-prefix: coverage
+          install-ripgrep: 'true'
       - name: Run sharded full-repo coverage
         env:
           COVERAGE_MIN: '80'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,57 @@
+name: CodeQL Security Analysis
+
+# Advisory SAST — never on the PR hot path (slow, occasionally flaky). Runs on a
+# weekly cron and on demand; findings land in the repo Security tab as SARIF.
+on:
+  workflow_dispatch:
+  schedule:
+    # Mondays 05:00 UTC — off-cycle from the CI (Sun 06:00) and E2E (Sun 07:00) crons.
+    - cron: '0 5 * * 1'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["javascript-typescript"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          config: |
+            paths:
+              - apps/
+              - packages/
+            paths-ignore:
+              - '**/node_modules/**'
+              - '**/dist/**'
+              - '**/out/**'
+              - '**/.next/**'
+              - '**/*.spec.ts'
+              - '**/*.test.ts'
+              - '**/*.e2e.ts'
+              - '**/test/**'
+              - '**/tests/**'
+              - '**/__tests__/**'
+              - '**/mocks/**'
+              - '**/fixtures/**'
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,13 +1,10 @@
 name: E2E
 
-# Branch model: develop (integration) → staging → master (default + release).
-# - Weekly cron fires ONLY from the default branch's copy of this file, so the
-#   scheduled review always runs against master. (It stays dormant on develop/
-#   staging — GitHub ignores cron on non-default branches.)
-# - workflow_dispatch is available on any branch that has this file; pick the
-#   branch to test via the `target_ref` input below. The suite currently lives
-#   on develop only; once promoted, master/staging dispatch + weekly cron light
-#   up with no further changes.
+# Trunk-based: master is the single trunk.
+# - Weekly cron fires from the default branch (master), so the scheduled review
+#   always runs against the trunk.
+# - workflow_dispatch defaults to master; `target_ref` lets you point the suite
+#   at any branch/tag (e.g. a release tag or a feature branch under test).
 run-name: >-
   E2E ·
   ${{ github.event_name == 'workflow_dispatch' && format('{0} (manual)', inputs.target_ref)
@@ -23,13 +20,9 @@ on:
   workflow_dispatch:
     inputs:
       target_ref:
-        description: 'Branch to run the full desktop E2E suite against'
-        type: choice
-        default: develop
-        options:
-          - develop
-          - staging
-          - master
+        description: 'Branch/tag to run the full desktop E2E suite against'
+        type: string
+        default: master
       only_failed:
         description: 'Re-run only previously-failed E2E tests (--last-failed). Faster after a fix, but SKIPS the flow-coverage gate — not authoritative. Default: full run.'
         type: boolean

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -55,7 +55,7 @@ on:
       - '.github/workflows/e2e.yml'
 
 env:
-  BUN_VERSION: "1.3.13"
+  BUN_VERSION: "1.3.14"
   NODE_VERSION: "22"
   E2E_FLOW_COVERAGE_MIN: "90"
 

--- a/.github/workflows/full.yml
+++ b/.github/workflows/full.yml
@@ -1,31 +1,16 @@
 name: Full (CI → E2E)
 
 # One-button orchestrator: runs the CI workflow first, then — only if CI is
-# green — the full E2E suite, in a single manual dispatch. Dispatchable on any
-# branch that has this file (develop today; staging/master once promoted).
+# green — the full E2E suite, in a single manual dispatch.
 #
 # It does NOT duplicate any job logic: it `uses:` the existing ci.yml and
-# e2e.yml as reusable workflows (they gained an additive `workflow_call:`
-# trigger). `needs: ci` enforces the ordering. Both children run against the
-# branch this workflow is dispatched on (github.ref); that branch is forwarded
-# to e2e as target_ref so its checkout resolves correctly.
+# e2e.yml as reusable workflows (both carry a `workflow_call:` trigger).
+# `needs: ci` enforces the ordering. Both children run against the branch/tag
+# this workflow is dispatched on (github.ref), forwarded to e2e as target_ref so
+# its checkout resolves correctly.
 #
-# Pick the branch in the "Run workflow" dropdown, or:
-#   gh workflow run full.yml --ref develop
-#
-# Registration note: GitHub indexes workflow_dispatch-only workflows ONLY from
-# the default branch (master). To make this dispatchable on develop *without*
-# promoting to master, it carries a paths-filtered `pull_request` trigger
-# (below) — that forces GitHub to index the file from develop. It is filtered to
-# this file alone, so it auto-runs only as a self-test when full.yml itself
-# changes in a PR; on that PR event the children run their light PR-path jobs
-# (ci → fast-qa, e2e → web-smoke), never the heavy macOS suite. Same trick e2e.yml
-# uses. Remove the pull_request trigger once the suite is promoted to master.
-#
-# (A workflow with only a pull_request/push trigger is registered the first time
-# that trigger actually FIRES — pushing the file is not enough. This PR, which
-# edits full.yml, is that first firing event and registers the workflow on the
-# repo so `gh workflow run full.yml --ref develop` works thereafter.)
+# Pick the ref in the "Run workflow" dropdown, or:
+#   gh workflow run full.yml --ref master
 
 run-name: "Full CI→E2E · ${{ github.ref_name }}"
 
@@ -36,11 +21,6 @@ on:
         description: 'E2E: re-run only previously-failed tests (--last-failed). Skips the flow-coverage gate. CI still runs in full.'
         type: boolean
         default: false
-  # Indexing-only trigger (see registration note above). NOT meant to run the
-  # orchestrator on normal PRs — paths-filtered to full.yml itself.
-  pull_request:
-    paths:
-      - '.github/workflows/full.yml'
 
 permissions:
   contents: read


### PR DESCRIPTION
## What

Rewrites the CI backbone to match the trunk-based model now shared with genfeed.ai / vitae.ai. Master is the single trunk; PRs target master, post-merge pushes run the full suite.

## Changes

- **`.github/actions/setup-bun-env`** (new) — composite action: Bun 1.3.14 + Node 22, Bun store + Turbo cache, optional ripgrep, `bun install --frozen-lockfile`. Setup block lives in one place instead of copy-paste per job.
- **`ci.yml`** — retargeted to single master trunk (`push`/`pull_request` on `[master]`). Split into parallel jobs: `trust` (fork-PR gate via author_association + `run-ci` label), `lint` (biome whole-repo), `design` (design.md), `typecheck`, `test`. Typecheck/test use `turbo run … --affected` (`TURBO_SCM_BASE` = PR base sha) on PRs, full run otherwise. `coverage` decoupled to cron/dispatch/push-master only. All non-trust jobs gate on `needs.trust.outputs.is-trusted`.
- **`codeql.yml`** (new) — advisory SAST, weekly cron + dispatch, off the PR hot path. SARIF → Security tab.
- **`e2e.yml`** — `target_ref` default `develop`→`master`, header note → trunk; BUN_VERSION aligned to 1.3.14.
- **`full.yml`** — dropped the develop-registration `pull_request` indexing trick; dispatch-only (master is default branch → registers natively).

## Notes

- Pre-release repo, no backward-compat concerns.
- gitleaks secret-scan + react-doctor already trunk-compatible, unchanged.
- Branch-protection / default-branch surgery is a follow-up, not in this PR.
