### PR TITLE
ci(bots): stop review bots from creating merge-blocking threads

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,9 +1,17 @@
 # yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
 language: en-US
 reviews:
+  # `chill` only surfaces substantive findings (skips nitpicks), so CodeRabbit
+  # speaks when it has something useful to say. There is no summary-only mode:
+  # genuine inline findings still post as review threads (desired signal) and
+  # auto-resolve once addressed. CodeRabbit self-throttles when over quota.
+  profile: chill
+  high_level_summary: true   # keep the non-blocking PR summary
+  review_status: false       # drop "review skipped" status-comment noise
+  poem: false                # signal only — no poem
   auto_review:
+    # Trunk-based: feature PRs target master (the repo default), which CodeRabbit
+    # auto-reviews without an explicit base_branches list. The old `develop`
+    # integration branch was deleted (PR #235).
     enabled: true
-    # Auto-review PRs targeting these branches in addition to the repo default.
-    # `develop` is our integration branch where feature PRs land.
-    base_branches:
-      - develop
+    drafts: false            # don't spend review quota on draft PRs

--- a/.github/workflows/react-doctor.yml
+++ b/.github/workflows/react-doctor.yml
@@ -24,3 +24,9 @@ jobs:
         with:
           fetch-depth: 0
       - uses: millionco/react-doctor@v2
+        with:
+          # Report via the sticky summary comment + commit status only.
+          # Inline review comments create unresolved PR review threads that
+          # block merges via the ruleset's required_review_thread_resolution,
+          # even though `blocking: none` keeps this check itself advisory/green.
+          review-comments: false


### PR DESCRIPTION
Replaces #254 (which accidentally carried an unrelated skills-sync commit). This branch is the same change, rebuilt clean off master — exactly two files.

## Why
The ruleset **Protect default branch** enforces `required_review_thread_resolution`, so any unresolved bot review thread blocks merge even when its check is green (this blocked #248 on a react-doctor advisory).

## Changes
- **`react-doctor.yml`**: `review-comments: false` → no inline PR review threads; findings still surface via the sticky summary comment + commit status. `blocking` is already `none`, so the check stays advisory/green. react-doctor can no longer block a merge.
- **`.coderabbit.yaml`**: `profile: chill` (substantive findings only), skip draft PRs (save quota), drop poem + "review skipped" noise, remove the dead `develop` base_branches ref (trunk-based since #235). CodeRabbit has no summary-only mode, so genuine inline findings still post (desired signal) and auto-resolve once addressed.