### PR TITLE
feat(automations): surface next-run in list + stop scheduler on app-quit

### DIFF
--- a/apps/desktop/src/main/index.test.ts
+++ b/apps/desktop/src/main/index.test.ts
@@ -103,6 +103,7 @@ const pipelineSchedulerMock = {
 
 const automationSchedulerMock = {
   start: vi.fn(),
+  stop: vi.fn(),
 };
 
 const updateServiceMock = {

--- a/apps/desktop/src/main/index.ts
+++ b/apps/desktop/src/main/index.ts
@@ -573,6 +573,7 @@ function createWindow() {
   mainWindow.on('closed', () => {
     if (watchdogTimer) clearInterval(watchdogTimer);
     reconciliationLoop.stop();
+    automationScheduler.stop();
     workflowWatchManager.dispose();
     updateService?.stop();
     updateService = null;

--- a/apps/desktop/src/renderer/features/automations/automations-view.test.tsx
+++ b/apps/desktop/src/renderer/features/automations/automations-view.test.tsx
@@ -217,6 +217,37 @@ describe('AutomationsView', () => {
     expect(screen.getByText(/My Repo/)).toBeInTheDocument();
   });
 
+  it('shows the next scheduled run when enabled and scheduled', async () => {
+    const future = new Date(Date.now() + 1000 * 60 * 60 * 26).toISOString();
+    invokeMock.mockImplementation(async (channel: string) => {
+      if (channel === 'automations:list-all') {
+        return [makeAutomation({ enabled: true, nextRunAt: future })];
+      }
+      if (channel === 'project:list-visible') return [makeProject()];
+      return null;
+    });
+
+    renderWithProviders();
+
+    expect(await screen.findByText(/Next in/)).toBeInTheDocument();
+  });
+
+  it('omits the next run line when the automation is disabled', async () => {
+    const future = new Date(Date.now() + 1000 * 60 * 60 * 26).toISOString();
+    invokeMock.mockImplementation(async (channel: string) => {
+      if (channel === 'automations:list-all') {
+        return [makeAutomation({ enabled: false, nextRunAt: future })];
+      }
+      if (channel === 'project:list-visible') return [makeProject()];
+      return null;
+    });
+
+    renderWithProviders();
+
+    await waitFor(() => expect(screen.getByText('Daily smoke')).toBeInTheDocument());
+    expect(screen.queryByText(/Next in/)).not.toBeInTheDocument();
+  });
+
   it('runs, edits, toggles, and deletes an automation from the card actions', async () => {
     invokeMock.mockImplementation(async (channel: string) => {
       if (channel === 'automations:list-all') return [makeAutomation({ enabled: true })];

--- a/apps/desktop/src/renderer/features/automations/automations-view.tsx
+++ b/apps/desktop/src/renderer/features/automations/automations-view.tsx
@@ -181,6 +181,9 @@ function AutomationCard({
               {automation.lastStartedAt
                 ? `Last run ${formatAutomationRelativeTime(automation.lastStartedAt)} · ${automation.runCount} total`
                 : 'Never run'}
+              {automation.enabled && automation.nextRunAt
+                ? ` · Next ${formatAutomationRelativeTime(automation.nextRunAt)}`
+                : ''}
             </div>
           </Button>
 


### PR DESCRIPTION
## Summary
Two P1 polish items for the local automation control plane (epic #242). Cloud-durable backend is **held** — the Claude Routines CRUD path is ToS-blocked for third-party use of the claude.ai OAuth token (see #242 spike); revisit when Anthropic ships a sanctioned management API.

## Changes
- **Next-run in the automations list** — enabled automations now show `· Next in Xh` (future-aware `formatAutomationRelativeTime`) next to the existing last-run/status line. `lastStatus` was already surfaced; `nextRunAt` was the gap.
- **Stop the scheduler on quit** — `AutomationScheduler.stop()` is now called in the `mainWindow 'closed'` cleanup alongside `reconciliationLoop.stop()`. It was `start()`ed but never stopped, leaking croner jobs.

## Tests / gates
2 new automations-view tests (next-run shown when enabled+scheduled; omitted when disabled) → view suite 9 pass · typecheck 15/15 · biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automation cards now show a “Next in…” segment when an automation is enabled and a upcoming scheduled run exists.

* **Chores**
  * Improved application shutdown cleanup to stop the automation scheduler when the main window is closed.

* **Tests**
  * Added UI test coverage for the “Next in…” display behavior for both enabled and disabled automations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->