### PR TITLE
feat(run-modes): default to programmatic; re-enable claude -p after billing revert

### DIFF
--- a/.agents/SESSIONS/2026-06-16.md
+++ b/.agents/SESSIONS/2026-06-16.md
@@ -81,3 +81,109 @@ AFTER:  master (single trunk, default, protected)
   reliably green on master (macstudio still authoritative; not disabled).
 - Optional: enable `enforce_admins` once the team grows (currently false so solo admin
   squash-merge works).
+
+## Session 2 — Re-enable `claude -p` programmatic + make it the default
+
+Anthropic reverted the 2026 Agent-SDK billing change (May→June 2026 email: "we're not
+making this change today"), so `claude -p` draws from the subscription seat again. Flipped
+the run-mode defaults from interactive back to programmatic for the structured pipeline
+phases, re-enabled the settings UI control, and retargeted all the billing-era guards/comments
+— while preserving a separate, still-valid **security** guard on programmatic Claude execute.
+
+Worktree: `.worktrees/feat-programmatic-default` on `feat/programmatic-default-reenable`
+(forked from master `c49b5f69`; trunk-based, no develop).
+
+### System flow
+
+```
+agentRunModes[agent][phase]  →  cli-provider routing
+  plan/review/revision/verify:  programmatic (claude -p / codex exec --json)   ← was interactive
+  execute:                      claude=interactive (no OS sandbox)             ← unchanged, security
+                                codex=programmatic (codex exec --sandbox)      ← was interactive
+  terminalFix/instant:          interactive (watched terminal panes)          ← unchanged
+  issueTerminal:                always interactive
+
+Safety nets retained:
+  isPoolExhausted()/markPoolExhausted()  →  programmatic claude auto-falls back to interactive
+  forceInteractiveClaude                 →  global force-interactive escape hatch
+```
+
+### Security model (the load-bearing decision)
+
+- Programmatic claude **plan/review/revision/verify** = `claude -p` with `--disallowedTools`
+  for EVERY host tool (Edit/Write/Bash/Read/Glob/Grep/Task/Web*) → pure prompt→JSON, zero host
+  risk. Billing was the only blocker → now safe to default programmatic.
+- Programmatic claude **execute/terminalFix/instant** = host Edit/Write/Bash, NO OS sandbox →
+  real risk. `cli-provider.ts` hard-rejects programmatic claude execute; `getRunMode` coerces
+  claude→interactive for instant/terminalFix. KEPT.
+- **Codex** all phases run through `codex exec --sandbox` (OS-sandboxed) → programmatic safe
+  everywhere, including execute. Default executor is codex → out-of-box pipeline is fully
+  programmatic.
+
+### Affected components
+
+- **Shared/config** — `constants.ts` defaults, `types/pipeline-core.ts`, `types/settings.ts`.
+- **Pipeline** — `runtime.ts` comment (routing + pool fallback retained).
+- **Agents** — `cli-provider.ts` execute-guard comment clarified (security, billing-independent).
+- **Desktop main** — `register-instant-handlers.ts` (`getRunMode` coercion; removed billing-era
+  `assertProgrammaticRunAllowed`).
+- **Desktop renderer** — `PipelineSettingsSection.tsx` (`RunModeSelect` now editable + wired to
+  `onUpdate`; programmatic disabled only for the 3 Claude host-tool rows; Codex selectable).
+- **Docs/memory** — `settings.mdx`, `interactive-cli-run-modes.md` (rewritten, `last_verified`
+  2026-06-16).
+
+### What was done
+
+- [x] `constants.ts`: `agentRunModes` defaults → programmatic for plan/review/revision/verify
+  (both providers) + codex execute; claude execute/terminalFix/instant stay interactive.
+- [x] `PipelineSettingsSection.tsx`: re-enabled the dropdown (real `onValueChange` → `onUpdate`),
+  per-agent/phase; programmatic disabled w/ sandbox tooltip for Claude execute/terminalFix/instant.
+- [x] `register-instant-handlers.ts`: `getRunMode` coerces claude programmatic→interactive
+  (security); deleted obsolete `assertProgrammaticRunAllowed` + 3 call sites; dropped unused
+  `isPoolExhausted` import.
+- [x] Retargeted comments billing→security in `cli-provider.ts`, `pipeline-core.ts`,
+  `settings.ts`, `runtime.ts`. Kept pool-exhaustion fallback + `forceInteractiveClaude`.
+- [x] `settings.test.ts`: updated default/backfill/invalid-fallback expectations to programmatic.
+- [x] `settings.mdx` row + `interactive-cli-run-modes.md` rewritten to the new model.
+- [x] Gates green: `turbo typecheck` (5 pkgs, exit 0), affected vitest (261 pass / 5 skip),
+  biome clean.
+
+### Key decisions
+
+- **Programmatic = default for structured phases; claude execute stays interactive.** Did NOT
+  remove the host-sandbox guard on programmatic claude execute — that block is security, not
+  billing. Codex (sandboxed) is the programmatic executor; claude execute remains interactive.
+- **Codex execute → programmatic by default.** `codex exec --sandbox` is OS-sandboxed and codex
+  is the default executor, so the default pipeline runs fully programmatic without exposing host.
+- **Kept the pool-exhaustion fallback + `forceInteractiveClaude`** as safety nets in case
+  Anthropic re-rations the Agent-SDK pool. Cheap insurance, no downside.
+- **Skills-repo integration deferred.** shipshitdev/skills (182 skills) wiring into pipeline
+  prompts is unbounded; programmatic mode is the enabler, but pulling specific skills is a
+  separate task.
+
+### Files changed
+
+- `M packages/shared/src/constants.ts`
+- `M packages/shared/src/types/pipeline-core.ts`
+- `M packages/shared/src/types/settings.ts`
+- `M packages/pipeline/src/pipeline/runtime.ts`
+- `M packages/agents/src/providers/cli-provider.ts`
+- `M apps/desktop/src/main/ipc/register-instant-handlers.ts`
+- `M apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx`
+- `M packages/db/src/queries/settings.test.ts`
+- `M apps/docs/content/desktop/settings.mdx`
+- `M .agents/memory/interactive-cli-run-modes.md`
+
+### Mistakes and fixes
+
+- **Worktree had no built deps** → LSP flooded with "Cannot find module @shipcode/*" + implicit-any
+  noise, and `bunx vitest` failed to resolve `@shipcode/shared`. Real cause: fresh worktree has no
+  `node_modules`/`dist`. Fixed by `bun install` then `turbo typecheck` (runs `^build` first), which
+  built the workspace dists; vitest resolved cleanly afterward.
+
+### Next steps
+
+- Decide whether to add an OS-sandbox wrapper so programmatic **Claude execute** can be enabled
+  safely (currently the one phase that can't go programmatic).
+- Wire specific shipshitdev/skills into the pipeline phase prompts now that programmatic `claude -p`
+  loads skills cleanly.

--- a/.agents/SESSIONS/2026-06-16.md
+++ b/.agents/SESSIONS/2026-06-16.md
@@ -183,7 +183,125 @@ Safety nets retained:
 
 ### Next steps
 
-- Decide whether to add an OS-sandbox wrapper so programmatic **Claude execute** can be enabled
-  safely (currently the one phase that can't go programmatic).
 - Wire specific shipshitdev/skills into the pipeline phase prompts now that programmatic `claude -p`
   loads skills cleanly.
+
+## Session 3 — Sandboxed programmatic Claude execute (srt OS sandbox)
+
+Follow-on to Session 2. Vincent challenged the "claude -p has no OS sandbox" claim. A research
+workflow (live docs + local CLI probe + adversarial synthesis) confirmed he was right: Claude Code
+v2.1.178 has a real OS sandbox (Seatbelt/bubblewrap) usable with `-p`, and `--permission-mode auto`
+is real — BUT the built-in Bash sandbox only constrains Bash, not Edit/Write/MCP. So we wrapped the
+WHOLE `claude -p` execute process in **`@anthropic-ai/sandbox-runtime` (`srt`)**, which contains
+file tools + MCP too, and enabled programmatic Claude execute behind it.
+
+### System flow
+
+```
+claude execute + programmatic + claudeExecuteSandboxEnabled
+  runtime.ts sets phaseHints.osSandbox  →  cli-provider builds:
+    srt -s <per-run policy.json> claude -p … (prompt via stdin)
+  policy: allowWrite=[worktree, tmp, ~/.claude]; denyRead=[~/.ssh,~/.aws,…];
+          network deny-by-default + (anthropic-only | anthropic-github) allowlist
+  no osSandbox hint OR srt unresolved  →  FAIL CLOSED (never unsandboxed)
+codex execute → still codex exec --sandbox (unchanged)
+claude terminalFix/instant → still interactive (no srt path there)
+```
+
+### Empirical gate (ran before writing app code)
+
+srt v0.0.55 verified on this Mac: stdin passes through (`printf … | srt cat`), exit code propagates
+verbatim (`srt sh -c 'exit 42'` → 42), writes confined to `allowWrite` (out-of-worktree write
+blocked, no leak), network deny-by-default with allowlist (example.com 200 when allowed, github
+blocked when not). Config schema is STRICT — partial config → `denyWrite: Required`, fail-closed.
+
+### What was done
+
+- [x] Bundled `@anthropic-ai/sandbox-runtime@0.0.55` as a dep of `@shipcode/agents`.
+- [x] New `packages/agents/src/sandbox/srt.ts`: `resolveSrt` (require.resolve bundled cli.js,
+  platform-gated, cached, registers the one allowlisted binary), `buildSrtPolicy` (0700 mkdtemp,
+  full strict-schema policy from a FIXED key set, cleanup), `buildSandboxedClaudeExecuteCommand`.
+- [x] `process-manager.ts`: `registerSandboxBinary` + narrow allowlist escape (only the exact
+  resolved srt path, never the bare string).
+- [x] `cli-provider.ts`: `runCli` gained `commandOverride` (spawn srt, keep TYPE tag `claude`);
+  replaced the execute hard-block with sandbox-required logic (fail-closed when disabled/unavailable;
+  policy cleanup in `finally`).
+- [x] `ProviderPhaseHints.osSandbox` + `runtime.ts` populates it for claude+execute+programmatic+enabled.
+- [x] Settings: `claudeExecuteSandboxEnabled` (default true), `claudeExecuteSandboxNetworkPolicy`
+  (default `anthropic-github`), `claudeExecuteSandboxExtraWritePaths` — interface, defaults, db
+  get()/set() parse + validate.
+- [x] UI: claude EXECUTE programmatic selectable only when sandbox enabled (else tooltip); claude
+  terminalFix/instant stay disabled; added a "Sandbox Claude execute" toggle + network-policy select.
+- [x] Tests: `srt.test.ts` (policy schema completeness, path filtering, network presets, resolver,
+  cleanup) + `cli-provider.execute-sandboxed.test.ts` (fail-closed, srt-wrapped spawn shape, cleanup,
+  interactive untouched). Updated docs + memory. Gates: typecheck green, 355 tests pass, biome clean.
+
+### Key decisions
+
+- **Wrap the whole process, not just Bash.** Built-in `/sandbox` is Bash-only; `srt` wraps file
+  tools + MCP, which is what EXECUTE needs. Confirmed by docs + the empirical write-confinement test.
+- **Fail closed, never silent.** No osSandbox hint or unresolved srt → error, no unsandboxed spawn.
+- **Bundle srt pinned (0.0.55)** rather than require a global install — avoids the CVE range
+  (≤0.0.16) and config drift, and removes user-install friction. Resolved via `require.resolve`.
+- **Default enabled, run-mode still interactive.** `claudeExecuteSandboxEnabled: true` makes
+  programmatic claude execute *selectable*; the run-mode default stays interactive, so the default
+  pipeline (codex executor) is unchanged and no srt runtime dependency is forced on anyone.
+
+### Files changed (this session)
+
+- `A packages/agents/src/sandbox/srt.ts`, `A packages/agents/src/sandbox/srt.test.ts`
+- `A packages/agents/src/providers/cli-provider.execute-sandboxed.test.ts`
+- `M packages/agents/package.json` (+ `bun.lock`)
+- `M packages/agents/src/process-manager.ts`, `M packages/agents/src/providers/cli-provider.ts`
+- `M packages/agents/src/providers/types.ts`
+- `M packages/pipeline/src/pipeline/runtime.ts`
+- `M packages/shared/src/constants.ts`, `M packages/shared/src/types/settings.ts`,
+  `M packages/shared/src/types/pipeline-core.ts`
+- `M packages/db/src/queries/settings.ts`
+- `M apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx`
+- `M apps/docs/content/desktop/settings.mdx`, `M .agents/memory/interactive-cli-run-modes.md`
+
+### Mistakes and fixes
+
+- **Was wrong that `claude -p` has no OS sandbox.** It does (settings.json `sandbox.enabled`, works
+  headless; `--permission-mode auto` is real). Corrected; the Bash-only caveat is what justified
+  wrapping the whole process in srt instead.
+- **First srt policy was partial** → srt rejected it (`denyWrite: Required`) and fail-closed. Lesson:
+  srt's schema is strict; always emit the full key set. Encoded in `buildSrtPolicy`.
+
+### Adversarial review + hardening (37-agent workflow, 26 confirmed findings)
+
+Ran a 4-dimension adversarial review (sandbox-escape / fail-closed / wiring / portability) with
+per-finding verification. Fixed the real ones in the same PR:
+
+- **CRITICAL — packaging.** srt was only a transitive dep; would be dead in packaged Electron
+  (require.resolve inside app.asar can't be spawned). Fix: added `@anthropic-ai/sandbox-runtime` to
+  `apps/desktop` deps, `asarUnpack` glob in `electron-builder.yml`, the package to vite
+  `NATIVE_EXTERNALS`, and a `unpackAsarPath()` rewrite in `resolveSrt` (app.asar → app.asar.unpacked).
+- **HIGH — `~/.claude` write escape.** Whole-dir write let a run plant `CLAUDE.md`/commands/agents
+  affecting future host sessions. Fix: scoped allowWrite to `~/.claude/todos|statsig|.credentials.json`
+  + `~/.claude.json`, and `denyWrite` for `CLAUDE.md`/`commands`/`agents`/`settings.json`.
+- **MED** — dropped `*.anthropic.com` wildcard → exact hosts; expanded `denyRead`
+  (`~/.config`, `~/.gitconfig`, `~/.docker`, `~/.kube`, `~/.pypirc`, …); `fs.realpath` canonicalization
+  of worktree + tmpdir (macOS `/var`→`/private/var`); `buildSrtPolicy` try/catch so a throw after
+  mkdtemp never leaks the temp dir; UI resets `claude.execute`→interactive when the sandbox toggles off.
+- **LOW** — `resolveCommand` absolute-path short-circuit; `registerSandboxBinary` write-once guard;
+  extra-write-path traversal/system-root validation (db + srt backstop); prompt-on-abort policy
+  cleanup; fixed stale UI copy; removed dead `sandboxPrimitiveAvailable`; added `binary_missing` +
+  try/finally temp-dir tests; corrected the "fail-closed" comment (srt actually opens on bad config —
+  which is *why* we always emit a complete policy).
+
+Re-verified: typecheck 11/11, 356 tests pass, biome clean.
+
+### Next steps
+
+- **Verify in the packaged app:** confirm `asarUnpack` lands srt on disk and the `app.asar.unpacked`
+  path rewrite resolves (works in dev; needs a real `electron-builder` build to confirm prod).
+- **Orphan-child on abort (deferred):** verify SIGTERM to the `srt` parent also kills the inner
+  `claude`; if not, spawn detached + kill the process group. Bounded today by the 2s grace timeout +
+  sandbox containment.
+- **Linux CI smoke (deferred):** add a Linux-only probe running `node <srt cli.js> --help` to catch a
+  broken bundled binary.
+- Optionally flip `agentRunModes.claude.execute` default → `programmatic` once srt is proven in the
+  packaged app on the target platforms.
+- Wire specific shipshitdev/skills into pipeline phase prompts.

--- a/.agents/memory/interactive-cli-run-modes.md
+++ b/.agents/memory/interactive-cli-run-modes.md
@@ -31,17 +31,30 @@ token/cost telemetry, and it composes with skills.
 - Default executor/planner/reviewer/verifier are all `codex`, so the out-of-box pipeline
   runs fully programmatic.
 
-**Security guard (independent of billing):** programmatic **Claude** `execute`, `terminalFix`,
-and `instant` would spawn `claude -p` with host `Edit/Write/Bash` and **no OS sandbox**.
-These stay on the interactive CLI regardless of settings:
-- `cli-provider.ts` hard-rejects `req.phase === 'execute' && runMode !== 'interactive'` for
-  claude with a clear error.
-- Structured claude phases are safe because `buildClaudeCommand` passes `--disallowedTools`
-  for *every* host tool (Edit/Write/Bash/Read/Glob/Grep/Task/Web*), i.e. pure prompt→JSON.
-- `register-instant-handlers.ts` `getRunMode` coerces claude programmatic → interactive for
-  instant/terminalFix. Codex is OS-sandboxed (`codex exec --sandbox`) so it runs programmatic.
-- The settings UI keeps the `programmatic` option disabled for the Claude execute/terminalFix/
-  instant rows (tooltip cites the sandbox reason); Codex rows are fully selectable.
+**Security guard (independent of billing):** programmatic **Claude** `execute`/`terminalFix`/
+`instant` would spawn `claude -p` with host `Edit/Write/Bash` and no *built-in* OS sandbox (the
+Claude Code Bash sandbox only constrains Bash, not the Edit/Write file tools or MCP). Handling:
+- **execute** → programmatic is allowed but ONLY wrapped in the `srt` OS sandbox
+  (`@anthropic-ai/sandbox-runtime`, Seatbelt/bubblewrap), which contains the WHOLE claude process
+  incl. file tools + MCP. The runtime sets `phaseHints.osSandbox` (from `claudeExecuteSandboxEnabled`)
+  and `cli-provider` spawns `srt -s <policy> claude -p …`. If the hint is absent (sandbox off) or
+  `srt` cannot be resolved, execute **fails closed** — it is never run unsandboxed. See `sandbox/srt.ts`.
+- **terminalFix / instant** → no srt path on those surfaces; `register-instant-handlers.ts`
+  `getRunMode` coerces claude programmatic → interactive. Codex is OS-sandboxed (`codex exec
+  --sandbox`) so codex runs programmatic everywhere.
+- Structured claude phases are safe because `buildClaudeCommand` passes `--disallowedTools` for
+  *every* host tool (Edit/Write/Bash/Read/Glob/Grep/Task/Web*), i.e. pure prompt→JSON.
+- The settings UI enables `programmatic` for the Claude **execute** row only when
+  `claudeExecuteSandboxEnabled`; Claude terminalFix/instant rows stay disabled; Codex rows are
+  fully selectable. A "Sandbox Claude execute" toggle + network-policy select live in the same panel.
+
+**srt policy (per-run, `sandbox/srt.ts`):** written to a 0700 mkdtemp dir, full strict schema
+(srt rejects partial configs and fail-closes). `allowWrite` = worktree + tmp + `~/.claude`(.json) +
+extra paths; `denyRead` = `~/.ssh`/`~/.aws`/`~/.gnupg`/`~/.config/gh`/`~/.npmrc`/`~/.netrc`;
+network deny-by-default with an `anthropic-only` | `anthropic-github` allowlist preset. Verified
+empirically (v0.0.55): srt passes stdin through, propagates the exact child exit code, confines
+writes, and blocks non-allowlisted domains. `srt` is bundled as a dep of `@shipcode/agents`,
+resolved via `require.resolve` and registered as the one allowlisted sandbox binary in ProcessManager.
 
 **Safety net retained:** if Anthropic ever re-rations the Agent-SDK pool, `markPoolExhausted`/
 `isPoolExhausted` (`agent-sdk-pool-state.ts`) still flips programmatic claude → interactive at
@@ -55,8 +68,10 @@ plus ShipCode lifecycle markers — do not pass raw interactive output off as pr
 **Grep-stable anchors:**
 - Defaults: `agentRunModes` in `packages/shared/src/constants.ts`.
 - Types/docs: `AgentRunModeConfig` in `packages/shared/src/types/pipeline-core.ts`.
-- Security guard: `'Programmatic Claude execute is disabled'` in `packages/agents/src/providers/cli-provider.ts`.
+- Execute sandbox gate: `'requires the OS sandbox'` + `osSandbox` in `packages/agents/src/providers/cli-provider.ts`.
+- srt wrapper: `buildSandboxedClaudeExecuteCommand` / `resolveSrt` / `buildSrtPolicy` in `packages/agents/src/sandbox/srt.ts`.
+- Allowlist escape: `registerSandboxBinary` in `packages/agents/src/process-manager.ts`.
 - Tool policy: `PHASE_TOOL_POLICIES` in `packages/agents/src/providers/types.ts`.
-- Pipeline routing: `getAgentPhaseRunMode` + `effectiveRunMode` in `packages/pipeline/src/pipeline/runtime.ts`.
+- Pipeline routing: `getAgentPhaseRunMode` + `osSandbox` hint in `packages/pipeline/src/pipeline/runtime.ts`.
 - Instant routing: `getRunMode` in `apps/desktop/src/main/ipc/register-instant-handlers.ts`.
 - UI: `RunModeSelect` / "Agent Output Mode" in `apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx`.

--- a/.agents/memory/interactive-cli-run-modes.md
+++ b/.agents/memory/interactive-cli-run-modes.md
@@ -1,39 +1,62 @@
 ---
 name: interactive_cli_run_modes
-description: Interactive provider CLI mode streams raw terminal events; programmatic Claude JSON requires claude -p and is billing-sensitive
+description: Run-mode routing — programmatic (claude -p / codex exec) is the default for structured phases; interactive CLI streams raw terminal events; Claude execute/instant/terminalFix stay interactive for host-sandbox safety
 type: project
 status: active
-last_verified: 2026-05-17
-topics: [claude-cli, codex-cli, pipeline, settings, terminal-events, billing]
+last_verified: 2026-06-16
+topics: [claude-cli, codex-cli, pipeline, settings, terminal-events, billing, security]
 ---
 
-**Rule:** For Claude billing-sensitive paths, prefer **interactive CLI mode** over `claude -p` / Agent SDK / headless mode. Interactive mode launches the real provider terminal and ShipCode wraps its PTY output in our own terminal events.
+**Rule:** `programmatic` (`claude -p` / `codex exec --json`) is the **default** transport
+for the structured reasoning phases. Anthropic reverted the 2026 Agent-SDK billing change
+(May→June 2026: "we're not making this change today"), so `claude -p` draws from the normal
+subscription seat again. Programmatic is preferred for automation: structured stream-json,
+token/cost telemetry, and it composes with skills.
 
-**Why:** Anthropic's 2026 Claude Agent SDK billing update separates non-interactive `claude -p`, Agent SDK, GitHub Actions, and third-party SDK app usage from normal Claude Code terminal/IDE subscription usage. Claude's official `stream-json` output is only for print/headless mode (`claude -p --output-format stream-json`), not the interactive terminal.
+**Two transports per agent/phase (`AppSettings.agentRunModes[agent][phase]`):**
+- `programmatic` — `claude -p --output-format stream-json` / `codex exec - --json`.
+- `interactive` — launches the real provider terminal CLI; ShipCode wraps raw PTY output in
+  its own terminal events (`terminal:start`, `terminal:raw_output`, `terminal:exit`) and
+  completes on process `exit`. Claude interactive args must **not** include `-p`; codex
+  interactive args must **not** include `exec`. Prompt content goes to
+  `.shipcode/runs/<threadId>/<phase>-prompt.md`; the CLI gets a short "read that artifact"
+  instruction.
 
-**How interactive mode works:**
-- ShipCode starts the provider CLI as a managed process.
-- Claude interactive args must **not** include `-p`.
-- Codex interactive args must **not** include `exec`.
-- Prompt content is written to `.shipcode/runs/<threadId>/<phase>-prompt.md`, and the interactive CLI receives a short instruction to read that artifact.
-- ShipCode streams raw PTY chunks into canonical terminal events like `terminal:start`, `terminal:raw_output`, and `terminal:exit`.
-- Completion is known from the process `exit` event and exit code, then the pipeline advances to verification or failure handling.
+**Defaults (DEFAULT_SETTINGS.agentRunModes):**
+- `plan / review / revision / verify` → **programmatic** for both claude and codex.
+- `execute` → **programmatic for codex** (sandboxed via `codex exec --sandbox`),
+  **interactive for claude** (see security guard below).
+- `terminalFix / instant` → **interactive** for both (watched terminal-pane surfaces).
+- `issueTerminal` → always interactive.
+- Default executor/planner/reviewer/verifier are all `codex`, so the out-of-box pipeline
+  runs fully programmatic.
 
-**What we do and do not get:**
-- We do get the visible terminal transcript: provider messages, command output, edits/tests as printed by the CLI, and lifecycle exit status.
-- We do not get Claude's official structured event stream (`tool_call`, `assistant_message_delta`, usage JSON, etc.) unless using `claude -p --output-format stream-json`.
-- It is acceptable to display ShipCode lifecycle markers around the terminal stream, but do not pretend raw interactive output is provider-native JSON.
+**Security guard (independent of billing):** programmatic **Claude** `execute`, `terminalFix`,
+and `instant` would spawn `claude -p` with host `Edit/Write/Bash` and **no OS sandbox**.
+These stay on the interactive CLI regardless of settings:
+- `cli-provider.ts` hard-rejects `req.phase === 'execute' && runMode !== 'interactive'` for
+  claude with a clear error.
+- Structured claude phases are safe because `buildClaudeCommand` passes `--disallowedTools`
+  for *every* host tool (Edit/Write/Bash/Read/Glob/Grep/Task/Web*), i.e. pure prompt→JSON.
+- `register-instant-handlers.ts` `getRunMode` coerces claude programmatic → interactive for
+  instant/terminalFix. Codex is OS-sandboxed (`codex exec --sandbox`) so it runs programmatic.
+- The settings UI keeps the `programmatic` option disabled for the Claude execute/terminalFix/
+  instant rows (tooltip cites the sandbox reason); Codex rows are fully selectable.
 
-**Settings contract:**
-- `AppSettings.agentRunModes` controls routing per provider/action.
-- Current default is `interactive` for `issueTerminal`, `execute`, `terminalFix`, and `instant`.
-- Programmatic mode remains a future/explicit path and should be disabled in UI while Claude non-interactive billing is unsettled.
-- If stored settings request programmatic Claude for terminal-like actions, fail clearly instead of silently using `claude -p`.
+**Safety net retained:** if Anthropic ever re-rations the Agent-SDK pool, `markPoolExhausted`/
+`isPoolExhausted` (`agent-sdk-pool-state.ts`) still flips programmatic claude → interactive at
+runtime, and `AppSettings.forceInteractiveClaude` forces interactive globally. Pool exhaustion
+is inferred from `claude -p` failure output (no balance API).
+
+**What programmatic gives vs interactive:** programmatic yields the official structured event
+stream (`tool_call`, usage JSON, cost). Interactive yields only the visible PTY transcript
+plus ShipCode lifecycle markers — do not pass raw interactive output off as provider-native JSON.
 
 **Grep-stable anchors:**
-- Settings/defaults: `agentRunModes` in `packages/shared/src/constants.ts`.
-- UI: `Agent Output Mode` in `apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx`.
-- Instant terminal routing: `startInteractiveInstantSession` in `apps/desktop/src/main/ipc/register-instant-handlers.ts`.
-- Pipeline execute routing: `runMode` phase hint in `packages/pipeline/src/pipeline/runtime.ts`.
-- CLI provider interactive execute: `buildClaudeInteractiveExecuteCommand` and `buildCodexInteractiveExecuteCommand` in `packages/agents/src/providers/cli-provider.ts`.
-
+- Defaults: `agentRunModes` in `packages/shared/src/constants.ts`.
+- Types/docs: `AgentRunModeConfig` in `packages/shared/src/types/pipeline-core.ts`.
+- Security guard: `'Programmatic Claude execute is disabled'` in `packages/agents/src/providers/cli-provider.ts`.
+- Tool policy: `PHASE_TOOL_POLICIES` in `packages/agents/src/providers/types.ts`.
+- Pipeline routing: `getAgentPhaseRunMode` + `effectiveRunMode` in `packages/pipeline/src/pipeline/runtime.ts`.
+- Instant routing: `getRunMode` in `apps/desktop/src/main/ipc/register-instant-handlers.ts`.
+- UI: `RunModeSelect` / "Agent Output Mode" in `apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx`.

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -7,6 +7,11 @@ directories:
 files:
   - dist/**/*
   - package.json
+# The srt sandbox CLI (and its native seccomp helper) must live on the real
+# filesystem so it can be spawned as a subprocess — it cannot run from inside
+# app.asar. resolveSrt() rewrites the resolved path to app.asar.unpacked.
+asarUnpack:
+  - node_modules/@anthropic-ai/sandbox-runtime/**
 mac:
   target:
     - dmg

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -5,6 +5,7 @@
     "url": "https://shipshit.dev"
   },
   "dependencies": {
+    "@anthropic-ai/sandbox-runtime": "0.0.55",
     "@fontsource/dm-sans": "5.2.8",
     "@sentry/electron": "7.13.0",
     "@shipcode/agents": "workspace:*",

--- a/apps/desktop/src/main/ipc/register-instant-handlers.ts
+++ b/apps/desktop/src/main/ipc/register-instant-handlers.ts
@@ -2,7 +2,7 @@ import crypto from 'node:crypto';
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
-import { extractCodexThreadId, isPoolExhausted } from '@shipcode/agents';
+import { extractCodexThreadId } from '@shipcode/agents';
 import {
   type InstantFixScope,
   type ProviderRunMode,
@@ -56,24 +56,16 @@ function getRunMode(
 ): ProviderRunMode {
   const settings = queries.settings.get();
   const configured = settings.agentRunModes[cli][action];
-  // Claude programmatic draws from the rationed Agent-SDK credit pool. Coerce
-  // to interactive when the user forces it or the pool is exhausted so the run
-  // succeeds against the interactive seat instead of failing.
-  if (
-    cli === 'claude' &&
-    configured === 'programmatic' &&
-    (settings.forceInteractiveClaude || isPoolExhausted())
-  ) {
+  // Programmatic Claude instant/terminalFix spawns `claude -p` with host
+  // Edit/Write/Bash tools and NO OS sandbox (unlike codex `exec --sandbox`),
+  // so it is never allowed for these surfaces — always coerce to the
+  // interactive CLI. The `forceInteractiveClaude` / pool-exhaustion escape
+  // hatch is folded in here as defense-in-depth. Codex programmatic is
+  // OS-sandboxed and passes through unchanged.
+  if (cli === 'claude' && configured === 'programmatic') {
     return 'interactive';
   }
   return configured;
-}
-
-function assertProgrammaticRunAllowed(cli: InstantCli): void {
-  if (cli !== 'claude') return;
-  throw new Error(
-    'Programmatic Claude runs are disabled while non-interactive billing is unsettled. Use Interactive CLI mode.',
-  );
 }
 
 async function writePromptArtifact(args: {
@@ -517,8 +509,6 @@ export function registerInstantHandlers({
         return { threadId: thread.id };
       }
 
-      assertProgrammaticRunAllowed(args.cli);
-
       // 5. Build CLI args (prompt piped via stdin, not argv)
       let cliArgs: string[];
       if (args.cli === 'claude') {
@@ -660,8 +650,6 @@ export function registerInstantHandlers({
         return { threadId: thread.id };
       }
 
-      assertProgrammaticRunAllowed(args.cli);
-
       const sessionId = args.cli === 'claude' ? crypto.randomUUID() : undefined;
       const cliArgs =
         args.cli === 'claude'
@@ -760,8 +748,6 @@ export function registerInstantHandlers({
         );
         return { threadId: thread.id, cli, title };
       }
-
-      assertProgrammaticRunAllowed(cli);
 
       const proc =
         cli === 'claude'

--- a/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.test.tsx
@@ -215,7 +215,7 @@ describe('PipelineSettingsSection', () => {
     expect(onUpdate).toHaveBeenCalledWith({ testingContext: null });
   });
 
-  it('shows interactive-only agent output mode controls', () => {
+  it('shows editable agent output mode controls and the Claude execute sandbox toggle', () => {
     render(
       <PipelineSettingsSection
         settings={DEFAULT_SETTINGS}
@@ -227,13 +227,49 @@ describe('PipelineSettingsSection', () => {
     expect(screen.getByText('Agent Output Mode')).toBeInTheDocument();
     expect(screen.getByText('Claude execute output')).toBeInTheDocument();
     expect(screen.getByText('Codex execute output')).toBeInTheDocument();
+    // Sandbox toggle gates whether programmatic Claude execute is selectable.
+    expect(screen.getByRole('switch', { name: 'Sandbox Claude execute' })).toBeInTheDocument();
+    // The six run-mode selects (claude/codex × execute/terminalFix/instant) are
+    // now editable, not hard-disabled. Codex execute defaults to Programmatic.
     const modeControls = screen.getAllByRole('combobox').filter((control) => {
-      return control.textContent?.includes('Interactive CLI');
+      const text = control.textContent ?? '';
+      return text.includes('Interactive CLI') || text.includes('Programmatic');
     });
-    expect(modeControls).toHaveLength(6);
+    expect(modeControls.length).toBeGreaterThanOrEqual(6);
     for (const control of modeControls) {
-      expect(control).toBeDisabled();
+      expect(control).not.toBeDisabled();
     }
+  });
+
+  it('reverts programmatic Claude execute to interactive when the sandbox is turned off', () => {
+    const onUpdate = vi.fn();
+    const settings: AppSettings = {
+      ...DEFAULT_SETTINGS,
+      claudeExecuteSandboxEnabled: true,
+      agentRunModes: {
+        ...DEFAULT_SETTINGS.agentRunModes,
+        claude: { ...DEFAULT_SETTINGS.agentRunModes.claude, execute: 'programmatic' },
+      },
+    };
+
+    render(
+      <PipelineSettingsSection
+        settings={settings}
+        integrationStatus={integrationStatus}
+        onUpdate={onUpdate}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('switch', { name: 'Sandbox Claude execute' }));
+
+    expect(onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        claudeExecuteSandboxEnabled: false,
+        agentRunModes: expect.objectContaining({
+          claude: expect.objectContaining({ execute: 'interactive' }),
+        }),
+      }),
+    );
   });
 
   it('labels PRD rewrite settings as shared format settings', () => {

--- a/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx
@@ -178,7 +178,7 @@ function pipelineSettingsSection({
         <TabsContent value="runtime" className="mt-0">
           <SettingsSection
             title="Agent Output Mode"
-            description="Per-surface transport for execute, terminal fixes, and instant sessions. Programmatic streams structured claude -p / codex exec output; Interactive drives the official CLI in a terminal pane. Pipeline plan/review/verify default to programmatic and are not shown here. Programmatic Claude execute requires the OS sandbox (enabled below); Claude terminal-fix and instant stay interactive-only (no sandbox path); Codex is always sandboxed."
+            description="Per-surface transport for execute, terminal fixes, and instant sessions. Programmatic streams structured claude -p / codex exec output; Interactive drives the official CLI in a terminal pane. Pipeline plan/review/revision/verify default to programmatic and are not shown here. Programmatic Claude execute requires the OS sandbox (enabled below); Claude terminal-fix and instant stay interactive-only (no sandbox path); Codex is always sandboxed."
           >
             <SettingsRow
               label="Claude execute output"

--- a/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx
@@ -41,28 +41,61 @@ import { ChevronDown } from 'lucide-react';
 import { getModelOptions } from '../model-provider-options-data';
 import { PhaseModelRow } from './PhaseModelRow';
 
-function RunModeSelect({ value }: { value: AppSettings['agentRunModes']['claude']['execute'] }) {
+type RunModeValue = AppSettings['agentRunModes']['claude']['execute'];
+type RunModePhase = 'execute' | 'terminalFix' | 'instant';
+
+function RunModeSelect({
+  agent,
+  phase,
+  settings,
+  onUpdate,
+}: {
+  agent: 'claude' | 'codex';
+  phase: RunModePhase;
+  settings: AppSettings;
+  onUpdate: (patch: Partial<AppSettings>) => void;
+}) {
+  const value = settings.agentRunModes[agent][phase];
+  // Programmatic Claude on these surfaces spawns `claude -p` with host
+  // Edit/Write/Bash tools and NO OS sandbox, so it stays disabled. Codex runs
+  // through `codex exec --sandbox`, so programmatic is safe and selectable.
+  const programmaticBlocked = agent === 'claude';
+
+  const handleChange = (next: RunModeValue) => {
+    onUpdate({
+      agentRunModes: {
+        ...settings.agentRunModes,
+        [agent]: { ...settings.agentRunModes[agent], [phase]: next },
+      },
+    });
+  };
+
+  const select = (
+    <Select value={value} onValueChange={(next) => handleChange(next as RunModeValue)}>
+      <SelectTrigger className="w-[190px]">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="interactive">Interactive CLI</SelectItem>
+        <SelectItem value="programmatic" disabled={programmaticBlocked}>
+          Programmatic
+        </SelectItem>
+      </SelectContent>
+    </Select>
+  );
+
+  if (!programmaticBlocked) return select;
+
   return (
     <TooltipProvider>
       <Tooltip>
         <TooltipTrigger asChild>
-          <span className="inline-flex cursor-not-allowed">
-            <Select value={value} disabled>
-              <SelectTrigger className="w-[190px]">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="interactive">Interactive CLI</SelectItem>
-                <SelectItem value="programmatic" disabled>
-                  Programmatic
-                </SelectItem>
-              </SelectContent>
-            </Select>
-          </span>
+          <span className="inline-flex">{select}</span>
         </TooltipTrigger>
         <TooltipContent side="top" className="max-w-[300px]">
-          Programmatic mode is disabled while Claude non-interactive billing is unsettled. ShipCode
-          will not route Claude through claude -p or SDK wrappers by default.
+          Programmatic mode runs claude -p with host file/shell tools and no OS sandbox, so it stays
+          disabled for Claude here. Use Interactive CLI for Claude, or Codex (which runs sandboxed
+          via codex exec) for programmatic output.
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>
@@ -139,43 +172,73 @@ function pipelineSettingsSection({
         <TabsContent value="runtime" className="mt-0">
           <SettingsSection
             title="Agent Output Mode"
-            description="Interactive CLI output is the active path. Programmatic mode stays visible for future structured automation, but is disabled while Claude non-interactive billing is unsettled."
+            description="Per-surface transport for execute, terminal fixes, and instant sessions. Programmatic streams structured claude -p / codex exec output; Interactive drives the official CLI in a terminal pane. Pipeline plan/review/verify default to programmatic and are not shown here. Programmatic Claude is disabled for these surfaces because it grants host tools without an OS sandbox — use Codex (sandboxed) for programmatic output."
           >
             <SettingsRow
               label="Claude execute output"
-              description="Uses the official Claude CLI session surface. Does not route through claude -p."
+              description="Claude execute stays on the interactive CLI: programmatic claude -p would run host Edit/Write/Bash with no OS sandbox."
             >
-              <RunModeSelect value={settings.agentRunModes.claude.execute} />
+              <RunModeSelect
+                agent="claude"
+                phase="execute"
+                settings={settings}
+                onUpdate={onUpdate}
+              />
             </SettingsRow>
             <SettingsRow
               label="Claude terminal fix output"
               description="Terminal fixes open as supervised interactive CLI sessions."
             >
-              <RunModeSelect value={settings.agentRunModes.claude.terminalFix} />
+              <RunModeSelect
+                agent="claude"
+                phase="terminalFix"
+                settings={settings}
+                onUpdate={onUpdate}
+              />
             </SettingsRow>
             <SettingsRow
               label="Claude instant output"
               description="Instant assistant output stays attached to an interactive terminal pane."
             >
-              <RunModeSelect value={settings.agentRunModes.claude.instant} />
+              <RunModeSelect
+                agent="claude"
+                phase="instant"
+                settings={settings}
+                onUpdate={onUpdate}
+              />
             </SettingsRow>
             <SettingsRow
               label="Codex execute output"
-              description="Uses official Codex CLI output instead of a synthetic console stream."
+              description="Codex execute defaults to programmatic — codex exec runs inside an OS sandbox (workspace-write)."
             >
-              <RunModeSelect value={settings.agentRunModes.codex.execute} />
+              <RunModeSelect
+                agent="codex"
+                phase="execute"
+                settings={settings}
+                onUpdate={onUpdate}
+              />
             </SettingsRow>
             <SettingsRow
               label="Codex terminal fix output"
-              description="Terminal fixes open as supervised interactive CLI sessions."
+              description="Interactive opens a supervised terminal pane; programmatic streams sandboxed codex exec output."
             >
-              <RunModeSelect value={settings.agentRunModes.codex.terminalFix} />
+              <RunModeSelect
+                agent="codex"
+                phase="terminalFix"
+                settings={settings}
+                onUpdate={onUpdate}
+              />
             </SettingsRow>
             <SettingsRow
               label="Codex instant output"
-              description="Instant assistant output stays attached to an interactive terminal pane."
+              description="Interactive keeps the terminal pane; programmatic streams sandboxed codex exec output."
             >
-              <RunModeSelect value={settings.agentRunModes.codex.instant} />
+              <RunModeSelect
+                agent="codex"
+                phase="instant"
+                settings={settings}
+                onUpdate={onUpdate}
+              />
             </SettingsRow>
           </SettingsSection>
 

--- a/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx
@@ -56,10 +56,18 @@ function RunModeSelect({
   onUpdate: (patch: Partial<AppSettings>) => void;
 }) {
   const value = settings.agentRunModes[agent][phase];
-  // Programmatic Claude on these surfaces spawns `claude -p` with host
-  // Edit/Write/Bash tools and NO OS sandbox, so it stays disabled. Codex runs
-  // through `codex exec --sandbox`, so programmatic is safe and selectable.
-  const programmaticBlocked = agent === 'claude';
+  // Codex always runs sandboxed (`codex exec --sandbox`), so programmatic is
+  // selectable. For Claude, programmatic spawns `claude -p` with host
+  // Edit/Write/Bash and no built-in sandbox:
+  //   - execute: allowed only when the srt OS sandbox is enabled (it wraps the
+  //     whole process); blocked otherwise.
+  //   - terminalFix / instant: no sandbox path on those surfaces, so blocked.
+  const programmaticBlocked =
+    agent === 'claude' && !(phase === 'execute' && settings.claudeExecuteSandboxEnabled);
+  const blockedReason =
+    agent === 'claude' && phase === 'execute'
+      ? 'Programmatic Claude execute runs inside the srt OS sandbox. Enable “Sandbox Claude execute” below to select it.'
+      : 'Programmatic mode runs claude -p with host file/shell tools and no OS sandbox, so it stays disabled for Claude here. Use Codex (sandboxed via codex exec) for programmatic output.';
 
   const handleChange = (next: RunModeValue) => {
     onUpdate({
@@ -93,9 +101,7 @@ function RunModeSelect({
           <span className="inline-flex">{select}</span>
         </TooltipTrigger>
         <TooltipContent side="top" className="max-w-[300px]">
-          Programmatic mode runs claude -p with host file/shell tools and no OS sandbox, so it stays
-          disabled for Claude here. Use Interactive CLI for Claude, or Codex (which runs sandboxed
-          via codex exec) for programmatic output.
+          {blockedReason}
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>
@@ -172,11 +178,11 @@ function pipelineSettingsSection({
         <TabsContent value="runtime" className="mt-0">
           <SettingsSection
             title="Agent Output Mode"
-            description="Per-surface transport for execute, terminal fixes, and instant sessions. Programmatic streams structured claude -p / codex exec output; Interactive drives the official CLI in a terminal pane. Pipeline plan/review/verify default to programmatic and are not shown here. Programmatic Claude is disabled for these surfaces because it grants host tools without an OS sandbox — use Codex (sandboxed) for programmatic output."
+            description="Per-surface transport for execute, terminal fixes, and instant sessions. Programmatic streams structured claude -p / codex exec output; Interactive drives the official CLI in a terminal pane. Pipeline plan/review/verify default to programmatic and are not shown here. Programmatic Claude execute requires the OS sandbox (enabled below); Claude terminal-fix and instant stay interactive-only (no sandbox path); Codex is always sandboxed."
           >
             <SettingsRow
               label="Claude execute output"
-              description="Claude execute stays on the interactive CLI: programmatic claude -p would run host Edit/Write/Bash with no OS sandbox."
+              description="Interactive drives the CLI in a terminal pane. Programmatic runs claude -p inside the srt OS sandbox — enable “Sandbox Claude execute” below to unlock it."
             >
               <RunModeSelect
                 agent="claude"
@@ -240,6 +246,54 @@ function pipelineSettingsSection({
                 onUpdate={onUpdate}
               />
             </SettingsRow>
+            <SettingsRow
+              label="Sandbox Claude execute"
+              htmlFor="claude-execute-sandbox"
+              description="Required to select Programmatic for Claude execute. Wraps claude -p in the srt OS sandbox (macOS Seatbelt / Linux bubblewrap) so file, shell, and MCP access is confined to the worktree. When off, programmatic Claude execute is disabled."
+            >
+              <Switch
+                id="claude-execute-sandbox"
+                checked={settings.claudeExecuteSandboxEnabled}
+                onCheckedChange={(checked: boolean) => {
+                  // Turning the sandbox off also reverts a programmatic Claude
+                  // execute selection to interactive, so settings never persist
+                  // the incoherent "programmatic + no sandbox" combination (which
+                  // would fail closed at run time).
+                  const patch: Partial<AppSettings> = { claudeExecuteSandboxEnabled: checked };
+                  if (!checked && settings.agentRunModes.claude.execute === 'programmatic') {
+                    patch.agentRunModes = {
+                      ...settings.agentRunModes,
+                      claude: { ...settings.agentRunModes.claude, execute: 'interactive' },
+                    };
+                  }
+                  onUpdate(patch);
+                }}
+              />
+            </SettingsRow>
+            {settings.claudeExecuteSandboxEnabled && (
+              <SettingsRow
+                label="Sandbox network policy"
+                description="Outbound allowlist for sandboxed Claude execute. Anthropic only is tightest; Anthropic + GitHub also permits GitHub and the npm registry for branch pushes and dependency installs."
+              >
+                <Select
+                  value={settings.claudeExecuteSandboxNetworkPolicy}
+                  onValueChange={(value) =>
+                    onUpdate({
+                      claudeExecuteSandboxNetworkPolicy:
+                        value as AppSettings['claudeExecuteSandboxNetworkPolicy'],
+                    })
+                  }
+                >
+                  <SelectTrigger className="w-[190px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="anthropic-only">Anthropic only</SelectItem>
+                    <SelectItem value="anthropic-github">Anthropic + GitHub</SelectItem>
+                  </SelectContent>
+                </Select>
+              </SettingsRow>
+            )}
           </SettingsSection>
 
           <SettingsSection>

--- a/apps/desktop/vite.config.ts
+++ b/apps/desktop/vite.config.ts
@@ -11,6 +11,8 @@ const NATIVE_EXTERNALS = [
   'node:sqlite',
   'node-pty',
   'simple-git',
+  // Resolved + spawned at runtime via createRequire; never bundle the shebang CLI.
+  '@anthropic-ai/sandbox-runtime',
   ...builtinModules,
   ...builtinModules.map((m) => `node:${m}`),
 ];

--- a/apps/docs/content/desktop/settings.mdx
+++ b/apps/docs/content/desktop/settings.mdx
@@ -39,7 +39,7 @@ Set `SHIPCODE_TELEMETRY_ENABLED=false` before launching the desktop app to disab
 | `maxConcurrentPipelines` | 3 | Workspace-wide active pipeline cap |
 | `maxConcurrentExecutions` | 3 | Per-project execution cap after planning/approval |
 | `pipelineSpeedProfile` | `smart_fast` | Default scheduling/execution profile |
-| `agentRunModes` | interactive | Per-provider output mode controls for Claude and Codex issue execution, terminal fixes, and instant sessions |
+| `agentRunModes` | programmatic (structured phases & Codex execute); interactive (Claude execute, terminal fixes, instant) | Per-provider, per-phase output transport. Programmatic streams `claude -p` / `codex exec --json`; interactive drives the official CLI in a terminal pane. Programmatic Claude execute/terminal-fix/instant is disabled (host tools, no OS sandbox); Codex programmatic runs sandboxed via `codex exec` |
 | `plannerReasoningEffort` | `low` | Default planner effort. Exact options depend on the selected provider |
 | `reviewerReasoningEffort` | `high` | Default reviewer effort. Exact options depend on the selected provider |
 | `executorReasoningEffort` | `medium` | Default executor effort. Exact options depend on the selected provider |

--- a/apps/docs/content/desktop/settings.mdx
+++ b/apps/docs/content/desktop/settings.mdx
@@ -39,7 +39,10 @@ Set `SHIPCODE_TELEMETRY_ENABLED=false` before launching the desktop app to disab
 | `maxConcurrentPipelines` | 3 | Workspace-wide active pipeline cap |
 | `maxConcurrentExecutions` | 3 | Per-project execution cap after planning/approval |
 | `pipelineSpeedProfile` | `smart_fast` | Default scheduling/execution profile |
-| `agentRunModes` | programmatic (structured phases & Codex execute); interactive (Claude execute, terminal fixes, instant) | Per-provider, per-phase output transport. Programmatic streams `claude -p` / `codex exec --json`; interactive drives the official CLI in a terminal pane. Programmatic Claude execute/terminal-fix/instant is disabled (host tools, no OS sandbox); Codex programmatic runs sandboxed via `codex exec` |
+| `agentRunModes` | programmatic (structured phases & Codex execute); interactive (Claude execute, terminal fixes, instant) | Per-provider, per-phase output transport. Programmatic streams `claude -p` / `codex exec --json`; interactive drives the official CLI in a terminal pane. Programmatic Claude execute requires the sandbox below; Claude terminal-fix/instant stay interactive (host tools, no sandbox path); Codex programmatic runs sandboxed via `codex exec` |
+| `claudeExecuteSandboxEnabled` | true | Required to select Programmatic for Claude execute. Wraps `claude -p` in the `srt` OS sandbox (`@anthropic-ai/sandbox-runtime`, macOS Seatbelt / Linux bubblewrap) so file/shell/MCP access is confined to the worktree. When false, programmatic Claude execute fails closed. No effect on Codex or the tool-less structured Claude phases |
+| `claudeExecuteSandboxNetworkPolicy` | `anthropic-github` | Outbound allowlist for the sandboxed execute run. `anthropic-only` = Anthropic API only; `anthropic-github` also permits GitHub + npm registry (branch pushes, dependency installs) |
+| `claudeExecuteSandboxExtraWritePaths` | `[]` | Extra absolute / `~`-prefixed paths the sandbox may write to, beyond the worktree and temp dir |
 | `plannerReasoningEffort` | `low` | Default planner effort. Exact options depend on the selected provider |
 | `reviewerReasoningEffort` | `high` | Default reviewer effort. Exact options depend on the selected provider |
 | `executorReasoningEffort` | `medium` | Default executor effort. Exact options depend on the selected provider |

--- a/bun.lock
+++ b/bun.lock
@@ -43,6 +43,7 @@
       "name": "@shipcode/desktop",
       "version": "0.1.2",
       "dependencies": {
+        "@anthropic-ai/sandbox-runtime": "0.0.55",
         "@fontsource/dm-sans": "5.2.8",
         "@sentry/electron": "7.13.0",
         "@shipcode/agents": "workspace:*",
@@ -142,6 +143,7 @@
       "name": "@shipcode/agents",
       "version": "0.1.2",
       "dependencies": {
+        "@anthropic-ai/sandbox-runtime": "0.0.55",
         "@shipcode/shared": "workspace:*",
         "nanoid": "5.1.11",
         "node-pty": "1.1.0",
@@ -246,6 +248,8 @@
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
     "@antfu/install-pkg": ["@antfu/install-pkg@1.1.0", "", { "dependencies": { "package-manager-detector": "^1.3.0", "tinyexec": "^1.0.1" } }, "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ=="],
+
+    "@anthropic-ai/sandbox-runtime": ["@anthropic-ai/sandbox-runtime@0.0.55", "", { "dependencies": { "@pondwader/socks5-server": "^1.0.10", "commander": "^12.1.0", "node-forge": "^1.4.0", "shell-quote": "^1.8.4", "zod": "^3.24.1" }, "bin": { "srt": "dist/cli.js" } }, "sha512-XGTLbzitn0y6OCdmqP5aYrBR0HlNi87ue++m9vMPxcNwaQeOj9i3f9CSWmXua8mv+Q8E55k4ZGlzJmpDHzQFBw=="],
 
     "@asamuzakjp/css-color": ["@asamuzakjp/css-color@5.1.11", "", { "dependencies": { "@asamuzakjp/generational-cache": "^1.0.1", "@csstools/css-calc": "^3.2.0", "@csstools/css-color-parser": "^4.1.0", "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg=="],
 
@@ -616,6 +620,8 @@
     "@oxc-project/types": ["@oxc-project/types@0.133.0", "", {}, "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA=="],
 
     "@playwright/test": ["@playwright/test@1.60.0", "", { "dependencies": { "playwright": "1.60.0" }, "bin": { "playwright": "cli.js" } }, "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag=="],
+
+    "@pondwader/socks5-server": ["@pondwader/socks5-server@1.0.10", "", {}, "sha512-bQY06wzzR8D2+vVCUoBsr5QS2U6UgPUQRmErNwtsuI6vLcyRKkafjkr3KxbtGFf9aBBIV2mcvlsKD1UYaIV+sg=="],
 
     "@prisma/instrumentation": ["@prisma/instrumentation@7.6.0", "", { "dependencies": { "@opentelemetry/instrumentation": "^0.207.0" }, "peerDependencies": { "@opentelemetry/api": "^1.8" } }, "sha512-ZPW2gRiwpPzEfgeZgaekhqXrbW+Y2RJKHVqUmlhZhKzRNCcvR6DykzylDrynpArKKRQtLxoZy36fK7U0p3pdgQ=="],
 
@@ -1977,6 +1983,8 @@
 
     "node-api-version": ["node-api-version@0.2.1", "", { "dependencies": { "semver": "^7.3.5" } }, "sha512-2xP/IGGMmmSQpI1+O/k72jF/ykvZ89JeuKX3TLJAYPDVLUalrshrLHkeVcCCZqG/eEa635cr8IBYzgnDvM2O8Q=="],
 
+    "node-forge": ["node-forge@1.4.0", "", {}, "sha512-LarFH0+6VfriEhqMMcLX2F7SwSXeWwnEAJEsYm5QKWchiVYVvJyV9v7UDvUv+w5HO23ZpQTXDv/GxdDdMyOuoQ=="],
+
     "node-gyp": ["node-gyp@12.3.0", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "graceful-fs": "^4.2.6", "nopt": "^9.0.0", "proc-log": "^6.0.0", "semver": "^7.3.5", "tar": "^7.5.4", "tinyglobby": "^0.2.12", "undici": "^6.25.0", "which": "^6.0.0" }, "bin": { "node-gyp": "bin/node-gyp.js" } }, "sha512-QNcUWM+HgJplcPzBvFBZ9VXacyGZ4+VTOb80PwWR+TlVzoHbRKULNEzpRsnaoxG3Wzr7Qh7BYxGDU3CbKib2Yg=="],
 
     "node-pty": ["node-pty@1.1.0", "", { "dependencies": { "node-addon-api": "^7.1.0" } }, "sha512-20JqtutY6JPXTUnL0ij1uad7Qe1baT46lyolh2sSENDd4sTzKZ4nmAFkeAARDKwmlLjPx6XKRlwRUxwjOy+lUg=="],
@@ -2247,6 +2255,8 @@
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
 
+    "shell-quote": ["shell-quote@1.8.4", "", {}, "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ=="],
+
     "shiki": ["shiki@4.2.0", "", { "dependencies": { "@shikijs/core": "4.2.0", "@shikijs/engine-javascript": "4.2.0", "@shikijs/engine-oniguruma": "4.2.0", "@shikijs/langs": "4.2.0", "@shikijs/themes": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
@@ -2506,6 +2516,10 @@
     "zustand": ["zustand@5.0.14", "", { "peerDependencies": { "@types/react": ">=18.0.0", "immer": ">=9.0.6", "react": ">=18.0.0", "use-sync-external-store": ">=1.2.0" }, "optionalPeers": ["@types/react", "immer", "react", "use-sync-external-store"] }, "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g=="],
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@anthropic-ai/sandbox-runtime/commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+
+    "@anthropic-ai/sandbox-runtime/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "@babel/code-frame/js-tokens": ["js-tokens@4.0.0", "", {}, "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="],
 

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -20,6 +20,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
+    "@anthropic-ai/sandbox-runtime": "0.0.55",
     "@shipcode/shared": "workspace:*",
     "node-pty": "1.1.0",
     "nanoid": "5.1.11",

--- a/packages/agents/src/process-manager.ts
+++ b/packages/agents/src/process-manager.ts
@@ -69,6 +69,25 @@ function filterEnv(env: Record<string, string>): Record<string, string> {
   return filtered;
 }
 
+/**
+ * Absolute path of the OS-sandbox binary (`srt`) resolved at runtime. Spawning
+ * the sandbox wrapper requires an allowlist escape, but we narrow it to the one
+ * exact resolved path — never the bare string "srt" — so this is not a general
+ * allowlist widening. Populated by resolveSrt() in sandbox/srt.ts.
+ */
+let allowedSandboxBinary: string | null = null;
+
+export function registerSandboxBinary(absolutePath: string): void {
+  // Write-once: only the first resolved sandbox binary is ever allowlisted.
+  // resolveSrt() caches, so this is effectively set a single time per process.
+  if (allowedSandboxBinary !== null) return;
+  allowedSandboxBinary = absolutePath;
+}
+
+function isAllowedSandboxBinary(command: string): boolean {
+  return allowedSandboxBinary !== null && command === allowedSandboxBinary;
+}
+
 function isTrustedShell(command: string): command is ProcessManagerShellCommand {
   return TRUSTED_SHELLS.has(command);
 }
@@ -85,7 +104,8 @@ function assertProcessManagerCommand(command: string): asserts command is Proces
   if (
     isTrustedShell(command) ||
     isAllowlistedAgentCommand(command) ||
-    isTrustedPackageCommand(command)
+    isTrustedPackageCommand(command) ||
+    isAllowedSandboxBinary(command)
   )
     return;
   throw new Error(`Command is not allowlisted for ProcessManager: ${command}`);
@@ -140,6 +160,10 @@ function getShellEnv(): Record<string, string> {
 function resolveCommand(command: string): string {
   assertProcessManagerCommand(command);
   if (isTrustedShell(command)) return command;
+  // Already-absolute paths (e.g. the resolved srt binary) passed the allowlist
+  // check and need no shell lookup — short-circuit to avoid a login-shell spawn
+  // and unquoted interpolation of paths containing spaces.
+  if (command.startsWith('/')) return command;
   const shell = process.env.SHELL;
   if (!shell || !isTrustedShell(shell)) return command;
   try {

--- a/packages/agents/src/providers/cli-provider.execute-sandbox-missing.test.ts
+++ b/packages/agents/src/providers/cli-provider.execute-sandbox-missing.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { ProcessManager } from '../process-manager';
+
+// Force the srt sandbox to resolve as unavailable for this whole file.
+vi.mock('../sandbox/srt', () => ({
+  buildSandboxedClaudeExecuteCommand: vi.fn(async () => null),
+  resolveSrt: vi.fn(() => ({
+    available: false,
+    command: null,
+    reason: 'srt sandbox unavailable: @anthropic-ai/sandbox-runtime not installed',
+  })),
+}));
+
+import { createClaudeCliProvider } from './cli-provider';
+import type { ProviderRequest } from './types';
+
+function mockPm() {
+  const spawnCalls: unknown[] = [];
+  const pm = {
+    spawn: vi.fn(() => {
+      spawnCalls.push(true);
+      return { id: 'p' };
+    }),
+    kill: vi.fn(),
+    on: vi.fn(),
+    removeListener: vi.fn(),
+  } as unknown as ProcessManager & { spawnWithStdin?: (...a: unknown[]) => { id: string } };
+  (pm as unknown as { spawnWithStdin: unknown }).spawnWithStdin = vi.fn(() => {
+    spawnCalls.push(true);
+    return { id: 'p' };
+  });
+  return { pm, spawnCalls };
+}
+
+describe('programmatic claude execute — srt unavailable', () => {
+  it('fails closed with binary_missing and never spawns', async () => {
+    const { pm, spawnCalls } = mockPm();
+    const provider = createClaudeCliProvider(pm);
+
+    const req: ProviderRequest = {
+      phase: 'execute',
+      prompt: 'DO IT',
+      cwd: '/tmp/wt',
+      projectPath: '/tmp/proj',
+      signal: new AbortController().signal,
+      threadId: 't1',
+      phaseHints: {
+        runMode: 'programmatic',
+        osSandbox: { backend: 'srt', networkPolicy: 'anthropic-github', extraWritePaths: [] },
+      },
+    };
+
+    const result = await provider.generate(req);
+
+    expect(spawnCalls).toHaveLength(0);
+    expect(result.exitCode).toBe(127);
+    expect(result.providerError?.kind).toBe('binary_missing');
+    expect(result.rawOutput).toMatch(/sandbox-runtime/i);
+  });
+});

--- a/packages/agents/src/providers/cli-provider.execute-sandboxed.test.ts
+++ b/packages/agents/src/providers/cli-provider.execute-sandboxed.test.ts
@@ -1,0 +1,141 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+import type { ProcessManager } from '../process-manager';
+import { createClaudeCliProvider } from './cli-provider';
+import type { ProviderRequest } from './types';
+
+/** Minimal ProcessManager mock: records spawnWithStdin calls, lets the test fire exit. */
+function mockPm() {
+  type Listener = (...args: unknown[]) => void;
+  const listeners: Record<string, Listener[]> = {};
+  const spawnCalls: Array<{ command: string; args: string[]; cwd: string; stdin?: string }> = [];
+  let n = 0;
+  const pm = {
+    spawn: vi.fn((_t: string, command: string, args: string[], cwd: string) => {
+      n++;
+      spawnCalls.push({ command, args, cwd });
+      return { id: `proc-${n}` };
+    }),
+    kill: vi.fn(),
+    on: vi.fn((event: string, h: Listener) => {
+      const handlers = listeners[event] ?? [];
+      handlers.push(h);
+      listeners[event] = handlers;
+    }),
+    removeListener: vi.fn((event: string, h: Listener) => {
+      listeners[event] = (listeners[event] ?? []).filter((x) => x !== h);
+    }),
+  } as unknown as ProcessManager & {
+    spawnWithStdin?: (...a: unknown[]) => { id: string };
+  };
+  (pm as unknown as { spawnWithStdin: unknown }).spawnWithStdin = vi.fn(
+    (_t, command: string, args: string[], cwd: string, stdin: string) => {
+      n++;
+      spawnCalls.push({ command, args, cwd, stdin });
+      return { id: `proc-${n}` };
+    },
+  );
+  async function trigger(event: string, ...args: unknown[]) {
+    for (const h of [...(listeners[event] ?? [])]) h(...args);
+    await new Promise((r) => setImmediate(r));
+  }
+  return { pm, trigger, spawnCalls };
+}
+
+function executeReq(overrides: Partial<ProviderRequest> = {}): ProviderRequest {
+  return {
+    phase: 'execute',
+    prompt: 'IMPLEMENT THE THING',
+    cwd: '/tmp/wt',
+    projectPath: '/tmp/proj',
+    signal: new AbortController().signal,
+    threadId: 't1',
+    ...overrides,
+  };
+}
+
+async function waitFor(calls: unknown[]): Promise<void> {
+  for (let i = 0; i < 40; i++) {
+    if (calls.length > 0) return;
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+describe('programmatic claude execute — sandbox gating', () => {
+  it('fails closed when programmatic execute has no OS sandbox hint', async () => {
+    const { pm, spawnCalls } = mockPm();
+    const provider = createClaudeCliProvider(pm);
+
+    const result = await provider.generate(executeReq({ phaseHints: { runMode: 'programmatic' } }));
+
+    expect(spawnCalls).toHaveLength(0); // never spawned
+    expect(result.exitCode).toBe(1);
+    expect(result.providerError?.kind).toBe('unexpected_stop');
+    expect(result.rawOutput).toMatch(/requires the OS sandbox/i);
+  });
+
+  it('wraps claude -p in srt when the sandbox hint is present, then cleans up the policy', async () => {
+    if (process.platform === 'win32') return; // srt unsupported
+    const wt = fs.mkdtempSync(path.join(os.tmpdir(), 'exec-wt-'));
+    try {
+      const { pm, trigger, spawnCalls } = mockPm();
+      const provider = createClaudeCliProvider(pm);
+
+      const promise = provider.generate(
+        executeReq({
+          cwd: wt,
+          phaseHints: {
+            runMode: 'programmatic',
+            osSandbox: { backend: 'srt', networkPolicy: 'anthropic-github', extraWritePaths: [] },
+          },
+        }),
+      );
+
+      await waitFor(spawnCalls);
+      expect(spawnCalls).toHaveLength(1);
+      const call = spawnCalls[0];
+      // Spawned command is the srt CLI, not claude directly.
+      expect(call.command).toMatch(/cli\.js$/);
+      expect(call.args[0]).toBe('-s');
+      const policyPath = call.args[1];
+      expect(call.args[2]).toBe('claude');
+      // Inner claude execute args follow, in programmatic stdin mode.
+      expect(call.args).toContain('-p');
+      expect(call.args).toContain('--dangerously-skip-permissions');
+      // Prompt is piped via stdin, never argv.
+      expect(call.stdin).toBe('IMPLEMENT THE THING');
+
+      await trigger('exit', 'proc-1', 0);
+      await promise;
+
+      // The per-run policy file is removed after the run settles.
+      expect(fs.existsSync(policyPath)).toBe(false);
+    } finally {
+      fs.rmSync(wt, { recursive: true, force: true });
+    }
+  });
+
+  it('interactive execute does not use the srt sandbox', async () => {
+    const wt = fs.mkdtempSync(path.join(os.tmpdir(), 'exec-int-wt-'));
+    try {
+      const { pm, trigger, spawnCalls } = mockPm();
+      const provider = createClaudeCliProvider(pm);
+
+      const promise = provider.generate(
+        executeReq({ cwd: wt, phaseHints: { runMode: 'interactive' } }),
+      );
+
+      await waitFor(spawnCalls);
+      expect(spawnCalls).toHaveLength(1);
+      expect(spawnCalls[0].command).toBe('claude');
+      expect(spawnCalls[0].args).toContain('--permission-mode');
+
+      await trigger('exit', 'proc-1', 0);
+      await promise;
+    } finally {
+      fs.rmSync(wt, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/agents/src/providers/cli-provider.ts
+++ b/packages/agents/src/providers/cli-provider.ts
@@ -17,6 +17,7 @@ import { PLAN_FENCE_TAG, REVIEW_FENCE_TAG, VERIFICATION_FENCE_TAG } from '@shipc
 import { classifyPoolExhaustion, markPoolExhausted } from '../agent-sdk-pool-state';
 import type { ProcessManager } from '../process-manager';
 import { measurePromptPayload } from '../prompt-scope';
+import { buildSandboxedClaudeExecuteCommand, resolveSrt } from '../sandbox/srt';
 import { StreamParser } from '../stream-parser';
 import { stripAnsi } from './output-summary';
 import { mapReasoningEffortToClaudeThinkingTokens, mapReasoningEffortToCodex } from './reasoning';
@@ -82,11 +83,16 @@ async function runCli(
   workspaceRoot?: string | null,
   options?: Parameters<ProcessManager['spawn']>[5],
   onProcessStart?: (processId: string) => void,
+  // Spawn a different binary than `agentId` while keeping the process TYPE tag
+  // as the agent (e.g. wrap `claude` inside the `srt` OS sandbox). The override
+  // must be a ProcessManager-allowlisted command (resolved srt path).
+  commandOverride?: string,
 ): Promise<CliRunResult> {
   if (signal.aborted) {
     return { rawOutput: '', exitCode: 130 };
   }
 
+  const command = commandOverride ?? agentId;
   let process: ReturnType<ProcessManager['spawn']>;
   try {
     const spawnOptions = {
@@ -97,7 +103,7 @@ async function runCli(
     if (stdin !== undefined && processManagerWithStdin.spawnWithStdin) {
       process = processManagerWithStdin.spawnWithStdin(
         agentId,
-        agentId,
+        command,
         args,
         cwd,
         stdin,
@@ -107,7 +113,7 @@ async function runCli(
     } else {
       process = processManager.spawn(
         agentId,
-        agentId,
+        command,
         materializeStdinArgsForLegacySpawn(args, stdin),
         cwd,
         threadId,
@@ -230,6 +236,9 @@ function buildClaudeCommand(req: ProviderRequest): CliCommand {
       if (allowedTools) execArgs.push('--allowedTools', allowedTools.join(','));
       /* v8 ignore next -- execute normally has no disallowed tools unless explicitly configured */
       if (disallowedTools) execArgs.push('--disallowedTools', disallowedTools.join(','));
+      // Safe ONLY because the execute branch in generate() always wraps this
+      // command in the srt OS sandbox (buildSandboxedClaudeExecuteCommand) and
+      // fails closed otherwise. Never spawn these args without that wrapper.
       execArgs.push('--dangerously-skip-permissions');
       injectThinkingTokens(execArgs, req);
       return { args: execArgs, stdin: req.prompt };
@@ -601,25 +610,6 @@ export function createClaudeCliProvider(processManager: ProcessManager): AgentPr
         promptSize: measurePromptPayload(req.prompt),
         ...(req.promptMaterialSummary ? { selectedMaterials: req.promptMaterialSummary } : {}),
       };
-      // Security guard, independent of the Agent-SDK billing question: a
-      // programmatic (`claude -p`) execute grants Edit/Write/Bash on the host
-      // with NO OS sandbox. This stays blocked even though programmatic is now
-      // the default for the (tool-less) structured phases. Use interactive
-      // Claude execute, or codex (sandboxed via `codex exec`).
-      if (req.phase === 'execute' && req.phaseHints?.runMode !== 'interactive') {
-        return {
-          rawOutput:
-            'Programmatic Claude execute is disabled because it exposes host shell/file tools without an OS sandbox. Use interactive Claude execute or a sandboxed provider.',
-          exitCode: 1,
-          resolvedModel: req.modelHint ?? 'claude',
-          promptTelemetry,
-          providerError: {
-            kind: 'unexpected_stop',
-            message: 'programmatic Claude execute is disabled',
-            retryable: false,
-          },
-        };
-      }
       // Interactive structured phases (plan/review/revision/verify) bridge
       // their machine-readable output through a written file artifact instead
       // of stream-json, so they avoid the rationed `claude -p` pool while
@@ -669,25 +659,86 @@ export function createClaudeCliProvider(processManager: ProcessManager): AgentPr
               : {}),
         };
       }
-      // `interactive` is true only when this run avoids the `claude -p`
-      // path entirely (so it draws from the interactive subscription seat,
-      // not the rationed Agent-SDK credit pool).
+      // `interactive` is true only when this run avoids the `claude -p` path
+      // entirely (interactive subscription seat, not the programmatic path).
       const interactive = req.phaseHints?.runMode === 'interactive' && req.phase === 'execute';
-      const command = interactive
-        ? await buildClaudeInteractiveExecuteCommand(req)
-        : buildClaudeCommand(req);
-      const result = await runCli(
-        processManager,
-        'claude',
-        command.args,
-        command.stdin,
-        req.cwd,
-        req.signal,
-        req.threadId,
-        req.workspaceRoot,
-        { ...(command.options ?? {}), envKeyAllowlist: [...CLAUDE_ENV_KEYS] },
-        req.onProcessStart,
-      );
+
+      // Resolve the command. Programmatic claude EXECUTE grants host
+      // Edit/Write/Bash with no built-in OS sandbox, so it is REQUIRED to run
+      // inside the `srt` OS sandbox (Seatbelt/bubblewrap). If the sandbox is
+      // disabled (no osSandbox hint) or unavailable (srt not resolvable), it
+      // fails closed — it is never run unsandboxed. Programmatic structured
+      // phases (plan/review/verify) are tool-less, so they skip this.
+      let command: CliCommand;
+      let commandOverride: string | undefined;
+      let sandboxCleanup: (() => Promise<void>) | undefined;
+      if (req.phase === 'execute' && !interactive) {
+        const osSandbox = req.phaseHints?.osSandbox;
+        if (osSandbox?.backend !== 'srt') {
+          return {
+            rawOutput:
+              'Programmatic Claude execute requires the OS sandbox (srt), which is disabled. Enable claudeExecuteSandboxEnabled, switch this phase to interactive, or use codex (sandboxed via codex exec).',
+            exitCode: 1,
+            resolvedModel: req.modelHint ?? 'claude',
+            promptTelemetry,
+            providerError: {
+              kind: 'unexpected_stop',
+              message: 'programmatic Claude execute requires the OS sandbox',
+              retryable: false,
+            },
+          };
+        }
+        const inner = buildClaudeCommand(req);
+        const sandboxed = await buildSandboxedClaudeExecuteCommand({
+          worktreePath: req.cwd,
+          innerClaudeArgs: inner.args,
+          networkPolicy: osSandbox.networkPolicy,
+          extraWritePaths: osSandbox.extraWritePaths,
+        });
+        if (!sandboxed) {
+          return {
+            rawOutput: `${resolveSrt().reason}. Install @anthropic-ai/sandbox-runtime or disable sandboxed Claude execute.`,
+            exitCode: 127,
+            resolvedModel: req.modelHint ?? 'claude',
+            promptTelemetry,
+            providerError: {
+              kind: 'binary_missing',
+              message: 'srt sandbox unavailable',
+              retryable: false,
+            },
+          };
+        }
+        command = { args: sandboxed.args, stdin: inner.stdin };
+        commandOverride = sandboxed.command;
+        sandboxCleanup = sandboxed.cleanup;
+        // Remove the policy file promptly on abort instead of waiting out
+        // runCli's kill grace window. fs.rm(force) is idempotent, so the
+        // finally below double-calling cleanup is harmless.
+        req.signal.addEventListener('abort', () => void sandboxCleanup?.(), { once: true });
+      } else {
+        command = interactive
+          ? await buildClaudeInteractiveExecuteCommand(req)
+          : buildClaudeCommand(req);
+      }
+
+      let result: CliRunResult;
+      try {
+        result = await runCli(
+          processManager,
+          'claude',
+          command.args,
+          command.stdin,
+          req.cwd,
+          req.signal,
+          req.threadId,
+          req.workspaceRoot,
+          { ...(command.options ?? {}), envKeyAllowlist: [...CLAUDE_ENV_KEYS] },
+          req.onProcessStart,
+          commandOverride,
+        );
+      } finally {
+        if (sandboxCleanup) await sandboxCleanup();
+      }
       const parser = new StreamParser();
       parser.feed(result.rawOutput);
       const usage = parser.extractUsage();

--- a/packages/agents/src/providers/cli-provider.ts
+++ b/packages/agents/src/providers/cli-provider.ts
@@ -601,6 +601,11 @@ export function createClaudeCliProvider(processManager: ProcessManager): AgentPr
         promptSize: measurePromptPayload(req.prompt),
         ...(req.promptMaterialSummary ? { selectedMaterials: req.promptMaterialSummary } : {}),
       };
+      // Security guard, independent of the Agent-SDK billing question: a
+      // programmatic (`claude -p`) execute grants Edit/Write/Bash on the host
+      // with NO OS sandbox. This stays blocked even though programmatic is now
+      // the default for the (tool-less) structured phases. Use interactive
+      // Claude execute, or codex (sandboxed via `codex exec`).
       if (req.phase === 'execute' && req.phaseHints?.runMode !== 'interactive') {
         return {
           rawOutput:

--- a/packages/agents/src/providers/types.ts
+++ b/packages/agents/src/providers/types.ts
@@ -142,6 +142,18 @@ export interface ProviderPhaseHints {
   reasoningEffort?: ReasoningEffort;
   /** Runtime transport selected from AppSettings.agentRunModes. */
   runMode?: ProviderRunMode;
+  /**
+   * OS-sandbox config for programmatic Claude EXECUTE. Set by the pipeline
+   * runtime (from AppSettings) only when claude + execute + programmatic +
+   * sandbox enabled. When present, the provider wraps `claude -p` in `srt`
+   * (Seatbelt/bubblewrap). When absent, programmatic claude execute fails
+   * closed — it is never run unsandboxed.
+   */
+  osSandbox?: {
+    backend: 'srt';
+    networkPolicy: 'anthropic-only' | 'anthropic-github';
+    extraWritePaths: string[];
+  };
 }
 
 export interface ProviderRequest {

--- a/packages/agents/src/sandbox/srt.test.ts
+++ b/packages/agents/src/sandbox/srt.test.ts
@@ -1,0 +1,132 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  buildSandboxedClaudeExecuteCommand,
+  buildSrtPolicy,
+  resetSrtResolutionCache,
+  resolveSrt,
+} from './srt';
+
+function tmpWorktree(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), 'srt-test-wt-'));
+}
+
+describe('buildSrtPolicy', () => {
+  it('writes a complete-schema policy scoped to the worktree', async () => {
+    const wt = tmpWorktree();
+    const { policyPath, cleanup } = await buildSrtPolicy({
+      worktreePath: wt,
+      networkPolicy: 'anthropic-github',
+      extraWritePaths: ['/data/cache', '~/scratch', 'relative/should-drop'],
+    });
+
+    const policy = JSON.parse(fs.readFileSync(policyPath, 'utf8'));
+    // srt's schema is strict — every key must be present or it fail-closes.
+    expect(Object.keys(policy.network).sort()).toEqual([
+      'allowLocalBinding',
+      'allowUnixSockets',
+      'allowedDomains',
+      'deniedDomains',
+    ]);
+    expect(Object.keys(policy.filesystem).sort()).toEqual([
+      'allowRead',
+      'allowWrite',
+      'denyRead',
+      'denyWrite',
+    ]);
+
+    expect(policy.network.allowedDomains).toContain('api.anthropic.com');
+    expect(policy.network.allowedDomains).toContain('github.com');
+    // No broad wildcard — exact hosts only.
+    expect(policy.network.allowedDomains).not.toContain('*.anthropic.com');
+    expect(policy.network.allowLocalBinding).toBe(false);
+
+    expect(policy.filesystem.allowWrite).toContain(wt);
+    expect(policy.filesystem.allowWrite).toContain(os.tmpdir());
+    // Scoped claude state paths are writable, but NOT the whole ~/.claude dir.
+    expect(policy.filesystem.allowWrite).toContain('~/.claude/todos');
+    expect(policy.filesystem.allowWrite).toContain('~/.claude.json');
+    expect(policy.filesystem.allowWrite).not.toContain('~/.claude');
+    // Persistent host-config files are write-denied (sandbox-to-host escape).
+    expect(policy.filesystem.denyWrite).toContain('~/.claude/CLAUDE.md');
+    expect(policy.filesystem.denyWrite).toContain('~/.claude/commands');
+    // Absolute + ~-prefixed extra paths kept; relative + traversal dropped.
+    expect(policy.filesystem.allowWrite).toContain('/data/cache');
+    expect(policy.filesystem.allowWrite).toContain('~/scratch');
+    expect(policy.filesystem.allowWrite).not.toContain('relative/should-drop');
+    // Secrets are read-denied.
+    expect(policy.filesystem.denyRead).toEqual(
+      expect.arrayContaining(['~/.ssh', '~/.aws', '~/.gitconfig', '~/.docker']),
+    );
+
+    await cleanup();
+    expect(fs.existsSync(policyPath)).toBe(false);
+    fs.rmSync(wt, { recursive: true, force: true });
+  });
+
+  it('anthropic-only policy omits GitHub and npm', async () => {
+    const wt = tmpWorktree();
+    const { policyPath, cleanup } = await buildSrtPolicy({
+      worktreePath: wt,
+      networkPolicy: 'anthropic-only',
+      extraWritePaths: [],
+    });
+    const policy = JSON.parse(fs.readFileSync(policyPath, 'utf8'));
+    expect(policy.network.allowedDomains).toContain('api.anthropic.com');
+    expect(policy.network.allowedDomains).not.toContain('github.com');
+    expect(policy.network.allowedDomains).not.toContain('registry.npmjs.org');
+    await cleanup();
+    fs.rmSync(wt, { recursive: true, force: true });
+  });
+});
+
+describe('resolveSrt', () => {
+  afterEach(() => resetSrtResolutionCache());
+
+  it('resolves the bundled srt entrypoint on supported platforms', () => {
+    const result = resolveSrt();
+    if (process.platform === 'win32') {
+      expect(result.available).toBe(false);
+      return;
+    }
+    expect(result.available).toBe(true);
+    expect(result.command).toMatch(/sandbox-runtime[\\/].*cli\.js$/);
+    expect(fs.existsSync(result.command as string)).toBe(true);
+  });
+
+  it('caches the resolution', () => {
+    const a = resolveSrt();
+    const b = resolveSrt();
+    expect(a).toBe(b);
+  });
+});
+
+describe('buildSandboxedClaudeExecuteCommand', () => {
+  it('wraps inner claude args as `srt -s <policy> claude ...`', async () => {
+    if (process.platform === 'win32') return; // srt unsupported
+    const wt = tmpWorktree();
+    const built = await buildSandboxedClaudeExecuteCommand({
+      worktreePath: wt,
+      innerClaudeArgs: ['-p', '--output-format', 'stream-json', '--dangerously-skip-permissions'],
+      networkPolicy: 'anthropic-github',
+      extraWritePaths: [],
+    });
+    expect(built).not.toBeNull();
+    if (!built) return;
+    expect(built.command).toMatch(/cli\.js$/);
+    expect(built.args[0]).toBe('-s');
+    expect(fs.existsSync(built.args[1])).toBe(true); // policy file written
+    expect(built.args[2]).toBe('claude');
+    expect(built.args.slice(3)).toEqual([
+      '-p',
+      '--output-format',
+      'stream-json',
+      '--dangerously-skip-permissions',
+    ]);
+    await built.cleanup();
+    expect(fs.existsSync(built.args[1])).toBe(false);
+    fs.rmSync(wt, { recursive: true, force: true });
+  });
+});

--- a/packages/agents/src/sandbox/srt.ts
+++ b/packages/agents/src/sandbox/srt.ts
@@ -1,0 +1,293 @@
+/**
+ * OS-level sandbox wrapper for programmatic (`claude -p`) EXECUTE runs.
+ *
+ * Programmatic claude execute grants the agent host Edit/Write/Bash with no
+ * built-in OS sandbox (the Claude Code Bash sandbox only constrains Bash, not
+ * the Edit/Write file tools or MCP servers). To run it unattended we wrap the
+ * WHOLE claude process in @anthropic-ai/sandbox-runtime (`srt`), which applies
+ * Seatbelt (macOS) / bubblewrap (Linux) to claude and every tool/MCP it spawns.
+ *
+ * Empirically verified (v0.0.55) before wiring: srt passes stdin through to the
+ * child, propagates the child's exact exit code, confines writes to
+ * `filesystem.allowWrite`, and denies network except `network.allowedDomains`.
+ *
+ * IMPORTANT: srt does NOT fail closed on a missing/malformed policy — it falls
+ * back to an OPEN default (no allowlist, no write confinement). So this module
+ * must always emit a complete, well-formed policy with a fixed key set; that is
+ * what keeps the sandbox actually restrictive. `buildSrtPolicy` is the single
+ * source of that object.
+ */
+import { existsSync } from 'node:fs';
+import * as fs from 'node:fs/promises';
+import { createRequire } from 'node:module';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { registerSandboxBinary } from '../process-manager';
+
+export type SandboxNetworkPolicy = 'anthropic-only' | 'anthropic-github';
+
+/**
+ * Outbound domain allowlists. Network is deny-by-default; only these resolve.
+ * `anthropic-github` adds the hosts an execute phase needs to push branches and
+ * install dependencies. Broader allowlists widen exfiltration surface (srt does
+ * hostname filtering, not TLS inspection), so keep these tight.
+ */
+// Exact hosts only — no `*.anthropic.com` wildcard. The agent holds its own
+// ANTHROPIC_API_KEY and srt does hostname filtering (not TLS inspection), so a
+// broad wildcard would widen the exfil surface for no functional gain.
+const ANTHROPIC_HOSTS = ['api.anthropic.com', 'statsig.anthropic.com'] as const;
+const NETWORK_PRESETS: Record<SandboxNetworkPolicy, readonly string[]> = {
+  'anthropic-only': [...ANTHROPIC_HOSTS],
+  'anthropic-github': [
+    ...ANTHROPIC_HOSTS,
+    'github.com',
+    'api.github.com',
+    'codeload.github.com',
+    'objects.githubusercontent.com',
+    'raw.githubusercontent.com',
+    'registry.npmjs.org',
+  ],
+};
+
+/**
+ * Home-relative secret stores the sandboxed agent must never read. srt is
+ * default-allow-read, so this is the explicit denylist of credential stores —
+ * keep it broad. (A full deny-`~`/allow-exceptions inversion would be tighter
+ * but risks breaking legitimate reads claude needs; this is the pragmatic line.)
+ */
+const DEFAULT_DENY_READ = [
+  '~/.ssh',
+  '~/.aws',
+  '~/.gnupg',
+  '~/.config',
+  '~/.npmrc',
+  '~/.netrc',
+  '~/.gitconfig',
+  '~/.git-credentials',
+  '~/.docker',
+  '~/.kube',
+  '~/.pypirc',
+  '~/.password-store',
+] as const;
+
+/**
+ * Writes always denied even though `~/.claude` is writable for session state:
+ * these files persist outside the sandbox and would let a prompt-injected run
+ * plant instructions/commands/subagents that affect FUTURE host Claude sessions.
+ */
+const DEFAULT_DENY_WRITE = [
+  '~/.claude/CLAUDE.md',
+  '~/.claude/commands',
+  '~/.claude/agents',
+  '~/.claude/settings.json',
+] as const;
+
+/** Specific `~/.claude` paths claude -p needs to write for session state. */
+const CLAUDE_STATE_WRITE_PATHS = [
+  '~/.claude/todos',
+  '~/.claude/statsig',
+  '~/.claude/.credentials.json',
+  '~/.claude.json',
+] as const;
+
+export interface SrtResolution {
+  available: boolean;
+  /** Absolute path to the srt CLI entrypoint (executable node shebang). */
+  command: string | null;
+  reason: string;
+}
+
+let cachedResolution: SrtResolution | null = null;
+
+/**
+ * Rewrite an `…/app.asar/…` path to its `app.asar.unpacked` counterpart when
+ * that file exists on disk (packaged Electron). Returns the input unchanged in
+ * dev or when no unpacked copy is present.
+ */
+function unpackAsarPath(p: string): string {
+  if (!p.includes(`app.asar${path.sep}`)) return p;
+  const unpacked = p.replace(`app.asar${path.sep}`, `app.asar.unpacked${path.sep}`);
+  return existsSync(unpacked) ? unpacked : p;
+}
+
+/**
+ * Resolve the bundled `srt` CLI. We ship @anthropic-ai/sandbox-runtime as a
+ * dependency of this package, so `require.resolve` finds it regardless of the
+ * package-manager hoisting layout. The resolved absolute path is registered
+ * with the ProcessManager allowlist so only THIS exact binary may be spawned.
+ *
+ * Returns unavailable (fail-closed) on Windows (srt is macOS/Linux only) or if
+ * the entrypoint cannot be located. Cached for the process lifetime.
+ */
+export function resolveSrt(): SrtResolution {
+  if (cachedResolution) return cachedResolution;
+
+  if (process.platform === 'win32') {
+    cachedResolution = {
+      available: false,
+      command: null,
+      reason:
+        'srt sandbox is not supported on Windows (requires macOS Seatbelt or Linux bubblewrap)',
+    };
+    return cachedResolution;
+  }
+
+  try {
+    const require = createRequire(import.meta.url);
+    const pkgJsonPath = require.resolve('@anthropic-ai/sandbox-runtime/package.json');
+    const pkgDir = path.dirname(pkgJsonPath);
+    const pkg = require('@anthropic-ai/sandbox-runtime/package.json') as { bin?: { srt?: string } };
+    const binRel = pkg.bin?.srt ?? 'dist/cli.js';
+    // In a packaged Electron build the module resolves inside app.asar, which
+    // the OS cannot exec as a subprocess. electron-builder unpacks this package
+    // to app.asar.unpacked (see asarUnpack in electron-builder.yml); rewrite the
+    // path to the unpacked copy when present. No-op in dev (no asar segment).
+    const cliPath = unpackAsarPath(path.join(pkgDir, binRel));
+    if (!existsSync(cliPath)) {
+      cachedResolution = {
+        available: false,
+        command: null,
+        reason: `srt entrypoint not found at ${cliPath} — reinstall @anthropic-ai/sandbox-runtime`,
+      };
+      return cachedResolution;
+    }
+    registerSandboxBinary(cliPath);
+    cachedResolution = { available: true, command: cliPath, reason: 'ok' };
+  } catch (error) {
+    cachedResolution = {
+      available: false,
+      command: null,
+      reason: `srt sandbox unavailable: ${error instanceof Error ? error.message : String(error)}`,
+    };
+  }
+  return cachedResolution;
+}
+
+/** Reset the cached resolution. Test-only. */
+export function resetSrtResolutionCache(): void {
+  cachedResolution = null;
+}
+
+/** Sensitive roots an extra write path may never equal or sit under. */
+const FORBIDDEN_WRITE_ROOTS = ['/etc', '/usr', '/bin', '/sbin', '/System', '/private/etc', '/var'];
+
+/**
+ * Validate a user-supplied extra write path before it lands in the srt policy.
+ * Must be absolute or `~/`-prefixed, contain no traversal segments, and not
+ * target the filesystem root or a sensitive system root.
+ */
+function isPlausibleWritePath(p: string): boolean {
+  if (typeof p !== 'string' || p.length === 0) return false;
+  if (!p.startsWith('/') && !p.startsWith('~/')) return false;
+  if (path.normalize(p) !== p) return false; // rejects `..` / redundant segments
+  if (p === '/') return false;
+  return !FORBIDDEN_WRITE_ROOTS.some((root) => p === root || p.startsWith(`${root}/`));
+}
+
+export interface SrtPolicyHandle {
+  policyPath: string;
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * Write a per-run srt policy to a 0700 temp dir and return its path plus a
+ * cleanup. The policy object is built from a FIXED key set — extra write paths
+ * only ever land in `filesystem.allowWrite` as strings; no caller-controlled
+ * keys are spread into the JSON, so a future srt weakening flag can never be
+ * injected through here.
+ */
+export async function buildSrtPolicy(opts: {
+  worktreePath: string;
+  networkPolicy: SandboxNetworkPolicy;
+  extraWritePaths: string[];
+}): Promise<SrtPolicyHandle> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'shipcode-srt-'));
+  try {
+    await fs.chmod(dir, 0o700);
+    const policyPath = path.join(dir, 'policy.json');
+
+    // Canonicalize: on macOS os.tmpdir() is /var/folders/… but /var → /private/var,
+    // and a custom worktreeRoot may be a symlink. Seatbelt/bubblewrap match on the
+    // real path, so include the resolved form (plus the original, defensively).
+    const tmpReal = await fs.realpath(os.tmpdir()).catch(() => os.tmpdir());
+    const worktreeReal = await fs.realpath(opts.worktreePath).catch(() => opts.worktreePath);
+
+    const allowWrite = Array.from(
+      new Set(
+        [
+          opts.worktreePath,
+          worktreeReal,
+          os.tmpdir(),
+          tmpReal,
+          // Scoped claude session-state paths only — NOT the whole ~/.claude dir,
+          // which would let a run rewrite CLAUDE.md / commands / agents for all
+          // future host sessions (see DEFAULT_DENY_WRITE).
+          ...CLAUDE_STATE_WRITE_PATHS,
+          ...opts.extraWritePaths.filter(isPlausibleWritePath),
+        ].filter(Boolean),
+      ),
+    );
+
+    const policy = {
+      network: {
+        allowedDomains: [...NETWORK_PRESETS[opts.networkPolicy]],
+        deniedDomains: [] as string[],
+        allowUnixSockets: [] as string[],
+        allowLocalBinding: false,
+      },
+      filesystem: {
+        denyRead: [...DEFAULT_DENY_READ],
+        allowRead: [] as string[],
+        allowWrite,
+        denyWrite: [...DEFAULT_DENY_WRITE],
+      },
+    };
+
+    await fs.writeFile(policyPath, JSON.stringify(policy, null, 2), { mode: 0o600 });
+
+    return {
+      policyPath,
+      cleanup: async () => {
+        await fs.rm(dir, { recursive: true, force: true });
+      },
+    };
+  } catch (err) {
+    // Never leak the temp dir if chmod/realpath/writeFile throws after mkdtemp.
+    await fs.rm(dir, { recursive: true, force: true }).catch(() => {});
+    throw err;
+  }
+}
+
+export interface SandboxedExecuteCommand {
+  /** The srt CLI path to spawn (passed to runCli as the command override). */
+  command: string;
+  /** srt flags + the wrapped `claude` argv, with policy applied. */
+  args: string[];
+  cleanup: () => Promise<void>;
+}
+
+/**
+ * Build the srt-wrapped command for a programmatic claude execute run.
+ * Shape: `srt -s <policy> claude <innerClaudeArgs...>` with the prompt piped
+ * via stdin (handled by runCli). Returns null when the sandbox is unavailable
+ * so the caller can fail closed instead of running unsandboxed.
+ */
+export async function buildSandboxedClaudeExecuteCommand(opts: {
+  worktreePath: string;
+  innerClaudeArgs: string[];
+  networkPolicy: SandboxNetworkPolicy;
+  extraWritePaths: string[];
+}): Promise<SandboxedExecuteCommand | null> {
+  const srt = resolveSrt();
+  if (!srt.available || !srt.command) return null;
+  const policy = await buildSrtPolicy({
+    worktreePath: opts.worktreePath,
+    networkPolicy: opts.networkPolicy,
+    extraWritePaths: opts.extraWritePaths,
+  });
+  return {
+    command: srt.command,
+    args: ['-s', policy.policyPath, 'claude', ...opts.innerClaudeArgs],
+    cleanup: policy.cleanup,
+  };
+}

--- a/packages/agents/src/verify-affected-workspaces.test.ts
+++ b/packages/agents/src/verify-affected-workspaces.test.ts
@@ -9,17 +9,22 @@ const scriptPath = path.join(repoRoot, 'scripts', 'verify-affected-workspaces.ts
 const tempDirs: string[] = [];
 
 function run(command: string, args: string[], cwd: string): string {
-  return execFileSync(command, args, {
-    cwd,
-    encoding: 'utf-8',
-    env: {
-      ...process.env,
-      GIT_AUTHOR_NAME: 'ShipCode Test',
-      GIT_AUTHOR_EMAIL: 'shipcode@example.com',
-      GIT_COMMITTER_NAME: 'ShipCode Test',
-      GIT_COMMITTER_EMAIL: 'shipcode@example.com',
-    },
-  });
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    GIT_AUTHOR_NAME: 'ShipCode Test',
+    GIT_AUTHOR_EMAIL: 'shipcode@example.com',
+    GIT_COMMITTER_NAME: 'ShipCode Test',
+    GIT_COMMITTER_EMAIL: 'shipcode@example.com',
+  };
+  // Run hermetically against the fixture repo. verify-affected-workspaces.ts
+  // reads these to choose its diff base / task set; a value inherited from the
+  // host (e.g. CI exports TURBO_SCM_BASE = the PR base sha) points outside the
+  // fixture and would make affected-detection find nothing. Strip them so the
+  // script falls back to its default base of HEAD within the fixture.
+  delete env.TURBO_SCM_BASE;
+  delete env.SHIPCODE_VERIFY_BASE;
+  delete env.SHIPCODE_VERIFY_TASKS;
+  return execFileSync(command, args, { cwd, encoding: 'utf-8', env });
 }
 
 function writeJson(filePath: string, value: unknown) {

--- a/packages/db/src/queries/settings.test.ts
+++ b/packages/db/src/queries/settings.test.ts
@@ -25,10 +25,17 @@ describe('SettingsQueries', () => {
     expect(s.telemetryEnabled).toBeNull();
     expect(s.defaultWorktreeEnabled).toBe(true);
     expect(s.terminalScrollback).toBe(10000);
+    // Structured phases default to programmatic for both providers.
+    expect(s.agentRunModes.claude.plan).toBe('programmatic');
+    expect(s.agentRunModes.claude.verify).toBe('programmatic');
+    expect(s.agentRunModes.codex.plan).toBe('programmatic');
+    // Codex execute is sandboxed (`codex exec`) → programmatic; Claude execute
+    // grants host tools with no OS sandbox → stays interactive.
+    expect(s.agentRunModes.codex.execute).toBe('programmatic');
     expect(s.agentRunModes.claude.execute).toBe('interactive');
-    expect(s.agentRunModes.codex.execute).toBe('interactive');
-    expect(s.agentRunModes.claude.plan).toBe('interactive');
-    expect(s.agentRunModes.claude.verify).toBe('interactive');
+    // Watched terminal-pane surfaces stay interactive by default.
+    expect(s.agentRunModes.claude.instant).toBe('interactive');
+    expect(s.agentRunModes.codex.terminalFix).toBe('interactive');
     expect(s.forceInteractiveClaude).toBe(false);
     expect(s.plannerModel).toBe('codex');
     expect(s.reviewerModel).toBe('codex');
@@ -108,12 +115,12 @@ describe('SettingsQueries', () => {
     const modes = settings.get().agentRunModes;
     // Pre-existing key preserved.
     expect(modes.claude.execute).toBe('programmatic');
-    // New per-phase keys backfilled from defaults.
-    expect(modes.claude.plan).toBe('interactive');
-    expect(modes.claude.review).toBe('interactive');
-    expect(modes.claude.revision).toBe('interactive');
-    expect(modes.claude.verify).toBe('interactive');
-    expect(modes.codex.plan).toBe('interactive');
+    // New per-phase keys backfilled from defaults (structured → programmatic).
+    expect(modes.claude.plan).toBe('programmatic');
+    expect(modes.claude.review).toBe('programmatic');
+    expect(modes.claude.revision).toBe('programmatic');
+    expect(modes.claude.verify).toBe('programmatic');
+    expect(modes.codex.plan).toBe('programmatic');
   });
 
   it('rejects an invalid run-mode value and falls back to the default', () => {
@@ -135,7 +142,7 @@ describe('SettingsQueries', () => {
       }),
     );
 
-    expect(settings.get().agentRunModes.claude.plan).toBe('interactive');
+    expect(settings.get().agentRunModes.claude.plan).toBe('programmatic');
   });
 
   describe('worktreeRoot', () => {

--- a/packages/db/src/queries/settings.ts
+++ b/packages/db/src/queries/settings.ts
@@ -1,3 +1,4 @@
+import nodePath from 'node:path';
 import type { DatabaseSync } from 'node:sqlite';
 import type {
   AppSettings,
@@ -175,6 +176,35 @@ function isExecutorModel(value: unknown): value is AppSettings['triageModel'] {
   return typeof value === 'string' && (EXECUTOR_MODELS as readonly string[]).includes(value);
 }
 
+const SANDBOX_NETWORK_POLICIES = ['anthropic-only', 'anthropic-github'] as const;
+function isSandboxNetworkPolicy(
+  value: unknown,
+): value is AppSettings['claudeExecuteSandboxNetworkPolicy'] {
+  return (
+    typeof value === 'string' && (SANDBOX_NETWORK_POLICIES as readonly string[]).includes(value)
+  );
+}
+
+const FORBIDDEN_WRITE_ROOTS = ['/etc', '/usr', '/bin', '/sbin', '/System', '/private/etc', '/var'];
+function isSafeExtraWritePath(p: unknown): p is string {
+  if (typeof p !== 'string' || p.length === 0) return false;
+  if (!p.startsWith('/') && !p.startsWith('~/')) return false;
+  if (nodePath.normalize(p) !== p) return false; // rejects `..`/redundant segments
+  if (p === '/') return false;
+  return !FORBIDDEN_WRITE_ROOTS.some((root) => p === root || p.startsWith(`${root}/`));
+}
+
+function parseStringArraySetting(raw: string | undefined, fallback: string[]): string[] {
+  if (!raw) return [...fallback];
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed) && parsed.every((x) => typeof x === 'string')) return parsed;
+  } catch {
+    // fall through
+  }
+  return [...fallback];
+}
+
 export class SettingsQueries {
   constructor(private db: DatabaseSync) {}
 
@@ -208,6 +238,19 @@ export class SettingsQueries {
       forceInteractiveClaude: parseBool(
         stored.forceInteractiveClaude,
         DEFAULT_SETTINGS.forceInteractiveClaude,
+      ),
+      claudeExecuteSandboxEnabled: parseBool(
+        stored.claudeExecuteSandboxEnabled,
+        DEFAULT_SETTINGS.claudeExecuteSandboxEnabled,
+      ),
+      claudeExecuteSandboxNetworkPolicy: isSandboxNetworkPolicy(
+        stored.claudeExecuteSandboxNetworkPolicy,
+      )
+        ? stored.claudeExecuteSandboxNetworkPolicy
+        : DEFAULT_SETTINGS.claudeExecuteSandboxNetworkPolicy,
+      claudeExecuteSandboxExtraWritePaths: parseStringArraySetting(
+        stored.claudeExecuteSandboxExtraWritePaths,
+        DEFAULT_SETTINGS.claudeExecuteSandboxExtraWritePaths,
       ),
       localPreview: parseJsonSetting(stored.localPreview, DEFAULT_SETTINGS.localPreview),
       projectOpenTarget: isProjectOpenTarget(stored.projectOpenTarget)
@@ -477,6 +520,27 @@ export class SettingsQueries {
     }
     if ('worktreeBranchFormat' in patch && patch.worktreeBranchFormat != null) {
       validateBranchFormat(patch.worktreeBranchFormat);
+    }
+    if (
+      'claudeExecuteSandboxNetworkPolicy' in patch &&
+      patch.claudeExecuteSandboxNetworkPolicy != null
+    ) {
+      if (!isSandboxNetworkPolicy(patch.claudeExecuteSandboxNetworkPolicy)) {
+        throw new Error(
+          'claudeExecuteSandboxNetworkPolicy must be anthropic-only|anthropic-github',
+        );
+      }
+    }
+    if (
+      'claudeExecuteSandboxExtraWritePaths' in patch &&
+      patch.claudeExecuteSandboxExtraWritePaths != null
+    ) {
+      const paths = patch.claudeExecuteSandboxExtraWritePaths;
+      if (!Array.isArray(paths) || !paths.every(isSafeExtraWritePath)) {
+        throw new Error(
+          'claudeExecuteSandboxExtraWritePaths must be an array of absolute or ~-prefixed paths with no traversal or system roots',
+        );
+      }
     }
     if ('devLogLevel' in patch && patch.devLogLevel != null) {
       if (!isDevLogLevel(patch.devLogLevel)) {

--- a/packages/pipeline/src/pipeline/runtime.ts
+++ b/packages/pipeline/src/pipeline/runtime.ts
@@ -290,9 +290,10 @@ export function createPipelineRuntime(
 
     // Structured phases parse machine-readable fenced JSON and cap turns at 1.
     const structuredPhases: ProviderPhase[] = ['plan', 'review', 'revision', 'verify'];
+    const settingsSnapshot = deps.settings.get();
     const configuredRunMode: ProviderRunMode | undefined =
       agent === 'claude' || agent === 'codex'
-        ? getAgentPhaseRunMode(deps.settings.get(), agent, phase)
+        ? getAgentPhaseRunMode(settingsSnapshot, agent, phase)
         : undefined;
     // Auto-fallback: when the rationed `claude -p` Agent-SDK credit pool is
     // exhausted, route programmatic claude phases through the interactive CLI
@@ -302,10 +303,25 @@ export function createPipelineRuntime(
       agent === 'claude' && configuredRunMode === 'programmatic' && isPoolExhausted()
         ? 'interactive'
         : configuredRunMode;
+    // Programmatic claude EXECUTE must run inside the `srt` OS sandbox (host
+    // tools, no built-in sandbox). Pass the policy down so the provider wraps
+    // `claude -p` in srt; absent this hint the provider fails closed.
+    const osSandbox =
+      agent === 'claude' &&
+      phase === 'execute' &&
+      effectiveRunMode === 'programmatic' &&
+      settingsSnapshot.claudeExecuteSandboxEnabled
+        ? {
+            backend: 'srt' as const,
+            networkPolicy: settingsSnapshot.claudeExecuteSandboxNetworkPolicy,
+            extraWritePaths: settingsSnapshot.claudeExecuteSandboxExtraWritePaths,
+          }
+        : undefined;
     const mergedHints: ProviderRequest['phaseHints'] = {
       ...(structuredPhases.includes(phase) ? { maxTurns: 1 } : {}),
       ...phaseHints,
       ...(effectiveRunMode ? { runMode: effectiveRunMode } : {}),
+      ...(osSandbox ? { osSandbox } : {}),
     };
 
     // Lifecycle envelope: start a pipeline_step_log row before generation so

--- a/packages/pipeline/src/pipeline/runtime.ts
+++ b/packages/pipeline/src/pipeline/runtime.ts
@@ -43,9 +43,11 @@ const execFileAsync = promisify(execFile);
 
 /**
  * Resolve the configured run mode (interactive vs programmatic) for a given
- * agent + pipeline phase from settings. Every provider phase now carries its
- * own selectable run mode (defaults to interactive so phases avoid the
- * rationed `claude -p` Agent-SDK credit pool); programmatic remains opt-in.
+ * agent + pipeline phase from settings. Every provider phase carries its own
+ * selectable run mode. Structured phases default to programmatic (`claude -p` /
+ * `codex exec --json`) for structured output; the pool-exhaustion fallback
+ * below still reroutes programmatic claude to interactive if Anthropic
+ * re-rations the Agent-SDK credit pool.
  */
 function getAgentPhaseRunMode(
   settings: AppSettings,

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -68,6 +68,13 @@ export const DEFAULT_SETTINGS: AppSettings = {
     },
   },
   forceInteractiveClaude: false,
+  // Programmatic claude execute runs only inside the srt OS sandbox. Enabled by
+  // default so selecting programmatic claude execute is safe out of the box; the
+  // run-mode default for claude execute stays interactive, so this only engages
+  // when a user opts that phase into programmatic.
+  claudeExecuteSandboxEnabled: true,
+  claudeExecuteSandboxNetworkPolicy: 'anthropic-github',
+  claudeExecuteSandboxExtraWritePaths: [],
   localPreview: {
     enabled: true,
     hostMode: 'localhost-subdomain',

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -32,24 +32,37 @@ export const DEFAULT_SETTINGS: AppSettings = {
   telemetryEnabled: null,
   defaultWorktreeEnabled: true,
   terminalScrollback: 10_000,
+  // Programmatic (`claude -p` / `codex exec --json`) is the default for the
+  // structured reasoning phases — Anthropic reverted the 2026 Agent-SDK billing
+  // change, so `claude -p` draws from the subscription seat again. Structured
+  // claude phases run with ALL tools disallowed (pure prompt→JSON), so they
+  // carry no host risk. EXCEPTIONS, kept on the interactive CLI:
+  //   - Claude execute/terminalFix/instant: programmatic claude there grants
+  //     host Edit/Write/Bash with NO OS sandbox (see cli-provider execute guard),
+  //     so they stay interactive regardless of this default.
+  //   - terminalFix/instant for both providers default to interactive because
+  //     they are watched terminal-pane surfaces, not headless automation.
+  // Codex execute is programmatic by default: `codex exec --sandbox` is
+  // OS-sandboxed, and codex is the default executor, so the out-of-box pipeline
+  // runs fully programmatic.
   agentRunModes: {
     claude: {
       issueTerminal: 'interactive',
-      plan: 'interactive',
-      review: 'interactive',
-      revision: 'interactive',
-      verify: 'interactive',
+      plan: 'programmatic',
+      review: 'programmatic',
+      revision: 'programmatic',
+      verify: 'programmatic',
       execute: 'interactive',
       terminalFix: 'interactive',
       instant: 'interactive',
     },
     codex: {
       issueTerminal: 'interactive',
-      plan: 'interactive',
-      review: 'interactive',
-      revision: 'interactive',
-      verify: 'interactive',
-      execute: 'interactive',
+      plan: 'programmatic',
+      review: 'programmatic',
+      revision: 'programmatic',
+      verify: 'programmatic',
+      execute: 'programmatic',
       terminalFix: 'interactive',
       instant: 'interactive',
     },

--- a/packages/shared/src/types/pipeline-core.ts
+++ b/packages/shared/src/types/pipeline-core.ts
@@ -31,11 +31,19 @@ export type InstantFixScope = 'user' | 'project' | 'custom';
 export type ProviderRunMode = 'programmatic' | 'interactive';
 
 /**
- * Per-agent run-mode selection. Each pipeline phase (plan/review/revision/
- * verify/execute) carries its own transport: `interactive` drives the official
- * CLI in a PTY (billed against the interactive subscription seat), while
- * `programmatic` uses `claude -p` / `codex exec --json` (claude draws from the
- * rationed Agent-SDK credit pool). `issueTerminal` is always interactive.
+ * Per-agent run-mode selection. Each phase carries its own transport:
+ * `programmatic` uses `claude -p` / `codex exec --json` (structured output);
+ * `interactive` drives the official CLI in a PTY. `issueTerminal` is always
+ * interactive.
+ *
+ * Defaults (see DEFAULT_SETTINGS): structured reasoning phases (plan/review/
+ * revision/verify) are programmatic for both providers — Anthropic reverted the
+ * 2026 Agent-SDK billing change, and these claude phases run with all tools
+ * disallowed (pure prompt→JSON), so they carry no host risk. execute is
+ * programmatic for codex (sandboxed via `codex exec`) but interactive for
+ * claude: programmatic claude execute/terminalFix/instant would grant host
+ * Edit/Write/Bash with no OS sandbox. terminalFix/instant default interactive
+ * (watched terminal panes).
  */
 export interface AgentRunModeConfig {
   issueTerminal: 'interactive';

--- a/packages/shared/src/types/pipeline-core.ts
+++ b/packages/shared/src/types/pipeline-core.ts
@@ -40,10 +40,12 @@ export type ProviderRunMode = 'programmatic' | 'interactive';
  * revision/verify) are programmatic for both providers — Anthropic reverted the
  * 2026 Agent-SDK billing change, and these claude phases run with all tools
  * disallowed (pure prompt→JSON), so they carry no host risk. execute is
- * programmatic for codex (sandboxed via `codex exec`) but interactive for
- * claude: programmatic claude execute/terminalFix/instant would grant host
- * Edit/Write/Bash with no OS sandbox. terminalFix/instant default interactive
- * (watched terminal panes).
+ * programmatic for codex (sandboxed via `codex exec`) and interactive for
+ * claude by default. Programmatic claude execute CAN be selected, but only runs
+ * wrapped in the `srt` OS sandbox (claudeExecuteSandboxEnabled) — see
+ * sandbox/srt.ts; otherwise it fails closed. Claude terminalFix/instant stay
+ * interactive (no sandbox path on those surfaces); terminalFix/instant default
+ * interactive (watched terminal panes).
  */
 export interface AgentRunModeConfig {
   issueTerminal: 'interactive';

--- a/packages/shared/src/types/settings.ts
+++ b/packages/shared/src/types/settings.ts
@@ -35,6 +35,23 @@ export interface AppSettings {
    * pool (see the pool-exhaustion fallback in cli-provider / runtime).
    */
   forceInteractiveClaude: boolean;
+  /**
+   * Master toggle for the programmatic Claude EXECUTE OS sandbox. Programmatic
+   * `claude -p` execute grants host Edit/Write/Bash with no built-in sandbox,
+   * so it only runs wrapped in `srt` (@anthropic-ai/sandbox-runtime, Seatbelt/
+   * bubblewrap). When false, programmatic claude execute fails closed (never
+   * runs unsandboxed). Has no effect on codex (already sandboxed) or on the
+   * tool-less structured claude phases.
+   */
+  claudeExecuteSandboxEnabled: boolean;
+  /**
+   * Outbound network allowlist preset for the sandboxed execute run.
+   * `anthropic-only` = Anthropic API only; `anthropic-github` also allows
+   * GitHub + npm registry (needed to push branches / install deps).
+   */
+  claudeExecuteSandboxNetworkPolicy: 'anthropic-only' | 'anthropic-github';
+  /** Extra absolute / ~-prefixed paths the sandbox may write to (beyond the worktree + tmp). */
+  claudeExecuteSandboxExtraWritePaths: string[];
   localPreview: LocalPreviewSettings;
   projectOpenTarget: ProjectOpenTarget;
   terminalOpenTarget: TerminalOpenTarget;

--- a/packages/shared/src/types/settings.ts
+++ b/packages/shared/src/types/settings.ts
@@ -30,7 +30,9 @@ export interface AppSettings {
   /**
    * When true, every programmatic (`claude -p`) phase is forced to the
    * interactive CLI regardless of per-phase run-mode settings. Escape hatch
-   * for users who never want to touch the rationed Agent-SDK credit pool.
+   * for users who prefer Claude to always run on the interactive subscription
+   * seat, or as a safety valve if Anthropic re-rations the Agent-SDK credit
+   * pool (see the pool-exhaustion fallback in cli-provider / runtime).
    */
   forceInteractiveClaude: boolean;
   localPreview: LocalPreviewSettings;


### PR DESCRIPTION
## Why
Anthropic reverted the 2026 Agent-SDK billing change (May→June 2026: *"we're not making this change today"*), so `claude -p` draws from the normal subscription seat again. ShipCode had defaulted every phase to `interactive` and disabled programmatic in the UI while that was unsettled. This flips programmatic back on as the default where it's safe, and re-enables the control.

## What
**Defaults (`DEFAULT_SETTINGS.agentRunModes`):**

| Phase | Claude | Codex |
|---|---|---|
| plan / review / revision / verify | **programmatic** | **programmatic** |
| execute | interactive *(no OS sandbox)* | **programmatic** *(codex exec --sandbox)* |
| terminalFix / instant | interactive | interactive |
| issueTerminal | interactive | interactive |

Default executor/planner/reviewer/verifier are all `codex`, so the out-of-box pipeline now runs **fully programmatic**.

## Security model (kept)
- Programmatic claude **plan/review/revision/verify** = `claude -p` with `--disallowedTools` for **every** host tool → pure prompt→JSON, zero host risk. Billing was the only blocker.
- Programmatic claude **execute/terminalFix/instant** = host `Edit/Write/Bash`, **no OS sandbox** → still guarded. `cli-provider.ts` hard-rejects programmatic claude execute; `getRunMode` coerces claude→interactive for instant/terminalFix. Only the *billing-era* blocks were removed (`assertProgrammaticRunAllowed`, UI hard-disable).
- **Codex** runs through `codex exec --sandbox` (OS-sandboxed) → programmatic safe everywhere, incl. execute.

## Safety nets retained
`isPoolExhausted`/`markPoolExhausted` runtime fallback + `forceInteractiveClaude` global escape hatch — if Anthropic ever re-rations the pool, programmatic claude auto-reroutes to interactive.

## UI
`RunModeSelect` is editable again and wired to `onUpdate`. Programmatic stays disabled (with a sandbox-reason tooltip) only on the three Claude host-tool rows; Codex rows are fully selectable.

## Tests / gates
- `turbo typecheck` across shared/db/agents/pipeline/desktop — green
- affected vitest — 261 pass / 5 skip
- biome — clean

## Follow-ups (not in this PR)
- Optional OS-sandbox wrapper so programmatic **Claude execute** could be enabled safely.
- Wire specific shipshitdev/skills into pipeline phase prompts (programmatic `claude -p` loads skills cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced settings panel to provide granular control over agent output modes per provider and operation type.

* **Documentation**
  * Updated documentation reflecting new default output mode behaviors and configuration guidance.

* **Chores**
  * Refined default agent output mode selections and added safety validations for security-sensitive operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->