### PR TITLE
fix(ci): pin gitleaks + harden secret-scan; stop e2e:ci dropping coverage artifact

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -18,14 +18,25 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # Filesystem-only scan: no authenticated git ops needed, so don't
+          # leave the token in git config (zizmor artipacked hardening).
+          persist-credentials: false
 
       - name: Run gitleaks (filesystem scan, license-free)
+        env:
+          # Pinned for reproducibility + supply-chain safety. The previous
+          # "fetch latest tag at runtime" approach 404'd whenever the
+          # unauthenticated GitHub API call was rate-limited (TAG=null),
+          # which broke the gate on master. Bump deliberately + re-verify.
+          GITLEAKS_VERSION: "8.30.1"
         run: |
           set -euo pipefail
-          TAG=$(curl -sSL https://api.github.com/repos/gitleaks/gitleaks/releases/latest | jq -r .tag_name)
-          NUM=${TAG#v}
-          echo "Using gitleaks ${TAG}"
-          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/${TAG}/gitleaks_${NUM}_linux_x64.tar.gz" -o /tmp/gitleaks.tar.gz
+          echo "Using gitleaks v${GITLEAKS_VERSION}"
+          base="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
+          curl -sSfL "${base}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -o /tmp/gitleaks.tar.gz
+          curl -sSfL "${base}/gitleaks_${GITLEAKS_VERSION}_checksums.txt" -o /tmp/gitleaks_checksums.txt
+          # Verify the tarball matches the published SHA256 before extracting.
+          ( cd /tmp && grep "gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" gitleaks_checksums.txt | sha256sum -c - )
           tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
           chmod +x /tmp/gitleaks
           /tmp/gitleaks dir . --redact --no-banner --exit-code 1

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -33,10 +33,13 @@ jobs:
           set -euo pipefail
           echo "Using gitleaks v${GITLEAKS_VERSION}"
           base="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
-          curl -sSfL "${base}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -o /tmp/gitleaks.tar.gz
+          tarball="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          # Keep the local filename identical to the asset name: `sha256sum -c`
+          # reads the filename from the checksum line, so the file must exist
+          # under that exact name in the cwd it runs from.
+          curl -sSfL "${base}/${tarball}" -o "/tmp/${tarball}"
           curl -sSfL "${base}/gitleaks_${GITLEAKS_VERSION}_checksums.txt" -o /tmp/gitleaks_checksums.txt
-          # Verify the tarball matches the published SHA256 before extracting.
-          ( cd /tmp && grep "gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" gitleaks_checksums.txt | sha256sum -c - )
-          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          ( cd /tmp && grep "${tarball}\$" gitleaks_checksums.txt | sha256sum -c - )
+          tar -xzf "/tmp/${tarball}" -C /tmp gitleaks
           chmod +x /tmp/gitleaks
           /tmp/gitleaks dir . --redact --no-banner --exit-code 1

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -6,7 +6,7 @@
   "description": "Repo-level end-to-end coverage for ShipCode (Playwright: Electron desktop + static web/docs smoke).",
   "scripts": {
     "e2e": "playwright test",
-    "e2e:ci": "playwright test --reporter=list,html,json && node scripts/check-flow-coverage.mjs",
+    "e2e:ci": "playwright test --reporter=list,html,json; pw=$?; node scripts/check-flow-coverage.mjs && exit $pw",
     "e2e:desktop": "playwright test --project=desktop",
     "e2e:smoke": "playwright test --project=web-smoke",
     "check:flow-coverage": "node scripts/check-flow-coverage.mjs"


### PR DESCRIPTION
## Why

Audited the bot reviews (CodeRabbit) on recently merged PRs. Three findings were flagged, merged unaddressed, and are **live on master right now**. Two are real; this PR fixes them.

### 1. `secret-scan.yml` — gitleaks unpinned (the active master red) 🔴
CodeRabbit flagged this on **#234**; it merged anyway. The gate resolved the gitleaks version at runtime:
```
TAG=$(curl -sSL .../releases/latest | jq -r .tag_name)
```
When that **unauthenticated** GitHub API call is rate-limited it returns no `tag_name` → `TAG=null` → the download 404s → the required `Secret Scan` gate **fails on master** (run `27610263871`, commit `a2e4695`). Fragile and flaps fleet-wide (this gate was rolled to every repo on 06-16).

**Fix:** pin `GITLEAKS_VERSION=8.30.1` and verify the published SHA256 before extracting — reproducible and supply-chain safe. Also add `persist-credentials: false` (zizmor artipacked: a filesystem-only scan never needs the token in git config).

### 2. `apps/e2e/package.json` — `e2e:ci` drops the coverage artifact on failure 🟠
CodeRabbit flagged this on **#228**. `e2e:ci` chained the two steps with `&&`:
```
playwright test ... && node scripts/check-flow-coverage.mjs
```
A test failure short-circuits the coverage step, so `e2e-flow-coverage.json` is never written — yet `e2e.yml` uploads it under `if: failure()`. Every real failure loses its diagnostic artifact.

**Fix:** always run the coverage step; still exit non-zero if either part fails.

## Verification
- `gitleaks 8.30.1` scan of a fresh-checkout-equivalent tree (`git archive HEAD`) → **no leaks, exit 0**. The gate goes green once the 404 is gone.
- The 6 local `.env` hits gitleaks flagged are **untracked + gitignored** (incl. `.deepsec/data`). **Nothing secret is committed.**
- `secret-scan.yml` YAML + `package.json` JSON both validate.

## Not included (verified, low priority)
Nits left for a follow-up: docstring coverage on `cli-provider.ts` (~40% vs 80% warning gate), inline `window` casts in `main.tsx` (a `.d.ts` pattern already exists next door), a dead `setup-node` step in the `web-smoke` job, and a request-context style inconsistency in `web-docs-smoke.e2e.ts`. The substantive #228 findings (fire() no-op, silent test returns, unsafe cast) were already fixed in `a729772`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)