### PR TITLE
feat(models): Opus 4.8 in catalog + model slug aliases (S1, #259)

### DIFF
--- a/apps/desktop/src/main/ipc/register-automation-handlers.ts
+++ b/apps/desktop/src/main/ipc/register-automation-handlers.ts
@@ -1,6 +1,7 @@
 import {
   type CreateAutomationInput,
   clampError,
+  resolveModelAlias,
   type UpdateAutomationInput,
 } from '@shipcode/shared';
 import { Cron } from 'croner';
@@ -47,7 +48,13 @@ export function registerAutomationHandlers(
 
   handleAutomation('automations:create', async (_e, input: CreateAutomationInput) => {
     validateCron(input.cronExpr);
-    const automation = queries.automations.create(input);
+    // Canonicalize friendly model shorthands (e.g. "opus", "5.5") on save so
+    // every downstream consumer sees a concrete model id.
+    const normalized: CreateAutomationInput =
+      input.executorModelId == null
+        ? input
+        : { ...input, executorModelId: resolveModelAlias(input.executorModelId) };
+    const automation = queries.automations.create(normalized);
     automationScheduler.schedule(automation);
     return automation;
   });
@@ -57,7 +64,11 @@ export function registerAutomationHandlers(
     async (_e, payload: { id: string } & UpdateAutomationInput) => {
       const { id, ...patch } = payload;
       if (patch.cronExpr !== undefined) validateCron(patch.cronExpr);
-      const automation = queries.automations.update(id, patch);
+      const normalized: UpdateAutomationInput =
+        patch.executorModelId == null
+          ? patch
+          : { ...patch, executorModelId: resolveModelAlias(patch.executorModelId) };
+      const automation = queries.automations.update(id, normalized);
       automationScheduler.schedule(automation);
       return automation;
     },

--- a/apps/desktop/src/renderer/features/automations/executor-model-options.ts
+++ b/apps/desktop/src/renderer/features/automations/executor-model-options.ts
@@ -35,7 +35,7 @@ export function executorModelPlaceholder(provider: 'inherit' | AgentType): strin
     case 'codex':
       return 'e.g. gpt-5-codex';
     case 'claude':
-      return 'e.g. anthropic/claude-opus-4-7';
+      return 'e.g. claude-opus-4-8';
     default:
       return 'Inherit from project default';
   }

--- a/packages/shared/src/model-catalog.test.ts
+++ b/packages/shared/src/model-catalog.test.ts
@@ -5,7 +5,9 @@ import {
   GEMINI_FALLBACK_MODEL_OPTIONS,
   getKnownModelLabel,
   OPENROUTER_MODEL_IDS,
+  OPENROUTER_MODEL_OPTIONS,
   PINNED_MODEL_DEFAULTS,
+  resolveModelAlias,
 } from './model-catalog';
 
 describe('model-catalog', () => {
@@ -65,5 +67,40 @@ describe('model-catalog', () => {
     expect(getKnownModelLabel(undefined)).toBeNull();
     expect(getKnownModelLabel('')).toBeNull();
     expect(getKnownModelLabel('provider/not-curated')).toBeNull();
+  });
+
+  it('exposes Opus 4.8 as a selectable Claude and OpenRouter option', () => {
+    expect(CLAUDE_MODEL_OPTIONS.map((option) => option.value)).toContain('claude-opus-4-8');
+    expect(OPENROUTER_MODEL_OPTIONS.map((option) => option.value)).toContain(
+      'anthropic/claude-opus-4.8',
+    );
+    expect(getKnownModelLabel('claude-opus-4-8')).toBe('Opus 4.8');
+    expect(getKnownModelLabel('anthropic/claude-opus-4.8')).toBe('Claude Opus 4.8');
+    expect(getKnownModelLabel('anthropic/claude-opus-4-8')).toBe('Claude Opus 4.8');
+  });
+
+  describe('resolveModelAlias', () => {
+    it('resolves bare family shorthands to the pinned generation', () => {
+      expect(resolveModelAlias('opus')).toBe('claude-opus-4-8');
+      expect(resolveModelAlias('sonnet')).toBe('claude-sonnet-4-6');
+      expect(resolveModelAlias('haiku')).toBe('claude-haiku-4-5-20251001');
+      expect(resolveModelAlias('5.5')).toBe('gpt-5.5');
+      expect(resolveModelAlias('5.4-mini')).toBe('gpt-5.4-mini');
+    });
+
+    it('is case-insensitive and trims whitespace', () => {
+      expect(resolveModelAlias('  OPUS  ')).toBe('claude-opus-4-8');
+    });
+
+    it('passes already-canonical ids through unchanged', () => {
+      expect(resolveModelAlias('claude-opus-4-8')).toBe('claude-opus-4-8');
+      expect(resolveModelAlias('openrouter/auto')).toBe('openrouter/auto');
+    });
+
+    it('returns null for nullish or blank input', () => {
+      expect(resolveModelAlias(null)).toBeNull();
+      expect(resolveModelAlias(undefined)).toBeNull();
+      expect(resolveModelAlias('   ')).toBeNull();
+    });
   });
 });

--- a/packages/shared/src/model-catalog.ts
+++ b/packages/shared/src/model-catalog.ts
@@ -7,6 +7,7 @@ export const CLAUDE_MODEL_IDS = {
   sonnet46: 'claude-sonnet-4-6',
   opus46: 'claude-opus-4-6',
   opus47: 'claude-opus-4-7',
+  opus48: 'claude-opus-4-8',
   haiku45: 'claude-haiku-4-5-20251001',
 } as const;
 
@@ -43,6 +44,7 @@ export const OPENROUTER_MODEL_IDS = {
   autoFree: 'openrouter/free',
   claudeSonnet46: 'anthropic/claude-sonnet-4.6',
   claudeOpus46: 'anthropic/claude-opus-4.6',
+  claudeOpus48: 'anthropic/claude-opus-4.8',
   qwen36Plus: 'qwen/qwen3.6-plus',
   qwen3CoderFree: 'qwen/qwen3-coder:free',
 } as const;
@@ -53,6 +55,7 @@ export const CLAUDE_MODEL_OPTIONS = [
   { value: CLAUDE_MODEL_IDS.sonnet46, label: 'Sonnet 4.6' },
   { value: CLAUDE_MODEL_IDS.opus46, label: 'Opus 4.6' },
   { value: CLAUDE_MODEL_IDS.opus47, label: 'Opus 4.7' },
+  { value: CLAUDE_MODEL_IDS.opus48, label: 'Opus 4.8' },
   { value: CLAUDE_MODEL_IDS.haiku45, label: 'Haiku 4.5' },
 ] as const satisfies readonly KnownModelOption<ClaudeModelId>[];
 
@@ -77,6 +80,7 @@ export const OPENROUTER_MODEL_OPTIONS = [
   { value: OPENROUTER_MODEL_IDS.autoPaid, label: 'Auto (paid)' },
   { value: OPENROUTER_MODEL_IDS.autoFree, label: 'Auto (free)' },
   { value: OPENROUTER_MODEL_IDS.claudeSonnet46, label: 'Claude Sonnet 4.6' },
+  { value: OPENROUTER_MODEL_IDS.claudeOpus48, label: 'Claude Opus 4.8' },
   { value: OPENROUTER_MODEL_IDS.qwen36Plus, label: 'Qwen 3.6 Plus' },
   { value: OPENROUTER_MODEL_IDS.qwen3CoderFree, label: 'Qwen 3 Coder Free' },
 ] as const satisfies readonly KnownModelOption<OpenRouterModelId>[];
@@ -132,10 +136,43 @@ export const KNOWN_MODEL_LABELS: Record<string, string> = {
   'anthropic/claude-sonnet-4-6': CURATED_MODEL_LABELS[OPENROUTER_MODEL_IDS.claudeSonnet46],
   [OPENROUTER_MODEL_IDS.claudeOpus46]: 'Claude Opus 4.6',
   'anthropic/claude-opus-4-6': 'Claude Opus 4.6',
+  'anthropic/claude-opus-4-8': 'Claude Opus 4.8',
   'openai/gpt-5-codex': 'GPT-5 Codex',
 };
 
 export function getKnownModelLabel(modelId: string | null | undefined): string | null {
   if (!modelId) return null;
   return KNOWN_MODEL_LABELS[modelId] ?? null;
+}
+
+// Human-friendly shorthands a user can type in a model field instead of an
+// exact id. Normalized at the input boundary so everything downstream sees a
+// canonical id. Keys are matched case-insensitively. Bare family names
+// (`opus`/`sonnet`/`haiku`) resolve to the current pinned generation.
+export const MODEL_SLUG_ALIASES: Record<string, string> = {
+  opus: CLAUDE_MODEL_IDS.opus48,
+  'opus-4.8': CLAUDE_MODEL_IDS.opus48,
+  'opus4.8': CLAUDE_MODEL_IDS.opus48,
+  'opus-4.7': CLAUDE_MODEL_IDS.opus47,
+  'opus-4.6': CLAUDE_MODEL_IDS.opus46,
+  sonnet: CLAUDE_MODEL_IDS.sonnet46,
+  'sonnet-4.6': CLAUDE_MODEL_IDS.sonnet46,
+  haiku: CLAUDE_MODEL_IDS.haiku45,
+  'haiku-4.5': CLAUDE_MODEL_IDS.haiku45,
+  '5.5': CODEX_FALLBACK_MODEL_IDS.gpt55,
+  '5.4': CODEX_FALLBACK_MODEL_IDS.gpt54,
+  '5.4-mini': CODEX_FALLBACK_MODEL_IDS.gpt54Mini,
+  mini: CODEX_FALLBACK_MODEL_IDS.gpt54Mini,
+};
+
+/**
+ * Resolve a user-typed model shorthand to its canonical id. Unknown values
+ * (including already-canonical ids) are trimmed and returned unchanged.
+ * Returns null only for nullish/blank input.
+ */
+export function resolveModelAlias(value: string | null | undefined): string | null {
+  if (value == null) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  return MODEL_SLUG_ALIASES[trimmed.toLowerCase()] ?? trimmed;
 }

--- a/packages/shared/src/reasoning-effort.test.ts
+++ b/packages/shared/src/reasoning-effort.test.ts
@@ -136,6 +136,19 @@ describe('reasoning-effort', () => {
     );
   });
 
+  it('treats OpenRouter Claude Opus 4.8 as adaptive like the 4.6 models', () => {
+    expect(normalizeReasoningModelId('openrouter', 'anthropic/claude-opus-4-8')).toBe(
+      'anthropic/claude-opus-4.8',
+    );
+    expect(getSupportedReasoningEfforts('openrouter', 'anthropic/claude-opus-4.8')).toEqual([
+      'none',
+      'high',
+    ]);
+    expect(formatProviderReasoningEffort('openrouter', 'xhigh', 'anthropic/claude-opus-4-8')).toBe(
+      'high',
+    );
+  });
+
   it('disables reasoning entirely for OpenRouter models without reasoning support', () => {
     expect(getSupportedReasoningEfforts('openrouter', 'qwen/qwen3-coder:free')).toEqual(['none']);
     expect(resolveProviderReasoningEffort('openrouter', 'none', 'qwen/qwen3-coder:free')).toEqual({

--- a/packages/shared/src/reasoning-effort.ts
+++ b/packages/shared/src/reasoning-effort.ts
@@ -42,11 +42,13 @@ const OPENROUTER_DISABLED_REASONING_EFFORTS = [
 const OPENROUTER_MODEL_ALIASES: Record<string, string> = {
   'anthropic/claude-sonnet-4-6': OPENROUTER_MODEL_IDS.claudeSonnet46,
   'anthropic/claude-opus-4-6': OPENROUTER_MODEL_IDS.claudeOpus46,
+  'anthropic/claude-opus-4-8': OPENROUTER_MODEL_IDS.claudeOpus48,
 };
 
 const OPENROUTER_ADAPTIVE_CLAUDE_MODELS = new Set<string>([
   OPENROUTER_MODEL_IDS.claudeSonnet46,
   OPENROUTER_MODEL_IDS.claudeOpus46,
+  OPENROUTER_MODEL_IDS.claudeOpus48,
 ]);
 
 const OPENROUTER_NO_REASONING_MODELS = new Set<string>([OPENROUTER_MODEL_IDS.qwen3CoderFree]);


### PR DESCRIPTION
Closes #259. Part of epic #258.

## What

S1 of the budget-aware automations epic — the unblocker. Adds Opus 4.8 to the model catalog so it's selectable for every phase and for an automation's executor, and introduces human-friendly model slug aliases (borrowed from pingdotgg/t3code).

## Changes

- **Catalog** (`packages/shared/src/model-catalog.ts`)
  - `claude-opus-4-8` added to `CLAUDE_MODEL_IDS` + `CLAUDE_MODEL_OPTIONS` (label "Opus 4.8").
  - `anthropic/claude-opus-4.8` added to `OPENROUTER_MODEL_IDS` + `OPENROUTER_MODEL_OPTIONS` (label "Claude Opus 4.8"), plus dash-variant label mapping.
  - New `MODEL_SLUG_ALIASES` table + `resolveModelAlias()` — resolves `opus`/`sonnet`/`haiku`/`5.5`/`5.4`/`5.4-mini` (case-insensitive, trimmed) to canonical ids; already-canonical ids pass through unchanged.
- **Reasoning** (`packages/shared/src/reasoning-effort.ts`)
  - OpenRouter Opus 4.8 wired into the dash→dot alias map and the adaptive-thinking set, so it behaves like Opus 4.6 (none/high efforts; `xhigh`→`high`).
- **Automation IPC** (`apps/desktop/src/main/ipc/register-automation-handlers.ts`)
  - `executorModelId` canonicalized via `resolveModelAlias()` on create + update, so a typed shorthand is persisted as a concrete id.
- **Automation UI** (`executor-model-options.ts`)
  - Claude model-id placeholder bumped to `claude-opus-4-8`. Opus 4.8 auto-surfaces in the suggestions datalist via the catalog.

## Notes / scope

- Claude's in-ShipCode reasoning policy is unchanged: `xhigh` still resolves to `high` (32k thinking-token budget) for all Claude models including 4.8. A distinct, larger `xhigh` thinking budget for Opus is deliberately deferred to S2 (budget/effort tuning) since it changes runtime cost.
- Broader alias wiring (settings OpenRouter model fields, project/issue model-id overrides) is intentionally out of S1; the reusable `resolveModelAlias()` primitive is exported for S2/S4 to adopt.

## Verification (local, Mac Studio)

- `@shipcode/shared` tests: 410 passed (incl. new catalog + reasoning-effort cases for Opus 4.8 and `resolveModelAlias`).
- `@shipcode/desktop` automations tests: 41 passed.
- Typecheck: `@shipcode/shared` + `@shipcode/desktop` clean (turbo graph build).
- Biome: clean on all 6 touched files.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a new Claude model option and its OpenRouter equivalent.
  * Model selections now accept common shorthand names and normalize them automatically.

* **Bug Fixes**
  * Improved saving and updating automations so model choices are stored in a consistent canonical form.
  * Updated reasoning-effort handling for the new model to match existing adaptive behavior.
  * Refreshed the example model shown in automation settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->