### PR TITLE
fix(desktop): SkillsView cascading setState → useReducer

### DIFF
--- a/.agents/SESSIONS/2026-06-20.md
+++ b/.agents/SESSIONS/2026-06-20.md
@@ -1,0 +1,104 @@
+# 2026-06-20
+
+## Session 1 — Fix SkillsView cascading-setState advisory left from PR #248
+
+Resolved the `react-doctor/no-cascading-set-state` advisory in the desktop
+`SkillsView` renderer that PR #248 shipped as an *accepted* warning (CI passed
+because the rule is warning-severity, but the underlying pattern was never
+fixed). Combined the three project-scoped state values into a single
+`useReducer` so the project-switch effect produces one re-render instead of
+three. Verified locally with react-doctor (before/after) plus the full desktop
+gate, then bundled into one PR alongside the pre-existing `chore(skills)` commit
+already on the branch (Vincent's call).
+
+### System flow
+
+```
+react-doctor baseline (bunx react-doctor@latest --lint --json)
+   └─ SkillsView.tsx:130  no-cascading-set-state (warning)
+        "3 setState calls in one useEffect redraw your screen each time"
+        │
+        ▼
+Fold scope + seedNotice + seedError → one useReducer
+   ├─ skillsScopeReducer { project-changed | set-scope | seed-success | seed-error }
+   ├─ effect: setScope+setSeedNotice+setSeedError  →  dispatchScope({project-changed})
+   ├─ handleScopeChange → set-scope
+   └─ seed onSuccess/onError → seed-success / seed-error  (2 setStates → 1 dispatch each)
+        │
+        ▼
+Verify
+   ├─ react-doctor re-run → 0 diagnostics on file, 0 no-cascading across desktop
+   └─ turbo lint typecheck test --filter=@shipcode/desktop → 8/8, 1503 tests pass
+        │
+        ▼
+Commit fix + this session doc → push → PR to master (bundles 466924ad chore(skills))
+```
+
+### Affected components
+
+- **Desktop renderer** — `apps/desktop/src/renderer/components/SkillsView.tsx`
+  (only code file changed this session).
+- **Trunk** — this session log + the bundled (pre-existing) `chore(skills)` commit.
+
+### What was done
+
+- [x] Read the target effect (lines 130–135): `setScope` + `setSeedNotice` +
+      `setSeedError` reset together on `activeProjectId` change.
+- [x] Confirmed the rule's exact trigger by running react-doctor locally
+      (`bunx react-doctor@latest`): baseline reported **1 warning at
+      `SkillsView.tsx:130`** — *"3 setState calls in one useEffect…"*.
+- [x] Added module-scope `SkillsScopeState` + `skillsScopeReducer` with a 4-action
+      discriminated union; replaced the 3 `useState` hooks with one `useReducer`
+      + destructure (`const { scope, seedNotice, seedError } = scopeState`).
+- [x] Rewired all four setter sites to `dispatchScope(...)`; the two seed mutation
+      callbacks collapse from 2 setStates each to 1 dispatch (bonus cleanup).
+- [x] Kept render JSX untouched — `role="alert"` (seedError) /
+      `aria-live="polite"` (seedNotice) intact.
+- [x] biome auto-format (one-lined the reducer signature), then re-checked clean.
+- [x] react-doctor re-run: **0** diagnostics on the file, **0** `no-cascading-set-state`
+      across the whole desktop project; no new warnings introduced.
+- [x] Full gate green: `turbo lint typecheck test --filter=@shipcode/desktop`
+      → **8/8 tasks**, biome + `tsc --noEmit` clean, **1503 tests / 151 files** pass.
+
+### Key decisions
+
+- **`useReducer` over a single `useState` object.** A single `setScopeState`
+  object would still be a `set*`-named call (react-doctor keys its heuristic off
+  React-style `set*` setters — see 2026-05-09 `useIpc` note) and reads as
+  "adjust state on dependency change." `dispatch` sidesteps the heuristic and a
+  single dispatch is unambiguously one update. Confirmed empirically: 0 diagnostics.
+- **`project-changed` returns the shared `INITIAL_SCOPE_STATE` constant.** Lets
+  `useReducer` bail out of a redundant re-render when state is already at
+  defaults (e.g. on mount); a real project switch still resets correctly.
+- **Behavior preserved exactly** at every site — verified action-by-action vs the
+  originals (scope-only change keeps seed feedback; seed notice/error stay
+  mutually exclusive). This is a render-count fix, not a behavior change.
+- **Bundle into one PR with `466924ad`** (chore/skills, ~95 files) rather than a
+  clean isolated PR — Vincent's explicit choice when surfaced.
+
+### Files changed
+
+- `apps/desktop/src/renderer/components/SkillsView.tsx` — `useReducer` +
+  `skillsScopeReducer`/`SkillsScopeState`/`SkillsScopeAction`; effect, scope
+  handler, and seed mutation callbacks now dispatch (+49 / −12).
+- `.agents/SESSIONS/2026-06-20.md` — this log.
+
+### Mistakes and fixes
+
+- **First typecheck failed in an unrelated package** (`@shipcode/agents`:
+  "Cannot find module '@shipcode/shared' / 'zod'"). Root cause: this is a fresh
+  git worktree with no installed deps — not my change. Ran `bun install`; the
+  re-run went green (zod resolves via bun's `.bun` store, not a top-level
+  `node_modules/zod` entry, so a naive `ls` still showed it "missing").
+- **`bun install` postinstall deleted the tracked `.claude/skills` symlink**
+  (`setup-skills.sh` prunes it during regen, and the regen `ln` failed in the
+  worktree). Restored with `git restore -- .claude/skills` so the working tree
+  stayed scoped to the one intended file.
+
+### Next steps
+
+- Open PR `claude/sweet-allen-eb1d0d → master` (bundles `466924ad` chore(skills)
+  + this fix); let the 7 required checks run, including the React Doctor job.
+- The `chore(skills)` commit's `setup-skills.sh` symlink regen is unreliable
+  inside agent worktrees (the `.claude/skills` ln failure above) — worth a follow-up
+  if it recurs on CI/Vercel, though postinstall is CI/Vercel-skipped per its commit msg.

--- a/apps/desktop/src/renderer/components/SkillsView.tsx
+++ b/apps/desktop/src/renderer/components/SkillsView.tsx
@@ -15,7 +15,7 @@ import {
 import { LoadingButtonContent } from '@shipshitdev/ui/common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { Download, Sparkles } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useReducer, useState } from 'react';
 import { useAppStore } from '../stores/app-store';
 
 // The row shape below mirrors what apps/desktop/src/main/ipc.ts builds in
@@ -108,10 +108,50 @@ const SKILLS_LOADING_ROW_KEYS = [
 
 const SCOPE_GLOBAL = '__GLOBAL__' as const;
 
+// Scope picker + dev-loop seed feedback are reset together whenever the active
+// project changes. Folding them into one reducer keeps that reset (and the
+// mutually-exclusive seed notice/error) a single state update, so the effect
+// produces one re-render instead of three (react-doctor/no-cascading-set-state).
+interface SkillsScopeState {
+  scope: string;
+  seedNotice: string | null;
+  seedError: string | null;
+}
+
+type SkillsScopeAction =
+  | { type: 'project-changed' }
+  | { type: 'set-scope'; scope: string }
+  | { type: 'seed-success'; notice: string }
+  | { type: 'seed-error'; error: string };
+
+const INITIAL_SCOPE_STATE: SkillsScopeState = {
+  scope: SCOPE_GLOBAL,
+  seedNotice: null,
+  seedError: null,
+};
+
+function skillsScopeReducer(state: SkillsScopeState, action: SkillsScopeAction): SkillsScopeState {
+  switch (action.type) {
+    // Switching projects clears any stale per-project view in one update.
+    case 'project-changed':
+      return INITIAL_SCOPE_STATE;
+    case 'set-scope':
+      return { ...state, scope: action.scope };
+    // Seed notice and error are mutually exclusive — showing one clears the other.
+    case 'seed-success':
+      return { ...state, seedNotice: action.notice, seedError: null };
+    case 'seed-error':
+      return { ...state, seedError: action.error, seedNotice: null };
+    default:
+      return state;
+  }
+}
+
 function useSkillsView() {
   const queryClient = useQueryClient();
   const activeProjectId = useAppStore((state) => state.activeProjectId);
-  const [scope, setScope] = useState<string>(SCOPE_GLOBAL);
+  const [scopeState, dispatchScope] = useReducer(skillsScopeReducer, INITIAL_SCOPE_STATE);
+  const { scope, seedNotice, seedError } = scopeState;
   const [activePhase, setActivePhase] = useState<PhaseSkillKey>('plan-generation');
   const [draft, setDraft] = useState<string>('');
   const [draftDirty, setDraftDirty] = useState(false);
@@ -119,8 +159,6 @@ function useSkillsView() {
   const [rewriteInstruction, setRewriteInstruction] = useState('');
   const [rewriteError, setRewriteError] = useState<string | null>(null);
   const [rewriteNotice, setRewriteNotice] = useState<string | null>(null);
-  const [seedNotice, setSeedNotice] = useState<string | null>(null);
-  const [seedError, setSeedError] = useState<string | null>(null);
 
   const projectId = scope === SCOPE_GLOBAL ? null : scope;
 
@@ -129,9 +167,7 @@ function useSkillsView() {
   // project.
   useEffect(() => {
     void activeProjectId;
-    setScope(SCOPE_GLOBAL);
-    setSeedNotice(null);
-    setSeedError(null);
+    dispatchScope({ type: 'project-changed' });
   }, [activeProjectId]);
 
   const { data: list, isLoading } = useQuery<SkillListEntry[]>({
@@ -173,7 +209,7 @@ function useSkillsView() {
     setRewriteNotice(null);
   };
   const handleScopeChange = (value: string) => {
-    setScope(value);
+    dispatchScope({ type: 'set-scope', scope: value });
     resetEditorChrome();
   };
   const handlePhaseChange = (phase: PhaseSkillKey) => {
@@ -277,13 +313,14 @@ function useSkillsView() {
     onSuccess: (result, variables) => {
       const written = result.files.filter((file) => file.status === 'written').length;
       const skipped = result.files.filter((file) => file.status === 'skipped').length;
-      setSeedNotice(`Dev-loop skills seeded: ${written} written, ${skipped} skipped.`);
-      setSeedError(null);
+      dispatchScope({
+        type: 'seed-success',
+        notice: `Dev-loop skills seeded: ${written} written, ${skipped} skipped.`,
+      });
       queryClient.invalidateQueries({ queryKey: ['skills:writing-prds', variables.projectId] });
     },
     onError: (err: unknown) => {
-      setSeedError(clampError(err));
-      setSeedNotice(null);
+      dispatchScope({ type: 'seed-error', error: clampError(err) });
     },
   });
 


### PR DESCRIPTION
Replaces #255, rebuilt down to the actual change. That branch also carried the full skills-content sync + `setup-skills.sh` tooling, which has since landed independently in #253 — so this PR is just the SkillsView fix and its session log.

## Change
`useSkillsView` previously fired three `setState`s in the active-project effect (`setScope`, `setSeedNotice`, `setSeedError`) — three re-renders, flagged by `react-doctor/no-cascading-set-state`. Folded `scope`/`seedNotice`/`seedError` into a single discriminated-union `useReducer`:

- `project-changed` → resets all three in one dispatch (one re-render)
- `set-scope` → updates scope
- `seed-success` / `seed-error` → mutually exclusive notice/error

Behaviour-preserving; resolves the advisory that was waved through at merge of #248.