### PR TITLE
harden(secret-scan): pin + checksum-verify gitleaks, harden checkout

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -13,33 +13,26 @@ jobs:
     name: Secret Scan
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      GITLEAKS_VERSION: 8.30.1
+      GITLEAKS_SHA256: 551f6fc83ea457d62a0d98237cbad105af8d557003051f41f3e7ca7b3f2470eb
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           fetch-depth: 0
-          # Filesystem-only scan: no authenticated git ops needed, so don't
-          # leave the token in git config (zizmor artipacked hardening).
           persist-credentials: false
 
-      - name: Run gitleaks (filesystem scan, license-free)
-        env:
-          # Pinned for reproducibility + supply-chain safety. The previous
-          # "fetch latest tag at runtime" approach 404'd whenever the
-          # unauthenticated GitHub API call was rate-limited (TAG=null),
-          # which broke the gate on master. Bump deliberately + re-verify.
-          GITLEAKS_VERSION: "8.30.1"
+      - name: Run gitleaks (filesystem scan, pinned + checksum-verified, license-free)
         run: |
           set -euo pipefail
-          echo "Using gitleaks v${GITLEAKS_VERSION}"
-          base="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}"
-          tarball="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
-          # Keep the local filename identical to the asset name: `sha256sum -c`
-          # reads the filename from the checksum line, so the file must exist
-          # under that exact name in the cwd it runs from.
-          curl -sSfL "${base}/${tarball}" -o "/tmp/${tarball}"
-          curl -sSfL "${base}/gitleaks_${GITLEAKS_VERSION}_checksums.txt" -o /tmp/gitleaks_checksums.txt
-          ( cd /tmp && grep "${tarball}\$" gitleaks_checksums.txt | sha256sum -c - )
-          tar -xzf "/tmp/${tarball}" -C /tmp gitleaks
+          TARBALL="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          URL="https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${TARBALL}"
+          echo "Downloading gitleaks v${GITLEAKS_VERSION}"
+          curl --fail --location --silent --show-error \
+            --connect-timeout 15 --max-time 120 --retry 3 \
+            "$URL" -o /tmp/gitleaks.tar.gz
+          echo "${GITLEAKS_SHA256}  /tmp/gitleaks.tar.gz" | sha256sum --check --strict
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
           chmod +x /tmp/gitleaks
           /tmp/gitleaks dir . --redact --no-banner --exit-code 1


### PR DESCRIPTION
Pins actions/checkout to a commit SHA (+ persist-credentials:false), pins gitleaks to 8.30.1 with sha256 verification, and adds curl timeouts/retries. Addresses the supply-chain hardening CodeRabbit flagged. No behavior change to the scan itself.