### PR TITLE
feat(ui): sync kanban column dot colors from GitHub Projects status options

### DIFF
--- a/packages/ui/src/kanban-board/utils.test.ts
+++ b/packages/ui/src/kanban-board/utils.test.ts
@@ -1,6 +1,12 @@
 // @vitest-environment jsdom
 
-import type { AppSettings, GitHubIssueCacheRecord, Project, Thread } from '@shipcode/shared';
+import type {
+  AppSettings,
+  GhStatusMapping,
+  GitHubIssueCacheRecord,
+  Project,
+  Thread,
+} from '@shipcode/shared';
 import { DEFAULT_SETTINGS } from '@shipcode/shared';
 import { describe, expect, it } from 'vitest';
 import {
@@ -700,6 +706,46 @@ describe('resolveIssuePriorityBadge', () => {
     expect(badge?.label).toBe('Icebox');
     expect(badge?.variant).toBe('accent');
     expect(badge?.rank).toBeNull();
+  });
+});
+
+describe('resolveColumnDotColor', () => {
+  const opt = (name: string, color: string | null): { name: string; color: string | null } => ({
+    name,
+    color,
+  });
+  const mapping: GhStatusMapping = {
+    todo: opt('Todo', 'GREEN'),
+    inProgress: opt('In Progress', 'PURPLE'),
+    humanReview: opt('Human Review', 'ORANGE'),
+    deferred: opt('Deferred', 'GRAY'),
+    done: opt('Done', 'BLUE'),
+  };
+
+  it('maps each macro column to its GitHub status option hex', () => {
+    expect(resolveColumnDotColor('todo', mapping)).toBe('#1a7f37');
+    expect(resolveColumnDotColor('agent', mapping)).toBe('#8250df');
+    expect(resolveColumnDotColor('human', mapping)).toBe('#bc4c00');
+    expect(resolveColumnDotColor('deferred', mapping)).toBe('#6e7781');
+    expect(resolveColumnDotColor('done', mapping)).toBe('#0969da');
+  });
+
+  it('accepts lowercase color enums from the API', () => {
+    expect(resolveColumnDotColor('todo', { ...mapping, todo: opt('Todo', 'green') })).toBe(
+      '#1a7f37',
+    );
+  });
+
+  it('falls back to null when mapping, option, or color is absent', () => {
+    expect(resolveColumnDotColor('todo', null)).toBeNull();
+    expect(resolveColumnDotColor('todo', undefined)).toBeNull();
+    expect(resolveColumnDotColor('todo', { ...mapping, todo: null })).toBeNull();
+    expect(resolveColumnDotColor('todo', { ...mapping, todo: opt('Todo', null) })).toBeNull();
+    expect(resolveColumnDotColor('deferred', { ...mapping, deferred: undefined })).toBeNull();
+  });
+
+  it('falls back to null for an unrecognized GitHub color enum', () => {
+    expect(resolveColumnDotColor('todo', { ...mapping, todo: opt('Todo', 'TEAL') })).toBeNull();
   });
 });
 

--- a/packages/ui/src/kanban-board/utils.ts
+++ b/packages/ui/src/kanban-board/utils.ts
@@ -2,6 +2,7 @@ import { type CollisionDetection, pointerWithin, rectIntersection } from '@dnd-k
 import type {
   AppSettings,
   GhStatusMapping,
+  GhStatusOption,
   GitHubIssueCacheRecord,
   IssuePipelineStatus,
   Project,
@@ -470,12 +471,52 @@ export function formatDate(iso: string): string {
 }
 
 /**
+ * GitHub Projects v2 single-select option colors → CSS hex.
+ * GitHub stores a Status option's color as an 8-value enum (not hex); map each to
+ * a Primer-aligned hex so the kanban column dot mirrors the board's own palette.
+ */
+const GH_STATUS_COLOR_HEX: Record<string, string> = {
+  GRAY: '#6e7781',
+  BLUE: '#0969da',
+  GREEN: '#1a7f37',
+  YELLOW: '#9a6700',
+  ORANGE: '#bc4c00',
+  RED: '#cf222e',
+  PINK: '#bf3989',
+  PURPLE: '#8250df',
+};
+
+/** ShipCode macro column → the GhStatusMapping field that backs it. */
+function statusOptionForColumn(
+  columnKey: ColumnKey,
+  mapping: GhStatusMapping,
+): GhStatusOption | null {
+  switch (columnKey) {
+    case 'todo':
+      return mapping.todo;
+    case 'agent':
+      return mapping.inProgress;
+    case 'human':
+      return mapping.humanReview;
+    case 'deferred':
+      return mapping.deferred ?? null;
+    case 'done':
+      return mapping.done;
+    default:
+      return null;
+  }
+}
+
+/**
  * Returns CSS hex color for a kanban column dot when a GitHub Projects
  * color is available, or null to fall back to the default Tailwind class.
  */
 export function resolveColumnDotColor(
-  _columnKey: ColumnKey,
-  _mapping: GhStatusMapping | null | undefined,
+  columnKey: ColumnKey,
+  mapping: GhStatusMapping | null | undefined,
 ): string | null {
-  return null;
+  if (!mapping) return null;
+  const color = statusOptionForColumn(columnKey, mapping)?.color;
+  if (!color) return null;
+  return GH_STATUS_COLOR_HEX[color.toUpperCase()] ?? null;
 }


### PR DESCRIPTION
## Summary
Fills the `resolveColumnDotColor` stub (previously always `return null`) so kanban column header dots mirror the linked **GitHub Projects v2 Status** option colors, instead of only the hardcoded Tailwind classes. Closes #33.

## What already existed (only the resolver body was missing)
- **Fetch** — `packages/agents/src/github/project-status.ts` already reads each Status single-select option's `{ name, color }`.
- **Storage** — `projects.github_status_mapping` JSON column + color migration (`packages/db`).
- **Type** — `GhStatusMapping` / `GhStatusOption` in `packages/shared`.
- **Call site** — `KanbanBoard.tsx:313` already calls `resolveColumnDotColor(col.key, project?.githubStatusMapping)` and `IssueListView` renders the returned hex as an inline dot color.

## This change
- Map each macro column (`todo`→todo, `agent`→inProgress, `human`→humanReview, `deferred`→deferred, `done`→done) to its backing `GhStatusMapping` field.
- Map the GitHub color enum (`GRAY|BLUE|GREEN|YELLOW|ORANGE|RED|PINK|PURPLE`, case-insensitive) to a Primer-aligned hex.
- **Fallback to `null`** (existing static colors) when no project is linked, the option/color is absent, or the enum is unrecognized.

## Tests
New `resolveColumnDotColor` describe block: per-column hex mapping, lowercase enum, all null/fallback paths, unknown enum. 
- utils.test.ts: **43 pass** · kanban-board suite: **166 pass** · ui typecheck clean · biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Kanban board column status indicators now display accurate color values aligned with GitHub's native status color scheme.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->