### PR TITLE
feat(automations): cron fire fans out across target repos (S3b, #261)

### DIFF
--- a/apps/desktop/src/main/automation-scheduler.cron.test.ts
+++ b/apps/desktop/src/main/automation-scheduler.cron.test.ts
@@ -74,6 +74,7 @@ describe('AutomationScheduler cron callback coverage', () => {
       listEnabled: vi.fn(() => [] as Automation[]),
       listDue: vi.fn(() => [makeAutomation({ id: 'overdue' })]),
       setNextRunAt: vi.fn(),
+      getById: vi.fn((id: string) => makeAutomation({ id })),
     };
     const pipelineScheduler = {
       startOrQueueAutomation: vi.fn(async () => {
@@ -93,7 +94,7 @@ describe('AutomationScheduler cron callback coverage', () => {
     await Promise.resolve();
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(pipelineScheduler.startOrQueueAutomation).toHaveBeenCalledWith('auto-1');
+    expect(pipelineScheduler.startOrQueueAutomation).toHaveBeenCalledWith('auto-1', 'project-1');
     expect(loggerMock.error).toHaveBeenCalledWith(
       '[automation:auto-1] fire failed:',
       expect.any(Error),

--- a/apps/desktop/src/main/automation-scheduler.test.ts
+++ b/apps/desktop/src/main/automation-scheduler.test.ts
@@ -39,6 +39,7 @@ describe('AutomationScheduler', () => {
     listEnabled: ReturnType<typeof vi.fn>;
     listDue: ReturnType<typeof vi.fn>;
     setNextRunAt: ReturnType<typeof vi.fn>;
+    getById: ReturnType<typeof vi.fn>;
   };
   let pipelineScheduler: {
     startOrQueueAutomation: ReturnType<typeof vi.fn>;
@@ -50,6 +51,7 @@ describe('AutomationScheduler', () => {
       listEnabled: vi.fn(() => [] as Automation[]),
       listDue: vi.fn(() => [] as Automation[]),
       setNextRunAt: vi.fn(),
+      getById: vi.fn((id: string) => makeAutomation({ id })),
     };
     pipelineScheduler = {
       startOrQueueAutomation: vi.fn(async () => ({ queued: false })),
@@ -127,7 +129,7 @@ describe('AutomationScheduler', () => {
     const result = await scheduler.fireNow('auto-1');
 
     expect(result).toEqual({ queued: false });
-    expect(pipelineScheduler.startOrQueueAutomation).toHaveBeenCalledWith('auto-1');
+    expect(pipelineScheduler.startOrQueueAutomation).toHaveBeenCalledWith('auto-1', 'project-1');
     expect(queries.setNextRunAt).toHaveBeenCalledWith('auto-1', null);
   });
 
@@ -173,5 +175,45 @@ describe('AutomationScheduler', () => {
     scheduler.schedule(makeAutomation({ id: 'b' }));
     scheduler.stop();
     expect(() => scheduler.unschedule('a')).not.toThrow();
+  });
+
+  it('fans out one dispatch per target project', async () => {
+    queries.getById.mockReturnValue(makeAutomation({ id: 'multi', targets: ['p1', 'p2', 'p3'] }));
+
+    await scheduler.fireNow('multi');
+
+    expect(pipelineScheduler.startOrQueueAutomation).toHaveBeenCalledTimes(3);
+    expect(pipelineScheduler.startOrQueueAutomation).toHaveBeenCalledWith('multi', 'p1');
+    expect(pipelineScheduler.startOrQueueAutomation).toHaveBeenCalledWith('multi', 'p2');
+    expect(pipelineScheduler.startOrQueueAutomation).toHaveBeenCalledWith('multi', 'p3');
+  });
+
+  it('per-target guard: a second fire only dispatches not-yet-running targets', async () => {
+    queries.getById.mockReturnValue(makeAutomation({ id: 'multi', targets: ['p1', 'p2'] }));
+    const resolvers: Array<() => void> = [];
+    pipelineScheduler.startOrQueueAutomation.mockImplementation(
+      () =>
+        new Promise<{ queued: boolean }>((resolve) =>
+          resolvers.push(() => resolve({ queued: false })),
+        ),
+    );
+
+    const first = scheduler.fireNow('multi'); // dispatches p1, p2 (pending)
+    const second = scheduler.fireNow('multi'); // both in-flight → no new dispatch
+
+    expect(pipelineScheduler.startOrQueueAutomation).toHaveBeenCalledTimes(2);
+    await expect(second).resolves.toEqual({ queued: false });
+    for (const r of resolvers) r();
+    await first;
+  });
+
+  it('skips a disabled automation without dispatching', async () => {
+    queries.getById.mockReturnValue(makeAutomation({ id: 'off', enabled: false }));
+
+    const result = await scheduler.fireNow('off');
+
+    expect(result).toEqual({ queued: false });
+    expect(pipelineScheduler.startOrQueueAutomation).not.toHaveBeenCalled();
+    expect(queries.setNextRunAt).toHaveBeenCalledWith('off', null);
   });
 });

--- a/apps/desktop/src/main/automation-scheduler.ts
+++ b/apps/desktop/src/main/automation-scheduler.ts
@@ -29,7 +29,10 @@ export interface AutomationSchedulerDeps {
  */
 export class AutomationScheduler implements AutomationSchedulerLike {
   private jobs = new Map<string, Cron>();
-  private inFlight = new Map<string, Promise<{ queued: boolean }>>();
+  // automationId -> (targetProjectId -> in-flight dispatch). Keyed per target so
+  // a multi-repo automation can dispatch each repo independently while still
+  // guarding against double-firing the same (automation, target) pair.
+  private inFlight = new Map<string, Map<string, Promise<{ queued: boolean }>>>();
 
   constructor(private readonly deps: AutomationSchedulerDeps) {}
 
@@ -96,18 +99,44 @@ export class AutomationScheduler implements AutomationSchedulerLike {
     this.jobs.clear();
   }
 
+  private _advanceNextRun(automationId: string): void {
+    const job = this.jobs.get(automationId);
+    const next = job?.nextRun() ?? null;
+    this.deps.automations.setNextRunAt(automationId, next ? next.toISOString() : null);
+  }
+
   private _fire(automationId: string): Promise<{ queued: boolean }> {
-    const existing = this.inFlight.get(automationId);
-    if (existing) return existing;
+    const automation = this.deps.automations.getById(automationId);
+    if (!automation?.enabled) {
+      this._advanceNextRun(automationId);
+      return Promise.resolve({ queued: false });
+    }
 
-    const promise = this.deps.pipelineScheduler.startOrQueueAutomation(automationId).finally(() => {
-      this.inFlight.delete(automationId);
-      const job = this.jobs.get(automationId);
-      const next = job?.nextRun() ?? null;
-      this.deps.automations.setNextRunAt(automationId, next ? next.toISOString() : null);
-    });
+    const targets = automation.targets.length > 0 ? automation.targets : [automation.projectId];
+    const inner =
+      this.inFlight.get(automationId) ?? new Map<string, Promise<{ queued: boolean }>>();
+    this.inFlight.set(automationId, inner);
 
-    this.inFlight.set(automationId, promise);
-    return promise;
+    const dispatched: Array<Promise<{ queued: boolean }>> = [];
+    for (const projectId of targets) {
+      if (inner.has(projectId)) continue; // per-target in-flight guard
+      const promise = this.deps.pipelineScheduler
+        .startOrQueueAutomation(automationId, projectId)
+        .finally(() => {
+          inner.delete(projectId);
+          if (inner.size === 0) this.inFlight.delete(automationId);
+        });
+      inner.set(projectId, promise);
+      dispatched.push(promise);
+    }
+
+    // Advance the cron cursor once targets are dispatched (not awaited), so the
+    // missed-tick skip logic at startup sees the next future occurrence.
+    this._advanceNextRun(automationId);
+
+    if (dispatched.length === 0) return Promise.resolve({ queued: false });
+    return Promise.all(dispatched).then((results) => ({
+      queued: results.every((r) => r.queued),
+    }));
   }
 }

--- a/apps/desktop/src/main/pipeline-scheduler.test.ts
+++ b/apps/desktop/src/main/pipeline-scheduler.test.ts
@@ -648,6 +648,7 @@ describe('PipelineScheduler', () => {
     const automation = {
       id: 'auto-1',
       projectId: 'project-1',
+      targets: ['project-1'],
       name: 'Hourly smoke',
       prompt: 'List 3 files',
       cronExpr: '0 * * * *',
@@ -733,7 +734,7 @@ describe('PipelineScheduler', () => {
       queries.settings.get.mockReturnValue(makeBaseSettings({ maxConcurrentPipelines: 1 }));
       queries.automations.getById.mockReturnValue(automation);
 
-      await scheduler.startOrQueueAutomation('auto-1');
+      await scheduler.startOrQueueAutomation('auto-1', 'project-1');
 
       pipeline.listActiveInPhases.mockReturnValue([]);
       queries.githubIssues.getNextQueued.mockReturnValue(makeIssue());
@@ -756,7 +757,7 @@ describe('PipelineScheduler', () => {
       queries.settings.get.mockReturnValue(makeBaseSettings({ maxConcurrentPipelines: 1 }));
       queries.automations.getById.mockReturnValue(null);
 
-      await scheduler.startOrQueueAutomation('missing-auto');
+      await scheduler.startOrQueueAutomation('missing-auto', 'project-1');
 
       pipeline.listActiveInPhases.mockReturnValue([]);
       scheduler.onSlotFreed();
@@ -806,7 +807,7 @@ describe('PipelineScheduler', () => {
       queries.settings.get.mockReturnValue(makeBaseSettings({ maxConcurrentPipelines: 1 }));
       queries.automations.getById.mockReturnValue(automation);
 
-      await scheduler.startOrQueueAutomation('auto-1');
+      await scheduler.startOrQueueAutomation('auto-1', 'project-1');
       scheduler.onSlotFreed();
 
       expect(pipeline.startFromAutomation).not.toHaveBeenCalled();
@@ -826,7 +827,7 @@ describe('PipelineScheduler', () => {
       queries.automations.getById.mockReturnValue(automation);
       pipeline.startFromAutomation.mockRejectedValueOnce(new Error('automation failed'));
 
-      await scheduler.startOrQueueAutomation('auto-1');
+      await scheduler.startOrQueueAutomation('auto-1', 'project-1');
 
       pipeline.listActiveInPhases.mockReturnValue([]);
       scheduler.onSlotFreed();
@@ -1204,6 +1205,7 @@ describe('PipelineScheduler', () => {
     const automation = {
       id: 'auto-1',
       projectId: 'project-1',
+      targets: ['project-1'],
       name: 'Hourly smoke',
       prompt: 'List 3 files',
       cronExpr: '0 * * * *',
@@ -1224,7 +1226,7 @@ describe('PipelineScheduler', () => {
       pipeline.listActiveInPhases.mockReturnValue([]);
       queries.automations.getById.mockReturnValue(automation);
 
-      const result = await scheduler.startOrQueueAutomation('auto-1');
+      const result = await scheduler.startOrQueueAutomation('auto-1', 'project-1');
 
       expect(result.queued).toBe(false);
       expect(pipeline.startFromAutomation).toHaveBeenCalledWith(
@@ -1245,7 +1247,7 @@ describe('PipelineScheduler', () => {
       queries.settings.get.mockReturnValue(makeBaseSettings({ maxConcurrentPipelines: 3 }));
       queries.automations.getById.mockReturnValue(automation);
 
-      const result = await scheduler.startOrQueueAutomation('auto-1');
+      const result = await scheduler.startOrQueueAutomation('auto-1', 'project-1');
 
       expect(result.queued).toBe(true);
       expect(pipeline.startFromAutomation).not.toHaveBeenCalled();
@@ -1262,8 +1264,8 @@ describe('PipelineScheduler', () => {
       queries.automations.getById.mockReturnValue(automation);
 
       const [r1, r2] = await Promise.all([
-        scheduler.startOrQueueAutomation('auto-1'),
-        scheduler.startOrQueueAutomation('auto-1'),
+        scheduler.startOrQueueAutomation('auto-1', 'project-1'),
+        scheduler.startOrQueueAutomation('auto-1', 'project-1'),
       ]);
 
       expect(r1.queued).toBe(true);
@@ -1274,7 +1276,7 @@ describe('PipelineScheduler', () => {
       queries.automations.getById.mockReturnValue(automation);
       queries.threads.hasActiveForAutomation.mockReturnValue(true);
 
-      const result = await scheduler.startOrQueueAutomation('auto-1');
+      const result = await scheduler.startOrQueueAutomation('auto-1', 'project-1');
 
       expect(result.queued).toBe(false);
       expect(pipeline.startFromAutomation).not.toHaveBeenCalled();
@@ -1282,12 +1284,12 @@ describe('PipelineScheduler', () => {
 
     it('returns without launching when the automation is missing or disabled', async () => {
       queries.automations.getById.mockReturnValueOnce(null);
-      await expect(scheduler.startOrQueueAutomation('missing-auto')).resolves.toEqual({
+      await expect(scheduler.startOrQueueAutomation('missing-auto', 'project-1')).resolves.toEqual({
         queued: false,
       });
 
       queries.automations.getById.mockReturnValueOnce({ ...automation, enabled: false });
-      await expect(scheduler.startOrQueueAutomation('auto-1')).resolves.toEqual({
+      await expect(scheduler.startOrQueueAutomation('auto-1', 'project-1')).resolves.toEqual({
         queued: false,
       });
 
@@ -1297,7 +1299,7 @@ describe('PipelineScheduler', () => {
     it('skips disabled automations after dispatch capacity is available', async () => {
       queries.automations.getById.mockReturnValue({ ...automation, enabled: false });
 
-      const result = await scheduler.startOrQueueAutomation('auto-1');
+      const result = await scheduler.startOrQueueAutomation('auto-1', 'project-1');
 
       expect(result.queued).toBe(false);
       expect(pipeline.startFromAutomation).not.toHaveBeenCalled();
@@ -1308,7 +1310,7 @@ describe('PipelineScheduler', () => {
       queries.automations.getById.mockReturnValue(automation);
       queries.projects.getById.mockReturnValue(null);
 
-      await scheduler.startOrQueueAutomation('auto-1');
+      await scheduler.startOrQueueAutomation('auto-1', 'project-1');
 
       expect(queries.automations.recordRunFinished).toHaveBeenCalledWith('auto-1', 'failed');
 
@@ -1316,7 +1318,7 @@ describe('PipelineScheduler', () => {
       queries.projects.getById.mockReturnValue(makeProject());
       vi.mocked(fs.existsSync).mockReturnValueOnce(false);
 
-      await scheduler.startOrQueueAutomation('auto-1');
+      await scheduler.startOrQueueAutomation('auto-1', 'project-1');
 
       expect(queries.automations.recordRunFinished).toHaveBeenCalledWith('auto-1', 'failed');
       expect(pipeline.startFromAutomation).not.toHaveBeenCalled();
@@ -1326,7 +1328,7 @@ describe('PipelineScheduler', () => {
       queries.automations.getById.mockReturnValue(automation);
       vi.mocked(assertCliPhaseModelsSupported).mockRejectedValueOnce(new Error('unsupported'));
 
-      await scheduler.startOrQueueAutomation('auto-1');
+      await scheduler.startOrQueueAutomation('auto-1', 'project-1');
 
       expect(queries.automations.recordRunFinished).toHaveBeenCalledWith('auto-1', 'failed');
       expect(pipeline.startFromAutomation).not.toHaveBeenCalled();
@@ -1336,7 +1338,7 @@ describe('PipelineScheduler', () => {
       queries.automations.getById.mockReturnValue(automation);
       pipeline.startFromAutomation.mockRejectedValueOnce(new Error('automation dispatch failed'));
 
-      await expect(scheduler.startOrQueueAutomation('auto-1')).rejects.toThrow(
+      await expect(scheduler.startOrQueueAutomation('auto-1', 'project-1')).rejects.toThrow(
         'automation dispatch failed',
       );
 

--- a/apps/desktop/src/main/pipeline-scheduler.ts
+++ b/apps/desktop/src/main/pipeline-scheduler.ts
@@ -63,12 +63,13 @@ const REUSABLE_THREAD_STATUSES = new Set<PipelinePhase>([
  */
 export class PipelineScheduler {
   /**
-   * In-memory FIFO queue for automations that fired while all pipeline
-   * slots were occupied. Drained one at a time by `onSlotFreed`.
-   * Lost on app restart by design — automation cron resumes from
-   * `next_run_at` so a missed tick is simply skipped.
+   * In-memory FIFO queue for automation targets that fired while all pipeline
+   * slots were occupied. Each entry is one (automation, target project) pair,
+   * so a multi-repo automation queues per target independently. Drained one at
+   * a time by `onSlotFreed`. Lost on app restart by design — automation cron
+   * resumes from `next_run_at` so a missed tick is simply skipped.
    */
-  private pendingAutomations: string[] = [];
+  private pendingAutomations: Array<{ automationId: string; projectId: string }> = [];
 
   constructor(private readonly deps: PipelineSchedulerDeps) {}
 
@@ -200,20 +201,21 @@ export class PipelineScheduler {
       // Drain one pending automation before queued issues — automations
       // already fired their cron tick and should not wait behind issues
       // that can simply re-queue.
-      const pendingAutomationId = this.pendingAutomations.shift();
-      if (pendingAutomationId) {
-        const automation = queries.automations.getById(pendingAutomationId);
-        const project = automation ? queries.projects.getById(automation.projectId) : null;
+      const pending = this.pendingAutomations.shift();
+      if (pending) {
+        const project = queries.projects.getById(pending.projectId);
         if (
           project &&
           (activeCount >= this._getProjectPipelineCap(project.path) ||
             !this._isPerStateSlotAvailable(project.path, PIPELINE_PHASE.planning))
         ) {
-          this.pendingAutomations.unshift(pendingAutomationId);
+          this.pendingAutomations.unshift(pending);
           return;
         }
-        log.info(`[scheduler] auto-promoting automation ${pendingAutomationId}`);
-        this._launchAutomation(pendingAutomationId).catch((err) => {
+        log.info(
+          `[scheduler] auto-promoting automation ${pending.automationId} → project ${pending.projectId}`,
+        );
+        this._launchAutomation(pending.automationId, pending.projectId).catch((err) => {
           log.error('[scheduler] automation promote failed:', err);
         });
         return;
@@ -241,16 +243,22 @@ export class PipelineScheduler {
   }
 
   /**
-   * Cron-driven entry: tries to launch an automation now or queues it
-   * in-memory if pipeline slots are full. Called by AutomationScheduler.
+   * Cron-driven entry: tries to launch one automation target now or queues it
+   * in-memory if pipeline slots are full. Called per target by
+   * AutomationScheduler so a multi-repo automation fans out across repos.
    */
-  async startOrQueueAutomation(automationId: string): Promise<{ queued: boolean }> {
+  async startOrQueueAutomation(
+    automationId: string,
+    targetProjectId: string,
+  ): Promise<{ queued: boolean }> {
     const { queries } = this.deps;
-    const automation = queries.automations.getById(automationId);
-    const project = automation ? queries.projects.getById(automation.projectId) : null;
+    const project = queries.projects.getById(targetProjectId);
 
-    if (queries.threads.hasActiveForAutomation(automationId)) {
-      log.info(`[scheduler] skipping automation ${automationId} — already has an active pipeline`);
+    // Per-target guard: this automation can still run a different target repo.
+    if (queries.threads.hasActiveForAutomation(automationId, targetProjectId)) {
+      log.info(
+        `[scheduler] skipping automation ${automationId} → ${targetProjectId} — target already active`,
+      );
       return { queued: false };
     }
 
@@ -265,16 +273,19 @@ export class PipelineScheduler {
       : false;
 
     if (activeCount >= pipelineCap || perStateBlocked) {
-      if (!this.pendingAutomations.includes(automationId)) {
-        this.pendingAutomations.push(automationId);
+      const alreadyQueued = this.pendingAutomations.some(
+        (p) => p.automationId === automationId && p.projectId === targetProjectId,
+      );
+      if (!alreadyQueued) {
+        this.pendingAutomations.push({ automationId, projectId: targetProjectId });
       }
       log.info(
-        `[scheduler] queued automation ${automationId} (${activeCount}/${pipelineCap} slots used)`,
+        `[scheduler] queued automation ${automationId} → ${targetProjectId} (${activeCount}/${pipelineCap} slots used)`,
       );
       return { queued: true };
     }
 
-    await this._launchAutomation(automationId);
+    await this._launchAutomation(automationId, targetProjectId);
     return { queued: false };
   }
 
@@ -515,7 +526,7 @@ export class PipelineScheduler {
     }
   }
 
-  private async _launchAutomation(automationId: string): Promise<void> {
+  private async _launchAutomation(automationId: string, targetProjectId: string): Promise<void> {
     const { queries, pipeline, emitter, getMainWindow } = this.deps;
 
     const automation = queries.automations.getById(automationId);
@@ -528,9 +539,9 @@ export class PipelineScheduler {
       return;
     }
 
-    const project = queries.projects.getById(automation.projectId);
+    const project = queries.projects.getById(targetProjectId);
     if (!project) {
-      log.warn(`[automation] project ${automation.projectId} not found`);
+      log.warn(`[automation] target project ${targetProjectId} not found`);
       queries.automations.recordRunFinished(automation.id, 'failed');
       return;
     }
@@ -562,11 +573,13 @@ export class PipelineScheduler {
       return;
     }
 
-    const thread = queries.threads.create(
-      project.id,
-      automation.prompt,
-      `[Auto] ${automation.name}`,
-    );
+    // Distinguish sibling runs of a multi-repo automation by target repo.
+    const projectLabel = project.path.split(/[\\/]/).filter(Boolean).pop() ?? project.path;
+    const title =
+      automation.targets.length > 1
+        ? `[Auto] ${automation.name} — ${projectLabel}`
+        : `[Auto] ${automation.name}`;
+    const thread = queries.threads.create(project.id, automation.prompt, title);
     queries.threads.setAutomationId(thread.id, automation.id);
     queries.threads.setPhaseModels(thread.id, mergedPhaseModels);
 

--- a/packages/db/src/queries/threads.ts
+++ b/packages/db/src/queries/threads.ts
@@ -84,7 +84,17 @@ export class ThreadQueries {
     return asRows<ThreadRow>(rows).map(mapThread);
   }
 
-  hasActiveForAutomation(automationId: string): boolean {
+  hasActiveForAutomation(automationId: string, projectId?: string): boolean {
+    // When projectId is given, the guard is scoped to one target repo so a
+    // multi-repo automation can run a different target concurrently.
+    if (projectId !== undefined) {
+      const row = this.db
+        .prepare(
+          "SELECT 1 FROM threads WHERE automation_id = ? AND project_id = ? AND status NOT IN ('idle', 'completed', 'failed') LIMIT 1",
+        )
+        .get(automationId, projectId);
+      return !!row;
+    }
     const row = this.db
       .prepare(
         "SELECT 1 FROM threads WHERE automation_id = ? AND status NOT IN ('idle', 'completed', 'failed') LIMIT 1",


### PR DESCRIPTION
Closes #261 (the S3 fan-out). Part of epic #258. Stacked on #266 (S3a) — base retargets to master once S3a lands.

## What
A single automation cron fire now dispatches **one pipeline run per target project**, each in its own thread + isolated worktree.

- `AutomationScheduler._fire` reads `automation.targets` and dispatches one `startOrQueueAutomation` per target. **In-flight guard is per (automation, target)** — one running repo never blocks the others. Cron cursor advances once all targets are dispatched.
- `PipelineScheduler.startOrQueueAutomation(automationId, targetProjectId)`: resolves the target project, guards + caps per target, queues the (automation, target) **pair** when full. `_launchAutomation` runs against the target; multi-repo runs get a `— <repo>` title suffix. `pendingAutomations` is now a pair queue; `onSlotFreed` drains pairs.
- `threads.hasActiveForAutomation(automationId, projectId?)` — optional per-project scope for the per-target guard.
- Worktree isolation is free: each target has a distinct `projectSlug`, so runs land in separate dirs.

## Verification (local)
- `@shipcode/db`: threads + automations 57 passed (per-project guard).
- `@shipcode/desktop`: scheduler + pipeline-scheduler 68 passed — incl. new fan-out (one dispatch per target), per-target guard (second fire skips in-flight targets), disabled-skip.
- Typecheck db + pipeline + desktop clean. Biome clean.

## Behavior
Single-target automations are unchanged (one target, one run). Multi-repo only activates once an automation has >1 target (UI to add targets lands in S4).