### PR TITLE
docs(session): log 2026-06-16 session 6 — weekly roadmap milestones + W1 (#33)

### DIFF
--- a/.agents/SESSIONS/2026-06-16.md
+++ b/.agents/SESSIONS/2026-06-16.md
@@ -453,3 +453,96 @@ Spark triage (no Sentry mail; all gh bot reviews)
 - **shipshit.games** `secret-scan.yml` uses a non-404 approach but is missing `persist-credentials:
   false` — optional hardening, skipped.
 - **Sessions 4 + 5 logs** still need to land on remote master via PR (master protected).
+
+## Session 6 — Product roadmap: weekly milestones + board cleanup, W1 execution (#33)
+
+Asked "do we have gh milestones + a clean roadmap?" → audited, found none real. Built a weekly
+milestone roadmap on GitHub Projects v2, then executed the (mostly-already-done) W1 batch — only
+#33 was a genuine build.
+
+### System flow
+
+```
+roadmap audit (5-agent workflow)  ->  verdict: no real milestones, no roadmap
+  └─ decisions: weekly GH milestones + project Start/Target date fields; auto-draft for approval
+       └─ W1 scoping flagged 3 of 4 stale:
+            #230 already done (#235 removed full.yml pull_request trigger)  -> close
+            #89  already shipped (telemetry opt-out: env gate + close() + consent dialog + tests) -> close
+            #7   defer-decision record (not a build)                        -> Deferred
+            #33  resolveColumnDotColor STUB (return null)                   -> BUILD
+       └─ build #33 (worktree) -> PR #240
+       └─ roadmap build: 7 weekly milestones (dated) + 2 date fields
+            + 20 issues scheduled + 5 deferred + 26 closed items archived + 1.1 closed
+```
+
+### What was done
+
+- [x] **Roadmap audit** (Workflow, 5 agents): milestones (1 empty "1.1"), 27 open issues (flat, all
+  P3, no milestones), Project #1 board (51 items, unstructured), **no committed roadmap doc**. Strong
+  label system (`shipcode:pipeline:*` ×11, `shipcode:agent:*` ×5) is the only real planning asset.
+- [x] **#33 — sync kanban column dot colors** (the one real W1 build). Filled the
+  `resolveColumnDotColor` stub in `packages/ui/src/kanban-board/utils.ts`: macro column
+  (todo/agent/human/deferred/done) → `GhStatusMapping` field → GH color enum
+  (GRAY|BLUE|GREEN|YELLOW|ORANGE|RED|PINK|PURPLE) → Primer-aligned hex; null fallback. The fetch
+  (`project-status.ts`), JSON storage (`projects.github_status_mapping` + migration), type, and the
+  `KanbanBoard.tsx:313` call site already existed — only the resolver body was missing. Added a
+  thorough `resolveColumnDotColor` test block. Gates: 43 utils + 166 kanban tests, ui typecheck,
+  biome — all green. → **PR #240** (`feat/kanban-dot-colors`).
+- [x] **Closed #230 + #89** with evidence (already-done); **#7 → Deferred** (defer record).
+- [x] **Roadmap build** on GitHub: 7 weekly milestones `Week N · <Mon>–<Sun>` (due = Sunday,
+  start in description); 2 project Date fields **Start date** (`…VqlrE`) / **Target date** (`…VqlrI`);
+  20 active issues scheduled (milestone + start/target + Status→Todo); 5 deferred (#88, #79, #159,
+  #173, #7 → Deferred status + `shipcode:deferred` label); **26 closed items archived**; stale `1.1`
+  milestone closed.
+
+### Weekly buckets (Mon–Sun, from 2026-06-15)
+
+| Week | Dates | Issues |
+|---|---|---|
+| W1 | Jun 15–21 | #33 |
+| W2 | Jun 22–28 | #194, #211, #212 (agent-chat epic) |
+| W3 | Jun 29–Jul 5 | #70, #76, #75, #66 (daemon foundations) |
+| W4 | Jul 6–12 | #60, #144 (cloud/EC2) |
+| W5 | Jul 13–19 | #85, #84, #81, #83 (kanban UX) |
+| W6 | Jul 20–26 | #82, #18 |
+| W7 | Jul 27–Aug 2 | #125, #124, #93, #91 (provider evals) |
+| Deferred | — | #159, #173, #88, #79, #7 |
+
+### Key decisions
+
+- **Milestones + project date fields, not iterations.** GH milestones store only `due_on` (target,
+  no start). Weekly milestones give the grouping lanes; the two project Date fields drive the
+  Roadmap's start→target bars. (Set the Roadmap view's date config to Start date / Target date.)
+- **Jira/Linear (#88, #79) → Deferred** (Vincent's edit) — issue-source integrations parked.
+- **Surface stale issues, don't blindly "implement."** #230/#89 were already shipped; #7 is a
+  defer-record. Implementing them would contradict the issues. Closed/deferred instead of building.
+- **Auto-draft → approve → execute.** Presented the full weekly table before any GitHub write.
+
+### Files changed
+
+- `M packages/ui/src/kanban-board/utils.ts` (PR #240 — `resolveColumnDotColor` impl + GH color map)
+- `M packages/ui/src/kanban-board/utils.test.ts` (PR #240 — resolver test block)
+- `M .agents/SESSIONS/2026-06-16.md` (this entry — separate PR)
+- GitHub state (no repo files): 7 milestones, 2 project date fields, 20 scheduled / 5 deferred
+  issues, 26 archived items, 1.1 closed.
+
+### Mistakes and fixes
+
+- **Python heredoc escaping** under the `gh api … | python3 -c '…'` pattern (backslash-quote in
+  f-strings) failed twice. Fixed by writing the script to a file and running `python3 file.py` — the
+  recurring "don't inline complex Python in single-quoted shell" lesson.
+- **#240 merge blocked twice.** (1) Strict up-to-date: master had advanced (#239 gitleaks hardening)
+  → `gh pr update-branch`. (2) After update, **`Socket Security: Project Report`** (a required
+  context) did not re-report on the update-branch head (Socket only posts on dep changes) →
+  permanent `BLOCKED`. Same unsatisfiable-required-context class as Session 4's `quality`. Left
+  pending; see next steps.
+
+### Next steps / loose ends
+
+- **#240 still unmerged** — required `Socket Security: Project Report` won't re-fire on the
+  update-branch head. Options: (a) push an empty commit to re-trigger Socket; (b) close/reopen the
+  PR; (c) drop `Socket Security: Project Report` from the ruleset's required set if it's unreliable
+  on non-dep PRs (Session-4-style ruleset fix); (d) one-off `--admin` merge. Vincent's call.
+- **Set the Roadmap view date fields** to Start date / Target date so the weekly bars render.
+- Deferred from prior sessions still stand: packaged-app srt verify, weekly-E2E macstudio→GH cutover,
+  wire shipshitdev/skills into pipeline prompts.


### PR DESCRIPTION
Session 6 log: roadmap audit → built a weekly-milestone roadmap on GitHub Projects v2, executed the W1 batch.

## What this session shipped (GitHub state, not code — except #33)
- **Roadmap audit** — no real milestones, no committed roadmap; strong label system is the only planning asset.
- **#33** (separate PR #240) — filled the `resolveColumnDotColor` stub so kanban dots mirror GitHub Projects Status colors.
- **W1 cleanup** — #230 + #89 closed (already shipped), #7 → Deferred (defer-record).
- **Weekly roadmap** — 7 dated milestones (`Week 1 · Jun 15–21` … `Week 7 · Jul 27–Aug 2`), 2 project Date fields (Start/Target), 20 issues scheduled, 5 deferred, 26 closed items archived, stale `1.1` closed.

## Loose end captured
- PR #240 merge blocked: required `Socket Security: Project Report` won't re-fire on the update-branch head (Session-4-style unsatisfiable-context). Options documented in the log.

Docs-only change: `.agents/SESSIONS/2026-06-16.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)