### PR TITLE
docs(session): log 2026-06-16 sessions 4-5 + gitleaks-pin gotcha

### DIFF
--- a/.agents/SESSIONS/2026-06-16.md
+++ b/.agents/SESSIONS/2026-06-16.md
@@ -305,3 +305,151 @@ Re-verified: typecheck 11/11, 356 tests pass, biome clean.
 - Optionally flip `agentRunModes.claude.execute` default → `programmatic` once srt is proven in the
   packaged app on the target platforms.
 - Wire specific shipshitdev/skills into pipeline phase prompts.
+
+## Session 4 — Merge #236 (no-admin), ruleset root-cause fix, cross-repo ruleset audit
+
+Landed everything from Sessions 2–3 and fixed the governance issue that was forcing admin merges.
+
+### What was done
+
+- [x] **CodeRabbit review on #236:** fixed one legit nit (UI copy omitted `revision` from the
+  programmatic-default list), resolved the thread via GraphQL `resolveReviewThread`.
+- [x] **Root-caused why merge was `BLOCKED` despite green checks.** The `Passing CI on master`
+  ruleset (id `17729072`) still required the **pre-#235 `quality`** status context, which the split
+  CI (Lint/Typecheck/Test/Design System) no longer emits → unsatisfiable on every PR. Also
+  `required_review_thread_resolution: true` (the CodeRabbit thread). `required_approving_review_count`
+  is 0 (no human approval needed).
+- [x] **Fixed the ruleset** (PUT `repos/shipshitdev/shipcode/rulesets/17729072`): required set is now
+  `Trust Check, Lint, Design System, Typecheck, Test, Secret Scan, Socket Security: Project Report,
+  react-doctor` (dropped `quality`). Future PRs merge with no admin.
+- [x] **Squash-merged #236 with NO --admin** → master `a2e46950`. Remote branch deleted; local
+  worktree (`.worktrees/feat-programmatic-default`) + branch removed; `quality` gone.
+- [x] **Cross-repo ruleset audit** (Vincent asked if other repos share the staleness): swept active
+  repos diffing each master ruleset's required contexts vs produced checks.
+
+### Audit result — shipcode was the only mismatch
+
+- `genfeedai/genfeed.ai` ✅ aligned (Format/Gitleaks/Lint/Secretlint/Socket/Typecheck).
+- `Gateway-Ventures/vitae.ai` ✅ aligned — all 5 required pass on PR #930 (PR-triggered "Quality Gate";
+  a master-HEAD sweep false-flags them, so verify on a PR not a push).
+- `shipshitdev/shipcut` ✅ requires `quality` and still **emits** a `quality` job (never split).
+- `v0`, `shipshitshow/live` ✅; `shipdeal/shiplead/skills/veref.work/openfan/sdk` have no required checks.
+- **shipcode was uniquely orphaned** — the one repo that migrated CI (`quality`→split, #235) without
+  updating its ruleset. Not systemic.
+- **Limitation:** ~8 private repos (`genfeedai/{agents,crm,harness,darkroom,admin,marketplace,skills-pro}`,
+  `shipshitdev/portal`) returned 403 on `rules/branches` — that API is GitHub-Pro-gated for private
+  repos, so their rulesets are unverified (likely follow genfeed's aligned pattern).
+
+### Key decisions
+
+- **Fix the ruleset, don't admin-merge** (Vincent's choice) — root-cause fix so no admin is needed
+  going forward, vs a one-off bypass.
+- **master-HEAD is the wrong probe for required checks** — PR-triggered jobs don't run on pushes;
+  always verify required-vs-produced against an actual PR head.
+
+### Mistakes and fixes
+
+- First audit loop used `for r in $REPOS` — **zsh doesn't word-split unquoted vars**, so the whole
+  list became one iteration. Fixed with a line-based `while read` heredoc.
+- Initial sweep mis-flagged vitae.ai (PR-only checks absent on master HEAD) and private repos (403
+  body captured as the "stale" value). Corrected by verifying vitae on PR #930 and recognizing the
+  Pro-gated 403s.
+
+### Loose ends
+
+- **Uncommitted `M .github/workflows/secret-scan.yml`** sits in the main checkout — NOT from this
+  session's work (all that happened in the worktree). Left untouched; flagged for Vincent to review.
+  (Possibly related to the gitleaks `releases/latest`→null download flake seen on #236's first run.)
+- This Session-4 log is on local master only; master is protected, so persisting it to remote needs a
+  PR (or fold into the next shipcode session). The deferred sandbox follow-ups from Session 3 still stand.
+
+## Session 5 — Spark inbox/PR triage → fleet-wide secret-scan fix → v0.1.2 release
+
+Started as a mailbox/PR triage ("read gh/sentry mail + latest PR comments via Spark, anything to act
+on?"). Became: root-cause the master-red Secret Scan, fan the fix across 4 repos, then cut the first
+release since v0.1.1 to prove the full publish pipeline end-to-end.
+
+### System flow
+
+```
+Spark triage (no Sentry mail; all gh bot reviews)
+  └─> Workflow (20 agents): gather 14 bot findings across #228/#231/#234/#235/#236,
+        verify each vs current master  ->  7 live, 6 already-fixed (a729772), 1 false-positive
+        └─> shipcode PR #237 (gitleaks pin+checksum, persist-credentials, e2e:ci) -> merge -> master b581eca4
+              └─> fan secret-scan fix: ui #2, v0 #3, vitae.ai #933 -> merge all -> 4 masters green
+                    └─> release v0.1.2 -> publish.yml: npm CLI + macOS/Linux installers + prod Vercel
+```
+
+### Affected components
+
+- **CI** — `.github/workflows/secret-scan.yml` in shipcode + `ui` + `v0` + `vitae.ai`.
+- **E2E** — `apps/e2e/package.json` (`e2e:ci` script) in shipcode.
+- **Release** — v0.1.2: npm `@shipshitdev/shipcode@0.1.2`, 6 desktop installers, prod web deploy.
+
+### What was done
+
+- [x] **Spark triage.** No Sentry mail at all (keyword only matched "Secret **Scan**"). All shipcode
+  mail = GitHub bot reviews (CodeRabbit / socket-security / codex-connector). Initially mis-called them
+  "noise"; Vincent corrected — they were unread review findings on now-merged PRs.
+- [x] **Verification workflow (20 agents, ~933k tok).** Gathered every actionable bot finding across the
+  last 6 PRs and verified each against current working-tree code. Result: **14 findings → 7 still live,
+  6 already fixed (commit `a729772`), 1 false-positive.**
+- [x] **Root-caused the master-red Secret Scan** (run 27610263871, commit a2e4695). The gate resolved
+  the gitleaks version at runtime via the **unauthenticated** GitHub API (`releases/latest`); when
+  rate-limited it returns no `tag_name` → `TAG=null` → 404 → required gate fails. (Same flake Session 4
+  flagged but didn't fix.)
+- [x] **shipcode PR #237** — pin `GITLEAKS_VERSION=8.30.1` + verify published SHA256 before extract;
+  `persist-credentials: false`; `e2e:ci` `&&`→always-run coverage (artifact was lost on test failure).
+  All checks green, squash-merged → master `b581eca4`. **shipcode master Secret Scan green again.**
+- [x] **Fanned the secret-scan fix** to the 3 other repos carrying the byte-identical broken file:
+  `ui` #2, `v0` #3, `vitae.ai` #933 (via GitHub contents API: branch → commit → PR). Merged all.
+  Secret Scan green on every master. **No real secrets committed anywhere** (the 6 local gitleaks hits
+  are untracked + gitignored `.env` files; CI never sees them — confirmed via `git archive HEAD` scan).
+  Repos with no `secret-scan.yml` (meterbar/kaibanboard/macsweep/genfeed) and shipshit.games
+  (different, non-404 approach) needed no fix.
+- [x] **Cut release v0.1.2** (desktop+cli already pre-bumped to 0.1.2; 113 commits since v0.1.1).
+  `publish.yml` fully green: `publish-cli`→npm, `build-desktop-macos` (arm64+x64) dmg/zip,
+  `build-desktop-linux` AppImage+deb, `deploy-web`→prod Vercel. Homebrew skipped (var off).
+
+### Key decisions
+
+- **Pin + checksum, keep the manual download** (vs swapping to `gitleaks-action`) — smallest change,
+  matches the existing license-free style, removes the runtime-API dependency entirely.
+- **`e2e:ci` = `playwright …; pw=$?; node check-flow-coverage.mjs && exit $pw`** — coverage artifact
+  always written, run still fails if either step fails.
+- **Fan via GitHub API, no clones** for the 3 repos; fell back to a shallow clone only for `ui`'s
+  version bump when API base64 round-tripping got fiddly.
+- **Cut a real release, not a dry dispatch** — version was pre-bumped to 0.1.2 (release intent) and
+  113 commits had accumulated, so it was worth it AND validates the full pipeline (prod deploy + npm)
+  as Vincent asked.
+
+### Files changed
+
+- shipcode (PR #237, merged → `b581eca4`): `.github/workflows/secret-scan.yml`, `apps/e2e/package.json`
+- ui (PR #2): `.github/workflows/secret-scan.yml` + `package.json` (0.8.1→0.8.2)
+- v0 (PR #3): `.github/workflows/secret-scan.yml`
+- vitae.ai (PR #933): `.github/workflows/secret-scan.yml`
+- Release `v0.1.2` + 6 installers + `@shipshitdev/shipcode@0.1.2` on npm
+- `.agents/memory/e2e-ci.md` (gitleaks-pin gotcha, `last_verified` 2026-06-16)
+
+### Mistakes and fixes
+
+- **Shipped a broken checksum on PR #237's first push.** Saved the tarball as `gitleaks.tar.gz`, but
+  `sha256sum -c` reads the filename **from the checksum line** (`gitleaks_8.30.1_linux_x64.tar.gz`) →
+  "No such file." Caught by the PR's own Secret Scan (failed in 4s). Fixed by naming the local file to
+  match the asset, and **tested the exact download+checksum flow locally** before re-push.
+- **Local gitleaks test gave false confidence** — used the brew binary and skipped the
+  download/checksum path CI actually runs. Lesson: exercise the real CI codepath, not an analogue.
+- **Merge poll loop used bash associative arrays under zsh** → "bad substitution"; re-ran under explicit
+  `bash -c`. (Recurring zsh-vs-bash gotcha — Session 4 hit the word-split variant.)
+- **ui PR blocked by a per-PR version-bump gate** (not Secret Scan) — ui requires `package.json`
+  bumped on every PR. Bumped 0.8.1→0.8.2.
+
+### Next steps / loose ends
+
+- **shipcode nits** (verified low priority, not done): `cli-provider.ts` docstring coverage (~40% vs
+  80% warning gate), inline `window` casts in `main.tsx` (a `.d.ts` pattern already exists next door),
+  dead `setup-node` step in the `web-smoke` job, request-context style in `web-docs-smoke.e2e.ts`.
+- **shipshit.games** `secret-scan.yml` uses a non-404 approach but is missing `persist-credentials:
+  false` — optional hardening, skipped.
+- **Sessions 4 + 5 logs** still need to land on remote master via PR (master protected).

--- a/.agents/memory/e2e-ci.md
+++ b/.agents/memory/e2e-ci.md
@@ -50,6 +50,24 @@ Shared setup lives in the **`.github/actions/setup-bun-env`** composite action (
 **CodeQL** (`.github/workflows/codeql.yml`): advisory SAST, `workflow_dispatch` +
 weekly cron (`0 5 * * 1`), never on the PR hot path; SARIF → Security tab.
 
+## Secret Scan — gitleaks (PIN it, never fetch `releases/latest`)
+
+`.github/workflows/secret-scan.yml`: license-free gitleaks **filesystem** scan
+(`gitleaks dir . --redact --no-banner --exit-code 1`). Required gate on every PR + push.
+
+**Hard rule (broke master 2026-06-16, fixed PR #237):** never resolve the gitleaks
+version at runtime via the unauthenticated GitHub API (`curl …/releases/latest | jq .tag_name`).
+That call gets rate-limited on shared runners → returns no `tag_name` → `TAG=null` → the
+download 404s → the required gate fails. **Pin** `GITLEAKS_VERSION` (env), download the
+`*_checksums.txt`, and `sha256sum -c` **before** extracting. The local tarball filename MUST
+equal the asset name (`gitleaks_<v>_linux_x64.tar.gz`) — `sha256sum -c` reads the name from
+the checksum line, so a renamed download fails verification. Checkout uses
+`persist-credentials: false` (filesystem scan needs no token; zizmor artipacked).
+
+Same broken pattern was fanned to and fixed in `ui`, `v0`, `vitae.ai` the same day. The scan
+runs on a fresh checkout, so untracked + gitignored local `.env` files are never seen by CI —
+verify suspected leaks with `gitleaks dir <git-archive-export>`, not a raw working-tree scan.
+
 ## E2E triggers
 
 - **`schedule` (`0 7 * * 0`, weekly Sun 07:00 UTC):** the weekly review. GitHub runs cron


### PR DESCRIPTION
Lands the session logs and the durable CI gotcha from today's work (master was protected, so they need a PR).

- **Session 4** (was sitting uncommitted from a prior run): #236 merge, ruleset root-cause fix, cross-repo ruleset audit.
- **Session 5**: Spark inbox/PR triage → verified 14 bot findings → fleet-wide `secret-scan.yml` gitleaks-pin fix (shipcode #237 + ui #2 / v0 #3 / vitae.ai #933) → cut **v0.1.2** (npm CLI + macOS/Linux installers + prod web, all green).
- **`memory/e2e-ci.md`**: new Secret Scan section — never resolve gitleaks via `releases/latest` at runtime (rate-limit → `TAG=null` → 404 broke master); pin + SHA256-verify; local tarball name must match the checksum entry; `persist-credentials: false`.

Docs-only. No code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)