### PR TITLE
feat(automations): discoverable executor model catalog (incl. OpenRouter)

### DIFF
--- a/apps/desktop/src/renderer/features/automations/create-automation-modal.tsx
+++ b/apps/desktop/src/renderer/features/automations/create-automation-modal.tsx
@@ -7,6 +7,7 @@ import {
   type ReasoningEffort,
   type UpdateAutomationInput,
 } from '@shipcode/shared';
+import { CollapsibleSection } from '@shipcode/ui';
 import {
   Button,
   Input,
@@ -29,6 +30,7 @@ import log from 'electron-log/renderer';
 import { Wand2 } from 'lucide-react';
 import { useEffect, useMemo, useReducer, useRef } from 'react';
 import { useAppStore } from '../../stores/app-store';
+import { executorModelPlaceholder, executorModelSuggestions } from './executor-model-options';
 
 const PRESETS: Array<{ id: string; label: string; cron: string | null }> = [
   { id: 'hourly', label: 'Every hour', cron: '0 * * * *' },
@@ -473,83 +475,102 @@ function useCreateAutomationModalView() {
           )}
         </div>
 
-        <details className="rounded-md border border-border bg-tertiary/20 px-3 py-2">
-          <summary className="cursor-pointer text-xs font-medium text-secondary">
-            Executor override (optional)
-          </summary>
-          <div className="mt-3 flex flex-col gap-3">
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="auto-provider" className="text-xs text-secondary">
-                Provider
-              </Label>
-              <Select
-                value={provider}
-                onValueChange={(value) =>
-                  dispatchForm({
-                    type: 'field',
-                    field: 'provider',
-                    value: value as 'inherit' | AgentType,
-                  })
-                }
-              >
-                <SelectTrigger id="auto-provider" className="bg-transparent">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {PROVIDER_OPTIONS.map((o) => (
-                    <SelectItem key={o.value} value={o.value}>
-                      {o.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="auto-model" className="text-xs text-secondary">
-                Model ID
-              </Label>
-              <Input
-                id="auto-model"
-                value={executorModelId}
-                onChange={(e) =>
-                  dispatchForm({
-                    type: 'field',
-                    field: 'executorModelId',
-                    value: e.target.value,
-                  })
-                }
-                placeholder="e.g. anthropic/claude-opus-4-7"
-                className="font-mono text-xs"
-              />
-            </div>
-            <div className="flex flex-col gap-1.5">
-              <Label htmlFor="auto-reasoning" className="text-xs text-secondary">
-                Reasoning effort
-              </Label>
-              <Select
-                value={reasoning}
-                onValueChange={(value) =>
-                  dispatchForm({
-                    type: 'field',
-                    field: 'reasoning',
-                    value: value as 'inherit' | ReasoningEffort,
-                  })
-                }
-              >
-                <SelectTrigger id="auto-reasoning" className="bg-transparent">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  {REASONING_OPTIONS.map((o) => (
-                    <SelectItem key={o.value} value={o.value}>
-                      {o.label}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
+        <CollapsibleSection
+          title="Executor override (optional)"
+          contentClassName="flex flex-col gap-3"
+        >
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="auto-provider" className="text-xs text-secondary">
+              Provider
+            </Label>
+            <Select
+              value={provider}
+              onValueChange={(value) =>
+                dispatchForm({
+                  type: 'field',
+                  field: 'provider',
+                  value: value as 'inherit' | AgentType,
+                })
+              }
+            >
+              <SelectTrigger id="auto-provider" className="bg-transparent">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {PROVIDER_OPTIONS.map((o) => (
+                  <SelectItem key={o.value} value={o.value}>
+                    {o.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
           </div>
-        </details>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="auto-model" className="text-xs text-secondary">
+              Model ID
+            </Label>
+            <Input
+              id="auto-model"
+              value={executorModelId}
+              onChange={(e) =>
+                dispatchForm({
+                  type: 'field',
+                  field: 'executorModelId',
+                  value: e.target.value,
+                })
+              }
+              placeholder={executorModelPlaceholder(provider)}
+              className="font-mono text-xs"
+            />
+            {executorModelSuggestions(provider).length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {executorModelSuggestions(provider).map((o) => (
+                  <Button
+                    key={o.value}
+                    type="button"
+                    variant="secondary"
+                    size="xs"
+                    onClick={() =>
+                      dispatchForm({
+                        type: 'field',
+                        field: 'executorModelId',
+                        value: o.value,
+                      })
+                    }
+                  >
+                    {o.label}
+                  </Button>
+                ))}
+              </div>
+            )}
+          </div>
+          <div className="flex flex-col gap-1.5">
+            <Label htmlFor="auto-reasoning" className="text-xs text-secondary">
+              Reasoning effort
+            </Label>
+            <Select
+              value={reasoning}
+              onValueChange={(value) =>
+                dispatchForm({
+                  type: 'field',
+                  field: 'reasoning',
+                  value: value as 'inherit' | ReasoningEffort,
+                })
+              }
+            >
+              <SelectTrigger id="auto-reasoning" className="bg-transparent">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {REASONING_OPTIONS.map((o) => (
+                  <SelectItem key={o.value} value={o.value}>
+                    {o.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </CollapsibleSection>
 
         <Label
           htmlFor="auto-enabled"

--- a/apps/desktop/src/renderer/features/automations/executor-model-options.test.ts
+++ b/apps/desktop/src/renderer/features/automations/executor-model-options.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { executorModelPlaceholder, executorModelSuggestions } from './executor-model-options';
+
+describe('executorModelSuggestions', () => {
+  it('returns the OpenRouter catalog (incl. openrouter/auto) for openrouter', () => {
+    const values = executorModelSuggestions('openrouter').map((o) => o.value);
+    expect(values).toContain('openrouter/auto');
+    expect(values.length).toBeGreaterThan(1);
+  });
+
+  it('returns Claude model ids for claude', () => {
+    const values = executorModelSuggestions('claude').map((o) => o.value);
+    expect(values.length).toBeGreaterThan(0);
+    expect(values.every((v) => typeof v === 'string' && v.length > 0)).toBe(true);
+  });
+
+  it('returns codex fallback ids for codex', () => {
+    expect(executorModelSuggestions('codex').length).toBeGreaterThan(0);
+  });
+
+  it('returns no suggestions for inherit', () => {
+    expect(executorModelSuggestions('inherit')).toEqual([]);
+  });
+});
+
+describe('executorModelPlaceholder', () => {
+  it('hints openrouter/auto for openrouter', () => {
+    expect(executorModelPlaceholder('openrouter')).toContain('openrouter/auto');
+  });
+
+  it('differs per provider and gives an inherit hint', () => {
+    expect(executorModelPlaceholder('claude')).not.toBe(executorModelPlaceholder('codex'));
+    expect(executorModelPlaceholder('inherit').toLowerCase()).toContain('inherit');
+  });
+});

--- a/apps/desktop/src/renderer/features/automations/executor-model-options.ts
+++ b/apps/desktop/src/renderer/features/automations/executor-model-options.ts
@@ -1,0 +1,42 @@
+import {
+  type AgentType,
+  CLAUDE_MODEL_OPTIONS,
+  CODEX_FALLBACK_MODEL_OPTIONS,
+  OPENROUTER_MODEL_OPTIONS,
+} from '@shipcode/shared';
+
+/**
+ * Curated executor-model suggestions for an automation, by provider. Backs the
+ * Model ID field's <datalist> so the catalog (notably the full OpenRouter set,
+ * including `openrouter/auto`) is discoverable instead of blind free-text. The
+ * field stays free-text — these are suggestions, not a closed set. Returns []
+ * for `inherit` (no override) and any provider without a curated list.
+ */
+export function executorModelSuggestions(
+  provider: 'inherit' | AgentType,
+): ReadonlyArray<{ value: string; label: string }> {
+  switch (provider) {
+    case 'openrouter':
+      return OPENROUTER_MODEL_OPTIONS;
+    case 'claude':
+      return CLAUDE_MODEL_OPTIONS;
+    case 'codex':
+      return CODEX_FALLBACK_MODEL_OPTIONS;
+    default:
+      return [];
+  }
+}
+
+/** Provider-aware placeholder for the automation Model ID field. */
+export function executorModelPlaceholder(provider: 'inherit' | AgentType): string {
+  switch (provider) {
+    case 'openrouter':
+      return 'e.g. openrouter/auto';
+    case 'codex':
+      return 'e.g. gpt-5-codex';
+    case 'claude':
+      return 'e.g. anthropic/claude-opus-4-7';
+    default:
+      return 'Inherit from project default';
+  }
+}


### PR DESCRIPTION
## Summary
Answers "can we use OpenRouter (more models) for automations?" — **it already runs end-to-end**; this makes the model catalog *discoverable* and tidies the advanced section. Part of the unified agent-automation control plane epic #242 (P1).

## Already working (verified)
Per-automation `executorProvider` / `executorModelId` / `executorReasoningEffort` are stored and **merged into the run at execute time** (`pipeline-scheduler.ts`), so OpenRouter/Claude/Codex automations already execute on the chosen model. The UI just didn't surface the options.

## This change
- **`executorModelSuggestions` / `executorModelPlaceholder` helpers** sourced from the shared `model-catalog` (`OPENROUTER_MODEL_OPTIONS` incl. `openrouter/auto`, `CLAUDE_MODEL_OPTIONS`, `CODEX_FALLBACK_MODEL_OPTIONS`) — unit-tested.
- **Automation modal:** provider-aware placeholder + **UI `Button` quick-picks** that set the Model ID on click. Field stays free-text for arbitrary models.
- **Converted the pre-existing raw `<details>`/`<summary>`** 'Executor override' section to `CollapsibleSection` from `@shipcode/ui` (satisfies the no-raw-html design gate; `@shipshitdev/ui@0.8.0` has no collapsible primitive, which is why it was raw HTML).

## Tests / gates
New `executor-model-options.test.ts` (6) + existing modal suite (12) pass · typecheck 15/15 · biome clean · no-raw-html clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced executor override section in the automation form with an improved collapsible UI design
  * Added provider-specific model suggestions displayed as interactive buttons for easier selection
  * Dynamic model ID placeholder text that adapts based on the selected provider

<!-- end of auto-generated comment: release notes by coderabbit.ai -->