### PR TITLE
feat(automations): multi-repo data model — automation_targets (S3a, #261)

### DIFF
--- a/apps/desktop/src/main/automation-scheduler.cron.test.ts
+++ b/apps/desktop/src/main/automation-scheduler.cron.test.ts
@@ -44,6 +44,7 @@ function makeAutomation(overrides: Partial<Automation> = {}): Automation {
   return {
     id: 'auto-1',
     projectId: 'project-1',
+    targets: ['project-1'],
     name: 'Hourly smoke',
     prompt: 'List 3 files',
     cronExpr: '0 * * * *',

--- a/apps/desktop/src/main/automation-scheduler.test.ts
+++ b/apps/desktop/src/main/automation-scheduler.test.ts
@@ -15,6 +15,7 @@ function makeAutomation(overrides: Partial<Automation> = {}): Automation {
   return {
     id: 'auto-1',
     projectId: 'project-1',
+    targets: ['project-1'],
     name: 'Hourly smoke',
     prompt: 'List 3 files',
     cronExpr: '0 * * * *',

--- a/apps/desktop/src/main/ipc/register-automation-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/register-automation-handlers.test.ts
@@ -16,6 +16,7 @@ function makeAutomation(overrides: Partial<Automation> = {}): Automation {
   return {
     id: 'auto-1',
     projectId: 'project-1',
+    targets: ['project-1'],
     name: 'Nightly cleanup',
     prompt: 'Clean up stale worktrees',
     cronExpr: '0 0 * * *',

--- a/apps/desktop/src/renderer/features/automations/automation-detail.test.tsx
+++ b/apps/desktop/src/renderer/features/automations/automation-detail.test.tsx
@@ -12,6 +12,7 @@ function makeAutomation(overrides: Partial<Automation> = {}): Automation {
   return {
     id: 'auto-1',
     projectId: 'project-1',
+    targets: ['project-1'],
     name: 'Daily smoke',
     prompt:
       '# Automation: Daily smoke\n\n## Goal\nRun the smoke test.\n\n## Verification\n- `bun test` passes',

--- a/apps/desktop/src/renderer/features/automations/automations-view.test.tsx
+++ b/apps/desktop/src/renderer/features/automations/automations-view.test.tsx
@@ -13,6 +13,7 @@ function makeAutomation(overrides: Partial<Automation> = {}): Automation {
   return {
     id: 'auto-1',
     projectId: 'project-1',
+    targets: ['project-1'],
     name: 'Daily smoke',
     prompt: 'List 3 files',
     cronExpr: '0 9 * * *',

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -84,6 +84,7 @@ import {
   migrateV60,
   migrateV61,
   migrateV62,
+  migrateV63,
 } from './schema';
 
 export { ActivityQueries } from './queries/activity';
@@ -211,6 +212,7 @@ export function getDatabase(dataDir: string): DatabaseSync {
   migrateV60(db);
   migrateV61(db);
   migrateV62(db);
+  migrateV63(db);
 
   // Startup cleanup: reset unclaimed queued issues to todo on every launch.
   // An unclaimed queued issue has no active worker holding it — it's stale state

--- a/packages/db/src/migrations/v63-v80.ts
+++ b/packages/db/src/migrations/v63-v80.ts
@@ -1,0 +1,52 @@
+import type { DatabaseSync } from 'node:sqlite';
+import { transaction } from '../utils';
+
+export function migrateV63(db: DatabaseSync): void {
+  const row = db
+    .prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1')
+    .get() as { version: number } | undefined;
+  if (row && row.version >= 63) return;
+
+  transaction(db, () => {
+    // Multi-repo automations: an automation can target more than one project.
+    // automation_targets is the junction (one row per automation×project) and
+    // is the source of truth for fan-out. automations.project_id is retained as
+    // the "primary" target so existing single-project callers keep working;
+    // dropping it would require an FK-aware table rebuild (threads.automation_id
+    // references automations) and is deferred to a later cleanup.
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS automation_targets (
+        id            TEXT PRIMARY KEY,
+        automation_id TEXT NOT NULL REFERENCES automations(id) ON DELETE CASCADE,
+        project_id    TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        created_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        UNIQUE (automation_id, project_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_automation_targets_automation
+        ON automation_targets(automation_id);
+      CREATE INDEX IF NOT EXISTS idx_automation_targets_project
+        ON automation_targets(project_id);
+    `);
+
+    // Backfill exactly one target per existing automation from its current
+    // single project_id. Idempotent via the NOT EXISTS guard so re-running the
+    // migration (or running it on a partially-migrated DB) never duplicates.
+    db.exec(`
+      INSERT INTO automation_targets (id, automation_id, project_id, created_at)
+      SELECT lower(hex(randomblob(10))),
+             id,
+             project_id,
+             COALESCE(created_at, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        FROM automations
+       WHERE project_id IS NOT NULL
+         AND NOT EXISTS (
+           SELECT 1 FROM automation_targets t
+            WHERE t.automation_id = automations.id
+              AND t.project_id = automations.project_id
+         );
+    `);
+
+    db.exec(`INSERT OR REPLACE INTO schema_version (version) VALUES (63)`);
+  });
+}

--- a/packages/db/src/queries/automations.test.ts
+++ b/packages/db/src/queries/automations.test.ts
@@ -324,4 +324,114 @@ describe('AutomationQueries', () => {
     );
     getById.mockRestore();
   });
+
+  it('create backfills a single target equal to the primary project', () => {
+    const { dataDir, automations, project } = setup();
+    tempDirs.push(dataDir);
+
+    const a = automations.create({
+      projectId: project.id,
+      name: 'A',
+      prompt: 'p',
+      cronExpr: '0 * * * *',
+    });
+
+    expect(a.projectId).toBe(project.id);
+    expect(a.targets).toEqual([project.id]);
+    expect(automations.listTargets(a.id)).toEqual([project.id]);
+  });
+
+  it('create with explicit targets stores all and lists under any target', () => {
+    const { dataDir, projects, automations, project } = setup();
+    tempDirs.push(dataDir);
+    const projectB = projects.add(path.join(dataDir, 'project-b'));
+
+    const a = automations.create({
+      projectId: project.id,
+      targets: [project.id, projectB.id, project.id], // duplicate is deduped
+      name: 'Multi',
+      prompt: 'p',
+      cronExpr: '0 * * * *',
+    });
+
+    expect(a.projectId).toBe(project.id);
+    expect(a.targets).toEqual([project.id, projectB.id]);
+    expect(automations.list(project.id).map((x) => x.id)).toContain(a.id);
+    expect(automations.list(projectB.id).map((x) => x.id)).toContain(a.id);
+  });
+
+  it('addTarget and removeTarget mutate the set idempotently', () => {
+    const { dataDir, projects, automations, project } = setup();
+    tempDirs.push(dataDir);
+    const projectB = projects.add(path.join(dataDir, 'project-b'));
+
+    const a = automations.create({
+      projectId: project.id,
+      name: 'A',
+      prompt: 'p',
+      cronExpr: '0 * * * *',
+    });
+
+    automations.addTarget(a.id, projectB.id);
+    automations.addTarget(a.id, projectB.id); // idempotent
+    expect(automations.listTargets(a.id)).toEqual([project.id, projectB.id]);
+
+    automations.removeTarget(a.id, projectB.id);
+    expect(automations.listTargets(a.id)).toEqual([project.id]);
+  });
+
+  it('setTargets replaces the set and realigns the primary projectId', () => {
+    const { dataDir, projects, automations, project } = setup();
+    tempDirs.push(dataDir);
+    const projectB = projects.add(path.join(dataDir, 'project-b'));
+
+    const a = automations.create({
+      projectId: project.id,
+      name: 'A',
+      prompt: 'p',
+      cronExpr: '0 * * * *',
+    });
+
+    automations.setTargets(a.id, [projectB.id, project.id]);
+    const reloaded = automations.getById(a.id);
+    if (!reloaded) throw new Error('Expected automation after setTargets');
+    expect(reloaded.targets).toEqual([projectB.id, project.id]);
+    expect(reloaded.projectId).toBe(projectB.id);
+
+    expect(() => automations.setTargets(a.id, [])).toThrow('at least one target');
+  });
+
+  it('hydrates targets to [projectId] when no target rows exist', () => {
+    const { dataDir, db, automations, project } = setup();
+    tempDirs.push(dataDir);
+
+    const a = automations.create({
+      projectId: project.id,
+      name: 'A',
+      prompt: 'p',
+      cronExpr: '0 * * * *',
+    });
+    db.prepare('DELETE FROM automation_targets WHERE automation_id = ?').run(a.id);
+
+    expect(automations.getById(a.id)?.targets).toEqual([project.id]);
+  });
+
+  it('CASCADE: deleting an automation removes its targets', () => {
+    const { dataDir, db, automations, project } = setup();
+    tempDirs.push(dataDir);
+
+    const a = automations.create({
+      projectId: project.id,
+      name: 'A',
+      prompt: 'p',
+      cronExpr: '0 * * * *',
+    });
+    expect(automations.listTargets(a.id)).toHaveLength(1);
+
+    automations.delete(a.id);
+    const remaining = db
+      .prepare('SELECT COUNT(*) AS n FROM automation_targets WHERE automation_id = ?')
+      .get(a.id) as { n: number };
+    expect(remaining.n).toBe(0);
+  });
 });

--- a/packages/db/src/queries/automations.ts
+++ b/packages/db/src/queries/automations.ts
@@ -9,7 +9,7 @@ import {
   type UpdateAutomationInput,
 } from '@shipcode/shared';
 import { nanoid } from 'nanoid';
-import { asRow, asRows } from '../utils';
+import { asRow, asRows, transaction } from '../utils';
 
 interface AutomationRow {
   id: string;
@@ -30,10 +30,11 @@ interface AutomationRow {
   updated_at: string;
 }
 
-function mapAutomation(row: AutomationRow): Automation {
+function mapAutomation(row: AutomationRow, targets: string[]): Automation {
   return {
     id: row.id,
     projectId: row.project_id,
+    targets: targets.length > 0 ? targets : [row.project_id],
     name: row.name,
     prompt: row.prompt,
     cronExpr: row.cron_expr,
@@ -54,23 +55,43 @@ function mapAutomation(row: AutomationRow): Automation {
 export class AutomationQueries {
   constructor(private db: DatabaseSync) {}
 
-  list(projectId: string): Automation[] {
+  /** Target project ids for an automation, oldest first (primary first). */
+  listTargets(automationId: string): string[] {
     const rows = this.db
-      .prepare('SELECT * FROM automations WHERE project_id = ? ORDER BY created_at DESC')
+      .prepare(
+        'SELECT project_id FROM automation_targets WHERE automation_id = ? ORDER BY created_at ASC',
+      )
+      .all(automationId);
+    return asRows<{ project_id: string }>(rows).map((r) => r.project_id);
+  }
+
+  private hydrate(row: AutomationRow): Automation {
+    return mapAutomation(row, this.listTargets(row.id));
+  }
+
+  list(projectId: string): Automation[] {
+    // Automations that target this project (multi-repo aware), newest first.
+    const rows = this.db
+      .prepare(
+        `SELECT a.* FROM automations a
+            JOIN automation_targets t ON t.automation_id = a.id
+           WHERE t.project_id = ?
+           ORDER BY a.created_at DESC`,
+      )
       .all(projectId);
-    return asRows<AutomationRow>(rows).map(mapAutomation);
+    return asRows<AutomationRow>(rows).map((row) => this.hydrate(row));
   }
 
   listAll(): Automation[] {
     const rows = this.db.prepare('SELECT * FROM automations ORDER BY created_at DESC').all();
-    return asRows<AutomationRow>(rows).map(mapAutomation);
+    return asRows<AutomationRow>(rows).map((row) => this.hydrate(row));
   }
 
   listEnabled(): Automation[] {
     const rows = this.db
       .prepare('SELECT * FROM automations WHERE enabled = 1 ORDER BY created_at DESC')
       .all();
-    return asRows<AutomationRow>(rows).map(mapAutomation);
+    return asRows<AutomationRow>(rows).map((row) => this.hydrate(row));
   }
 
   /**
@@ -84,38 +105,91 @@ export class AutomationQueries {
         'SELECT * FROM automations WHERE enabled = 1 AND next_run_at IS NOT NULL AND next_run_at <= ?',
       )
       .all(nowIso);
-    return asRows<AutomationRow>(rows).map(mapAutomation);
+    return asRows<AutomationRow>(rows).map((row) => this.hydrate(row));
   }
 
   getById(id: string): Automation | null {
     const row = this.db.prepare('SELECT * FROM automations WHERE id = ?').get(id);
-    return row ? mapAutomation(asRow<AutomationRow>(row)) : null;
+    return row ? this.hydrate(asRow<AutomationRow>(row)) : null;
   }
 
   create(input: CreateAutomationInput): Automation {
     const id = nanoid();
-    this.db
-      .prepare(
-        `INSERT INTO automations (
-           id, project_id, name, prompt, cron_expr, enabled,
-           executor_provider, executor_model_id, executor_reasoning_effort,
-           run_count, created_at, updated_at
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ${ISO_NOW_SQL}, ${ISO_NOW_SQL})`,
-      )
-      .run(
-        id,
-        input.projectId,
-        input.name,
-        input.prompt,
-        input.cronExpr,
-        input.enabled === false ? 0 : 1,
-        input.executorProvider ?? null,
-        input.executorModelId ?? null,
-        input.executorReasoningEffort ?? null,
+    // Dedupe while preserving order; the first target becomes the primary
+    // project_id so single-project callers keep working unchanged.
+    const targets = [...new Set(input.targets?.length ? input.targets : [input.projectId])];
+    const primary = targets[0] ?? input.projectId;
+
+    transaction(this.db, () => {
+      this.db
+        .prepare(
+          `INSERT INTO automations (
+             id, project_id, name, prompt, cron_expr, enabled,
+             executor_provider, executor_model_id, executor_reasoning_effort,
+             run_count, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ${ISO_NOW_SQL}, ${ISO_NOW_SQL})`,
+        )
+        .run(
+          id,
+          primary,
+          input.name,
+          input.prompt,
+          input.cronExpr,
+          input.enabled === false ? 0 : 1,
+          input.executorProvider ?? null,
+          input.executorModelId ?? null,
+          input.executorReasoningEffort ?? null,
+        );
+
+      const insertTarget = this.db.prepare(
+        `INSERT OR IGNORE INTO automation_targets (id, automation_id, project_id, created_at)
+         VALUES (?, ?, ?, ${ISO_NOW_SQL})`,
       );
+      for (const projectId of targets) {
+        insertTarget.run(nanoid(), id, projectId);
+      }
+    });
+
     const automation = this.getById(id);
     if (!automation) throw new Error(`Failed to create automation ${id}`);
     return automation;
+  }
+
+  /** Add a target project (idempotent on the automation×project pair). */
+  addTarget(automationId: string, projectId: string): void {
+    this.db
+      .prepare(
+        `INSERT OR IGNORE INTO automation_targets (id, automation_id, project_id, created_at)
+         VALUES (?, ?, ?, ${ISO_NOW_SQL})`,
+      )
+      .run(nanoid(), automationId, projectId);
+  }
+
+  /** Remove a target project. */
+  removeTarget(automationId: string, projectId: string): void {
+    this.db
+      .prepare('DELETE FROM automation_targets WHERE automation_id = ? AND project_id = ?')
+      .run(automationId, projectId);
+  }
+
+  /** Replace the full target set, keeping `project_id` aligned to the first. */
+  setTargets(automationId: string, projectIds: string[]): void {
+    const targets = [...new Set(projectIds)];
+    if (targets.length === 0) throw new Error('An automation must have at least one target');
+
+    transaction(this.db, () => {
+      this.db.prepare('DELETE FROM automation_targets WHERE automation_id = ?').run(automationId);
+      const insertTarget = this.db.prepare(
+        `INSERT OR IGNORE INTO automation_targets (id, automation_id, project_id, created_at)
+         VALUES (?, ?, ?, ${ISO_NOW_SQL})`,
+      );
+      for (const projectId of targets) {
+        insertTarget.run(nanoid(), automationId, projectId);
+      }
+      this.db
+        .prepare(`UPDATE automations SET project_id = ?, updated_at = ${ISO_NOW_SQL} WHERE id = ?`)
+        .run(targets[0], automationId);
+    });
   }
 
   update(id: string, patch: UpdateAutomationInput): Automation {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -66,3 +66,4 @@ export {
   migrateV61,
   migrateV62,
 } from './migrations/v41-v62';
+export { migrateV63 } from './migrations/v63-v80';

--- a/packages/db/src/test-helpers.ts
+++ b/packages/db/src/test-helpers.ts
@@ -62,6 +62,7 @@ import {
   migrateV60,
   migrateV61,
   migrateV62,
+  migrateV63,
 } from './schema';
 
 export function createTestDb(): DatabaseSync {
@@ -128,5 +129,6 @@ export function createTestDb(): DatabaseSync {
   migrateV60(db);
   migrateV61(db);
   migrateV62(db);
+  migrateV63(db);
   return db;
 }

--- a/packages/shared/src/types/project.ts
+++ b/packages/shared/src/types/project.ts
@@ -65,7 +65,10 @@ export type AutomationLastStatus = 'running' | 'completed' | 'failed';
 
 export interface Automation {
   id: string;
+  /** Primary target project. Retained for back-compat; equals `targets[0]`. */
   projectId: string;
+  /** All target projects this automation fans out to (includes the primary). */
+  targets: string[];
   name: string;
   prompt: string;
   cronExpr: string;
@@ -83,7 +86,10 @@ export interface Automation {
 }
 
 export interface CreateAutomationInput {
+  /** Primary target project. Used as `targets[0]` when `targets` is omitted. */
   projectId: string;
+  /** Optional full target set. Defaults to `[projectId]` when omitted. */
+  targets?: string[];
   name: string;
   prompt: string;
   cronExpr: string;


### PR DESCRIPTION
Part of #261 (epic #258). Independent of #264/#265 — branches off `master`.

## What

The data-model foundation for multi-repo automations. An automation can now hold multiple target projects via a junction table. The **runtime fan-out** across those targets (one cron fire → N per-target runs, each its own worktree) follows in **S3b** — this PR is deliberately runtime-neutral and safe to merge on its own.

## Why split S3a / S3b

S3 touches a SQLite migration *and* concurrency-critical scheduler code. Splitting keeps each PR independently reviewable and low-risk: S3a is additive schema + queries (no behavior change), S3b is the scheduler/pipeline fan-out.

## Changes

- **migrateV63** (`packages/db/src/migrations/v63-v80.ts`) — new `automation_targets(automation_id, project_id)` junction table, cascade FKs + indexes, `UNIQUE(automation_id, project_id)`. Backfills exactly one target per existing automation from its current `project_id` (idempotent via `NOT EXISTS`). Wired into the startup runner and `createTestDb`.
- **`automations.project_id` kept** as the "primary" target. Dropping it would require an FK-aware table rebuild (`threads.automation_id` references `automations`) — real boot-risk for cosmetic gain, so deferred. `project_id` always equals `targets[0]`.
- **Types** (`packages/shared/src/types/project.ts`): `Automation.targets: string[]` (includes the primary); `CreateAutomationInput.targets?: string[]` (optional, defaults to `[projectId]`).
- **`AutomationQueries`**: `listTargets` / `addTarget` / `removeTarget` / `setTargets`; `create()` inserts target rows atomically (deduped); `list(projectId)` now matches **any** target via a join (multi-repo aware); all reads hydrate `targets` with a defensive `[projectId]` fallback.

## Runtime unchanged

The scheduler and pipeline still resolve a single project per fire in this PR. No fan-out yet. Existing single-project automations are identical in behavior (backfilled to exactly one target).

## Verification (local, Mac Studio)

- `@shipcode/db`: 505 passed (new tests: backfill-to-single-target, explicit multi-target create, `listTargets`, add/remove, `setTargets` realigns primary, fallback hydration, target cascade).
- `@shipcode/desktop` automations + scheduler + handler suites: 59 passed.
- Typecheck: `@shipcode/db` + `@shipcode/pipeline` + `@shipcode/desktop` clean.
- Biome: clean.
