### PR TITLE
feat(automations): multi-repo target picker in create UI (S4, #262)

### DIFF
--- a/apps/desktop/src/main/automation-scheduler.cron.test.ts
+++ b/apps/desktop/src/main/automation-scheduler.cron.test.ts
@@ -44,6 +44,7 @@ function makeAutomation(overrides: Partial<Automation> = {}): Automation {
   return {
     id: 'auto-1',
     projectId: 'project-1',
+    targets: ['project-1'],
     name: 'Hourly smoke',
     prompt: 'List 3 files',
     cronExpr: '0 * * * *',

--- a/apps/desktop/src/main/automation-scheduler.cron.test.ts
+++ b/apps/desktop/src/main/automation-scheduler.cron.test.ts
@@ -74,6 +74,7 @@ describe('AutomationScheduler cron callback coverage', () => {
       listEnabled: vi.fn(() => [] as Automation[]),
       listDue: vi.fn(() => [makeAutomation({ id: 'overdue' })]),
       setNextRunAt: vi.fn(),
+      getById: vi.fn((id: string) => makeAutomation({ id })),
     };
     const pipelineScheduler = {
       startOrQueueAutomation: vi.fn(async () => {
@@ -93,7 +94,7 @@ describe('AutomationScheduler cron callback coverage', () => {
     await Promise.resolve();
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(pipelineScheduler.startOrQueueAutomation).toHaveBeenCalledWith('auto-1');
+    expect(pipelineScheduler.startOrQueueAutomation).toHaveBeenCalledWith('auto-1', 'project-1');
     expect(loggerMock.error).toHaveBeenCalledWith(
       '[automation:auto-1] fire failed:',
       expect.any(Error),

--- a/apps/desktop/src/main/automation-scheduler.test.ts
+++ b/apps/desktop/src/main/automation-scheduler.test.ts
@@ -15,6 +15,7 @@ function makeAutomation(overrides: Partial<Automation> = {}): Automation {
   return {
     id: 'auto-1',
     projectId: 'project-1',
+    targets: ['project-1'],
     name: 'Hourly smoke',
     prompt: 'List 3 files',
     cronExpr: '0 * * * *',

--- a/apps/desktop/src/main/automation-scheduler.test.ts
+++ b/apps/desktop/src/main/automation-scheduler.test.ts
@@ -39,6 +39,7 @@ describe('AutomationScheduler', () => {
     listEnabled: ReturnType<typeof vi.fn>;
     listDue: ReturnType<typeof vi.fn>;
     setNextRunAt: ReturnType<typeof vi.fn>;
+    getById: ReturnType<typeof vi.fn>;
   };
   let pipelineScheduler: {
     startOrQueueAutomation: ReturnType<typeof vi.fn>;
@@ -50,6 +51,7 @@ describe('AutomationScheduler', () => {
       listEnabled: vi.fn(() => [] as Automation[]),
       listDue: vi.fn(() => [] as Automation[]),
       setNextRunAt: vi.fn(),
+      getById: vi.fn((id: string) => makeAutomation({ id })),
     };
     pipelineScheduler = {
       startOrQueueAutomation: vi.fn(async () => ({ queued: false })),
@@ -127,7 +129,7 @@ describe('AutomationScheduler', () => {
     const result = await scheduler.fireNow('auto-1');
 
     expect(result).toEqual({ queued: false });
-    expect(pipelineScheduler.startOrQueueAutomation).toHaveBeenCalledWith('auto-1');
+    expect(pipelineScheduler.startOrQueueAutomation).toHaveBeenCalledWith('auto-1', 'project-1');
     expect(queries.setNextRunAt).toHaveBeenCalledWith('auto-1', null);
   });
 
@@ -173,5 +175,45 @@ describe('AutomationScheduler', () => {
     scheduler.schedule(makeAutomation({ id: 'b' }));
     scheduler.stop();
     expect(() => scheduler.unschedule('a')).not.toThrow();
+  });
+
+  it('fans out one dispatch per target project', async () => {
+    queries.getById.mockReturnValue(makeAutomation({ id: 'multi', targets: ['p1', 'p2', 'p3'] }));
+
+    await scheduler.fireNow('multi');
+
+    expect(pipelineScheduler.startOrQueueAutomation).toHaveBeenCalledTimes(3);
+    expect(pipelineScheduler.startOrQueueAutomation).toHaveBeenCalledWith('multi', 'p1');
+    expect(pipelineScheduler.startOrQueueAutomation).toHaveBeenCalledWith('multi', 'p2');
+    expect(pipelineScheduler.startOrQueueAutomation).toHaveBeenCalledWith('multi', 'p3');
+  });
+
+  it('per-target guard: a second fire only dispatches not-yet-running targets', async () => {
+    queries.getById.mockReturnValue(makeAutomation({ id: 'multi', targets: ['p1', 'p2'] }));
+    const resolvers: Array<() => void> = [];
+    pipelineScheduler.startOrQueueAutomation.mockImplementation(
+      () =>
+        new Promise<{ queued: boolean }>((resolve) =>
+          resolvers.push(() => resolve({ queued: false })),
+        ),
+    );
+
+    const first = scheduler.fireNow('multi'); // dispatches p1, p2 (pending)
+    const second = scheduler.fireNow('multi'); // both in-flight → no new dispatch
+
+    expect(pipelineScheduler.startOrQueueAutomation).toHaveBeenCalledTimes(2);
+    await expect(second).resolves.toEqual({ queued: false });
+    for (const r of resolvers) r();
+    await first;
+  });
+
+  it('skips a disabled automation without dispatching', async () => {
+    queries.getById.mockReturnValue(makeAutomation({ id: 'off', enabled: false }));
+
+    const result = await scheduler.fireNow('off');
+
+    expect(result).toEqual({ queued: false });
+    expect(pipelineScheduler.startOrQueueAutomation).not.toHaveBeenCalled();
+    expect(queries.setNextRunAt).toHaveBeenCalledWith('off', null);
   });
 });

--- a/apps/desktop/src/main/automation-scheduler.ts
+++ b/apps/desktop/src/main/automation-scheduler.ts
@@ -29,7 +29,10 @@ export interface AutomationSchedulerDeps {
  */
 export class AutomationScheduler implements AutomationSchedulerLike {
   private jobs = new Map<string, Cron>();
-  private inFlight = new Map<string, Promise<{ queued: boolean }>>();
+  // automationId -> (targetProjectId -> in-flight dispatch). Keyed per target so
+  // a multi-repo automation can dispatch each repo independently while still
+  // guarding against double-firing the same (automation, target) pair.
+  private inFlight = new Map<string, Map<string, Promise<{ queued: boolean }>>>();
 
   constructor(private readonly deps: AutomationSchedulerDeps) {}
 
@@ -96,18 +99,44 @@ export class AutomationScheduler implements AutomationSchedulerLike {
     this.jobs.clear();
   }
 
+  private _advanceNextRun(automationId: string): void {
+    const job = this.jobs.get(automationId);
+    const next = job?.nextRun() ?? null;
+    this.deps.automations.setNextRunAt(automationId, next ? next.toISOString() : null);
+  }
+
   private _fire(automationId: string): Promise<{ queued: boolean }> {
-    const existing = this.inFlight.get(automationId);
-    if (existing) return existing;
+    const automation = this.deps.automations.getById(automationId);
+    if (!automation?.enabled) {
+      this._advanceNextRun(automationId);
+      return Promise.resolve({ queued: false });
+    }
 
-    const promise = this.deps.pipelineScheduler.startOrQueueAutomation(automationId).finally(() => {
-      this.inFlight.delete(automationId);
-      const job = this.jobs.get(automationId);
-      const next = job?.nextRun() ?? null;
-      this.deps.automations.setNextRunAt(automationId, next ? next.toISOString() : null);
-    });
+    const targets = automation.targets.length > 0 ? automation.targets : [automation.projectId];
+    const inner =
+      this.inFlight.get(automationId) ?? new Map<string, Promise<{ queued: boolean }>>();
+    this.inFlight.set(automationId, inner);
 
-    this.inFlight.set(automationId, promise);
-    return promise;
+    const dispatched: Array<Promise<{ queued: boolean }>> = [];
+    for (const projectId of targets) {
+      if (inner.has(projectId)) continue; // per-target in-flight guard
+      const promise = this.deps.pipelineScheduler
+        .startOrQueueAutomation(automationId, projectId)
+        .finally(() => {
+          inner.delete(projectId);
+          if (inner.size === 0) this.inFlight.delete(automationId);
+        });
+      inner.set(projectId, promise);
+      dispatched.push(promise);
+    }
+
+    // Advance the cron cursor once targets are dispatched (not awaited), so the
+    // missed-tick skip logic at startup sees the next future occurrence.
+    this._advanceNextRun(automationId);
+
+    if (dispatched.length === 0) return Promise.resolve({ queued: false });
+    return Promise.all(dispatched).then((results) => ({
+      queued: results.every((r) => r.queued),
+    }));
   }
 }

--- a/apps/desktop/src/main/ipc/register-automation-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/register-automation-handlers.test.ts
@@ -16,6 +16,7 @@ function makeAutomation(overrides: Partial<Automation> = {}): Automation {
   return {
     id: 'auto-1',
     projectId: 'project-1',
+    targets: ['project-1'],
     name: 'Nightly cleanup',
     prompt: 'Clean up stale worktrees',
     cronExpr: '0 0 * * *',

--- a/apps/desktop/src/main/pipeline-scheduler.test.ts
+++ b/apps/desktop/src/main/pipeline-scheduler.test.ts
@@ -648,6 +648,7 @@ describe('PipelineScheduler', () => {
     const automation = {
       id: 'auto-1',
       projectId: 'project-1',
+      targets: ['project-1'],
       name: 'Hourly smoke',
       prompt: 'List 3 files',
       cronExpr: '0 * * * *',
@@ -733,7 +734,7 @@ describe('PipelineScheduler', () => {
       queries.settings.get.mockReturnValue(makeBaseSettings({ maxConcurrentPipelines: 1 }));
       queries.automations.getById.mockReturnValue(automation);
 
-      await scheduler.startOrQueueAutomation('auto-1');
+      await scheduler.startOrQueueAutomation('auto-1', 'project-1');
 
       pipeline.listActiveInPhases.mockReturnValue([]);
       queries.githubIssues.getNextQueued.mockReturnValue(makeIssue());
@@ -756,7 +757,7 @@ describe('PipelineScheduler', () => {
       queries.settings.get.mockReturnValue(makeBaseSettings({ maxConcurrentPipelines: 1 }));
       queries.automations.getById.mockReturnValue(null);
 
-      await scheduler.startOrQueueAutomation('missing-auto');
+      await scheduler.startOrQueueAutomation('missing-auto', 'project-1');
 
       pipeline.listActiveInPhases.mockReturnValue([]);
       scheduler.onSlotFreed();
@@ -806,7 +807,7 @@ describe('PipelineScheduler', () => {
       queries.settings.get.mockReturnValue(makeBaseSettings({ maxConcurrentPipelines: 1 }));
       queries.automations.getById.mockReturnValue(automation);
 
-      await scheduler.startOrQueueAutomation('auto-1');
+      await scheduler.startOrQueueAutomation('auto-1', 'project-1');
       scheduler.onSlotFreed();
 
       expect(pipeline.startFromAutomation).not.toHaveBeenCalled();
@@ -826,7 +827,7 @@ describe('PipelineScheduler', () => {
       queries.automations.getById.mockReturnValue(automation);
       pipeline.startFromAutomation.mockRejectedValueOnce(new Error('automation failed'));
 
-      await scheduler.startOrQueueAutomation('auto-1');
+      await scheduler.startOrQueueAutomation('auto-1', 'project-1');
 
       pipeline.listActiveInPhases.mockReturnValue([]);
       scheduler.onSlotFreed();
@@ -1204,6 +1205,7 @@ describe('PipelineScheduler', () => {
     const automation = {
       id: 'auto-1',
       projectId: 'project-1',
+      targets: ['project-1'],
       name: 'Hourly smoke',
       prompt: 'List 3 files',
       cronExpr: '0 * * * *',
@@ -1224,7 +1226,7 @@ describe('PipelineScheduler', () => {
       pipeline.listActiveInPhases.mockReturnValue([]);
       queries.automations.getById.mockReturnValue(automation);
 
-      const result = await scheduler.startOrQueueAutomation('auto-1');
+      const result = await scheduler.startOrQueueAutomation('auto-1', 'project-1');
 
       expect(result.queued).toBe(false);
       expect(pipeline.startFromAutomation).toHaveBeenCalledWith(
@@ -1245,7 +1247,7 @@ describe('PipelineScheduler', () => {
       queries.settings.get.mockReturnValue(makeBaseSettings({ maxConcurrentPipelines: 3 }));
       queries.automations.getById.mockReturnValue(automation);
 
-      const result = await scheduler.startOrQueueAutomation('auto-1');
+      const result = await scheduler.startOrQueueAutomation('auto-1', 'project-1');
 
       expect(result.queued).toBe(true);
       expect(pipeline.startFromAutomation).not.toHaveBeenCalled();
@@ -1262,8 +1264,8 @@ describe('PipelineScheduler', () => {
       queries.automations.getById.mockReturnValue(automation);
 
       const [r1, r2] = await Promise.all([
-        scheduler.startOrQueueAutomation('auto-1'),
-        scheduler.startOrQueueAutomation('auto-1'),
+        scheduler.startOrQueueAutomation('auto-1', 'project-1'),
+        scheduler.startOrQueueAutomation('auto-1', 'project-1'),
       ]);
 
       expect(r1.queued).toBe(true);
@@ -1274,7 +1276,7 @@ describe('PipelineScheduler', () => {
       queries.automations.getById.mockReturnValue(automation);
       queries.threads.hasActiveForAutomation.mockReturnValue(true);
 
-      const result = await scheduler.startOrQueueAutomation('auto-1');
+      const result = await scheduler.startOrQueueAutomation('auto-1', 'project-1');
 
       expect(result.queued).toBe(false);
       expect(pipeline.startFromAutomation).not.toHaveBeenCalled();
@@ -1282,12 +1284,12 @@ describe('PipelineScheduler', () => {
 
     it('returns without launching when the automation is missing or disabled', async () => {
       queries.automations.getById.mockReturnValueOnce(null);
-      await expect(scheduler.startOrQueueAutomation('missing-auto')).resolves.toEqual({
+      await expect(scheduler.startOrQueueAutomation('missing-auto', 'project-1')).resolves.toEqual({
         queued: false,
       });
 
       queries.automations.getById.mockReturnValueOnce({ ...automation, enabled: false });
-      await expect(scheduler.startOrQueueAutomation('auto-1')).resolves.toEqual({
+      await expect(scheduler.startOrQueueAutomation('auto-1', 'project-1')).resolves.toEqual({
         queued: false,
       });
 
@@ -1297,7 +1299,7 @@ describe('PipelineScheduler', () => {
     it('skips disabled automations after dispatch capacity is available', async () => {
       queries.automations.getById.mockReturnValue({ ...automation, enabled: false });
 
-      const result = await scheduler.startOrQueueAutomation('auto-1');
+      const result = await scheduler.startOrQueueAutomation('auto-1', 'project-1');
 
       expect(result.queued).toBe(false);
       expect(pipeline.startFromAutomation).not.toHaveBeenCalled();
@@ -1308,7 +1310,7 @@ describe('PipelineScheduler', () => {
       queries.automations.getById.mockReturnValue(automation);
       queries.projects.getById.mockReturnValue(null);
 
-      await scheduler.startOrQueueAutomation('auto-1');
+      await scheduler.startOrQueueAutomation('auto-1', 'project-1');
 
       expect(queries.automations.recordRunFinished).toHaveBeenCalledWith('auto-1', 'failed');
 
@@ -1316,7 +1318,7 @@ describe('PipelineScheduler', () => {
       queries.projects.getById.mockReturnValue(makeProject());
       vi.mocked(fs.existsSync).mockReturnValueOnce(false);
 
-      await scheduler.startOrQueueAutomation('auto-1');
+      await scheduler.startOrQueueAutomation('auto-1', 'project-1');
 
       expect(queries.automations.recordRunFinished).toHaveBeenCalledWith('auto-1', 'failed');
       expect(pipeline.startFromAutomation).not.toHaveBeenCalled();
@@ -1326,7 +1328,7 @@ describe('PipelineScheduler', () => {
       queries.automations.getById.mockReturnValue(automation);
       vi.mocked(assertCliPhaseModelsSupported).mockRejectedValueOnce(new Error('unsupported'));
 
-      await scheduler.startOrQueueAutomation('auto-1');
+      await scheduler.startOrQueueAutomation('auto-1', 'project-1');
 
       expect(queries.automations.recordRunFinished).toHaveBeenCalledWith('auto-1', 'failed');
       expect(pipeline.startFromAutomation).not.toHaveBeenCalled();
@@ -1336,7 +1338,7 @@ describe('PipelineScheduler', () => {
       queries.automations.getById.mockReturnValue(automation);
       pipeline.startFromAutomation.mockRejectedValueOnce(new Error('automation dispatch failed'));
 
-      await expect(scheduler.startOrQueueAutomation('auto-1')).rejects.toThrow(
+      await expect(scheduler.startOrQueueAutomation('auto-1', 'project-1')).rejects.toThrow(
         'automation dispatch failed',
       );
 

--- a/apps/desktop/src/main/pipeline-scheduler.ts
+++ b/apps/desktop/src/main/pipeline-scheduler.ts
@@ -63,12 +63,13 @@ const REUSABLE_THREAD_STATUSES = new Set<PipelinePhase>([
  */
 export class PipelineScheduler {
   /**
-   * In-memory FIFO queue for automations that fired while all pipeline
-   * slots were occupied. Drained one at a time by `onSlotFreed`.
-   * Lost on app restart by design — automation cron resumes from
-   * `next_run_at` so a missed tick is simply skipped.
+   * In-memory FIFO queue for automation targets that fired while all pipeline
+   * slots were occupied. Each entry is one (automation, target project) pair,
+   * so a multi-repo automation queues per target independently. Drained one at
+   * a time by `onSlotFreed`. Lost on app restart by design — automation cron
+   * resumes from `next_run_at` so a missed tick is simply skipped.
    */
-  private pendingAutomations: string[] = [];
+  private pendingAutomations: Array<{ automationId: string; projectId: string }> = [];
 
   constructor(private readonly deps: PipelineSchedulerDeps) {}
 
@@ -200,20 +201,21 @@ export class PipelineScheduler {
       // Drain one pending automation before queued issues — automations
       // already fired their cron tick and should not wait behind issues
       // that can simply re-queue.
-      const pendingAutomationId = this.pendingAutomations.shift();
-      if (pendingAutomationId) {
-        const automation = queries.automations.getById(pendingAutomationId);
-        const project = automation ? queries.projects.getById(automation.projectId) : null;
+      const pending = this.pendingAutomations.shift();
+      if (pending) {
+        const project = queries.projects.getById(pending.projectId);
         if (
           project &&
           (activeCount >= this._getProjectPipelineCap(project.path) ||
             !this._isPerStateSlotAvailable(project.path, PIPELINE_PHASE.planning))
         ) {
-          this.pendingAutomations.unshift(pendingAutomationId);
+          this.pendingAutomations.unshift(pending);
           return;
         }
-        log.info(`[scheduler] auto-promoting automation ${pendingAutomationId}`);
-        this._launchAutomation(pendingAutomationId).catch((err) => {
+        log.info(
+          `[scheduler] auto-promoting automation ${pending.automationId} → project ${pending.projectId}`,
+        );
+        this._launchAutomation(pending.automationId, pending.projectId).catch((err) => {
           log.error('[scheduler] automation promote failed:', err);
         });
         return;
@@ -241,16 +243,22 @@ export class PipelineScheduler {
   }
 
   /**
-   * Cron-driven entry: tries to launch an automation now or queues it
-   * in-memory if pipeline slots are full. Called by AutomationScheduler.
+   * Cron-driven entry: tries to launch one automation target now or queues it
+   * in-memory if pipeline slots are full. Called per target by
+   * AutomationScheduler so a multi-repo automation fans out across repos.
    */
-  async startOrQueueAutomation(automationId: string): Promise<{ queued: boolean }> {
+  async startOrQueueAutomation(
+    automationId: string,
+    targetProjectId: string,
+  ): Promise<{ queued: boolean }> {
     const { queries } = this.deps;
-    const automation = queries.automations.getById(automationId);
-    const project = automation ? queries.projects.getById(automation.projectId) : null;
+    const project = queries.projects.getById(targetProjectId);
 
-    if (queries.threads.hasActiveForAutomation(automationId)) {
-      log.info(`[scheduler] skipping automation ${automationId} — already has an active pipeline`);
+    // Per-target guard: this automation can still run a different target repo.
+    if (queries.threads.hasActiveForAutomation(automationId, targetProjectId)) {
+      log.info(
+        `[scheduler] skipping automation ${automationId} → ${targetProjectId} — target already active`,
+      );
       return { queued: false };
     }
 
@@ -265,16 +273,19 @@ export class PipelineScheduler {
       : false;
 
     if (activeCount >= pipelineCap || perStateBlocked) {
-      if (!this.pendingAutomations.includes(automationId)) {
-        this.pendingAutomations.push(automationId);
+      const alreadyQueued = this.pendingAutomations.some(
+        (p) => p.automationId === automationId && p.projectId === targetProjectId,
+      );
+      if (!alreadyQueued) {
+        this.pendingAutomations.push({ automationId, projectId: targetProjectId });
       }
       log.info(
-        `[scheduler] queued automation ${automationId} (${activeCount}/${pipelineCap} slots used)`,
+        `[scheduler] queued automation ${automationId} → ${targetProjectId} (${activeCount}/${pipelineCap} slots used)`,
       );
       return { queued: true };
     }
 
-    await this._launchAutomation(automationId);
+    await this._launchAutomation(automationId, targetProjectId);
     return { queued: false };
   }
 
@@ -515,7 +526,7 @@ export class PipelineScheduler {
     }
   }
 
-  private async _launchAutomation(automationId: string): Promise<void> {
+  private async _launchAutomation(automationId: string, targetProjectId: string): Promise<void> {
     const { queries, pipeline, emitter, getMainWindow } = this.deps;
 
     const automation = queries.automations.getById(automationId);
@@ -528,9 +539,9 @@ export class PipelineScheduler {
       return;
     }
 
-    const project = queries.projects.getById(automation.projectId);
+    const project = queries.projects.getById(targetProjectId);
     if (!project) {
-      log.warn(`[automation] project ${automation.projectId} not found`);
+      log.warn(`[automation] target project ${targetProjectId} not found`);
       queries.automations.recordRunFinished(automation.id, 'failed');
       return;
     }
@@ -562,11 +573,13 @@ export class PipelineScheduler {
       return;
     }
 
-    const thread = queries.threads.create(
-      project.id,
-      automation.prompt,
-      `[Auto] ${automation.name}`,
-    );
+    // Distinguish sibling runs of a multi-repo automation by target repo.
+    const projectLabel = project.path.split(/[\\/]/).filter(Boolean).pop() ?? project.path;
+    const title =
+      automation.targets.length > 1
+        ? `[Auto] ${automation.name} — ${projectLabel}`
+        : `[Auto] ${automation.name}`;
+    const thread = queries.threads.create(project.id, automation.prompt, title);
     queries.threads.setAutomationId(thread.id, automation.id);
     queries.threads.setPhaseModels(thread.id, mergedPhaseModels);
 

--- a/apps/desktop/src/renderer/features/automations/automation-detail.test.tsx
+++ b/apps/desktop/src/renderer/features/automations/automation-detail.test.tsx
@@ -12,6 +12,7 @@ function makeAutomation(overrides: Partial<Automation> = {}): Automation {
   return {
     id: 'auto-1',
     projectId: 'project-1',
+    targets: ['project-1'],
     name: 'Daily smoke',
     prompt:
       '# Automation: Daily smoke\n\n## Goal\nRun the smoke test.\n\n## Verification\n- `bun test` passes',

--- a/apps/desktop/src/renderer/features/automations/automations-view.test.tsx
+++ b/apps/desktop/src/renderer/features/automations/automations-view.test.tsx
@@ -13,6 +13,7 @@ function makeAutomation(overrides: Partial<Automation> = {}): Automation {
   return {
     id: 'auto-1',
     projectId: 'project-1',
+    targets: ['project-1'],
     name: 'Daily smoke',
     prompt: 'List 3 files',
     cronExpr: '0 9 * * *',

--- a/apps/desktop/src/renderer/features/automations/automations-view.tsx
+++ b/apps/desktop/src/renderer/features/automations/automations-view.tsx
@@ -84,7 +84,12 @@ export function AutomationsView() {
               <AutomationCard
                 key={automation.id}
                 automation={automation}
-                projectName={projectById.get(automation.projectId)?.name ?? 'Unknown project'}
+                projectName={(automation.targets.length > 0
+                  ? automation.targets
+                  : [automation.projectId]
+                )
+                  .map((id) => projectById.get(id)?.name ?? 'Unknown project')
+                  .join(', ')}
                 onEdit={() => openCreateAutomationModal(automation.id)}
                 onToggleEnabled={(enabled) => setEnabled.mutate({ id: automation.id, enabled })}
                 onDelete={() => {

--- a/apps/desktop/src/renderer/features/automations/create-automation-modal.test.tsx
+++ b/apps/desktop/src/renderer/features/automations/create-automation-modal.test.tsx
@@ -205,6 +205,42 @@ describe('CreateAutomationModal', () => {
     });
   });
 
+  it('creates a multi-repo automation with all selected targets', async () => {
+    invokeMock.mockImplementation(async (channel: string) => {
+      if (channel === 'project:list-visible')
+        return [makeProject(), makeProject({ id: 'project-2', name: 'Other Repo' })];
+      if (channel === 'automations:create') {
+        return { id: 'auto-new', projectId: 'project-1', targets: ['project-1', 'project-2'] };
+      }
+      return null;
+    });
+
+    renderWithProviders();
+
+    // Second repo chip appears once projects load; primary is pre-selected.
+    fireEvent.click(await screen.findByRole('button', { name: 'Other Repo' }));
+    fireEvent.change(screen.getByPlaceholderText(/Daily smoke test/), {
+      target: { value: 'Smoke' },
+    });
+    fireEvent.change(screen.getByPlaceholderText(/What should this run do\?/), {
+      target: { value: 'do thing' },
+    });
+
+    const create = screen.getByRole('button', { name: /Create/ });
+    await waitFor(() => expect(create).not.toBeDisabled());
+    fireEvent.click(create);
+
+    await waitFor(() => {
+      expect(invokeMock).toHaveBeenCalledWith(
+        'automations:create',
+        expect.objectContaining({
+          projectId: 'project-1',
+          targets: ['project-1', 'project-2'],
+        }),
+      );
+    });
+  });
+
   it('submits edits for an existing automation', async () => {
     act(() => {
       useAppStore.setState({ editingAutomationId: 'auto-1' });

--- a/apps/desktop/src/renderer/features/automations/create-automation-modal.tsx
+++ b/apps/desktop/src/renderer/features/automations/create-automation-modal.tsx
@@ -68,7 +68,7 @@ interface FormatAutomationVariables {
 }
 
 interface AutomationFormState {
-  projectId: string;
+  projectIds: string[];
   name: string;
   prompt: string;
   presetId: string;
@@ -90,7 +90,7 @@ type AutomationFormAction =
     };
 
 const INITIAL_AUTOMATION_FORM_STATE: AutomationFormState = {
-  projectId: '',
+  projectIds: [],
   name: '',
   prompt: '',
   presetId: 'hourly',
@@ -110,7 +110,7 @@ function automationFormReducer(
     case 'load':
       return action.form;
     case 'ensure-project':
-      return state.projectId ? state : { ...state, projectId: action.projectId };
+      return state.projectIds.length > 0 ? state : { ...state, projectIds: [action.projectId] };
     case 'field':
       return { ...state, [action.field]: action.value };
   }
@@ -161,7 +161,7 @@ function useCreateAutomationModalView() {
 
   const [form, dispatchForm] = useReducer(automationFormReducer, INITIAL_AUTOMATION_FORM_STATE);
   const {
-    projectId,
+    projectIds,
     name,
     prompt,
     presetId,
@@ -194,7 +194,7 @@ function useCreateAutomationModalView() {
       dispatchForm({
         type: 'load',
         form: {
-          projectId: existing.projectId,
+          projectIds: existing.targets?.length ? existing.targets : [existing.projectId],
           name: existing.name,
           prompt: existing.prompt,
           presetId: pid,
@@ -210,7 +210,10 @@ function useCreateAutomationModalView() {
     } else if (!isEdit) {
       dispatchForm({
         type: 'load',
-        form: { ...INITIAL_AUTOMATION_FORM_STATE, projectId: fallbackProjectId },
+        form: {
+          ...INITIAL_AUTOMATION_FORM_STATE,
+          projectIds: fallbackProjectId ? [fallbackProjectId] : [],
+        },
       });
       initializedFormKeyRef.current = currentFormKey;
     }
@@ -240,7 +243,8 @@ function useCreateAutomationModalView() {
         return window.shipcode.invoke<Automation>('automations:update', patch);
       }
       const input: CreateAutomationInput = {
-        projectId,
+        projectId: projectIds[0],
+        targets: projectIds,
         name: name.trim(),
         prompt: prompt.trim(),
         cronExpr,
@@ -311,12 +315,15 @@ function useCreateAutomationModalView() {
   const submitDisabled =
     createOrUpdate.isPending ||
     formatPendingForCurrentForm ||
-    !projectId ||
+    projectIds.length === 0 ||
     !name.trim() ||
     !prompt.trim() ||
     !!cronError;
   const formatDisabled =
-    formatPendingForCurrentForm || createOrUpdate.isPending || !projectId || !prompt.trim();
+    formatPendingForCurrentForm ||
+    createOrUpdate.isPending ||
+    projectIds.length === 0 ||
+    !prompt.trim();
 
   const handleSubmit = () => {
     dispatchForm({ type: 'field', field: 'error', value: null });
@@ -333,7 +340,7 @@ function useCreateAutomationModalView() {
     formatAutomation.mutate({
       requestId,
       formKey: currentFormKey,
-      projectId,
+      projectId: projectIds[0],
       prompt,
       provider,
       modelId: executorModelId,
@@ -382,24 +389,35 @@ function useCreateAutomationModalView() {
 
         {!isEdit && (
           <div className="flex flex-col gap-1.5">
-            <Label htmlFor="auto-project" className="text-xs text-secondary">
-              Project
-            </Label>
-            <Select
-              value={projectId}
-              onValueChange={(value) => dispatchForm({ type: 'field', field: 'projectId', value })}
-            >
-              <SelectTrigger id="auto-project" className="bg-transparent">
-                <SelectValue placeholder="Select a project…" />
-              </SelectTrigger>
-              <SelectContent>
-                {projects.map((p) => (
-                  <SelectItem key={p.id} value={p.id}>
+            <Label className="text-xs text-secondary">Target repos</Label>
+            <div className="flex flex-wrap gap-1.5">
+              {projects.map((p) => {
+                const selected = projectIds.includes(p.id);
+                return (
+                  <Button
+                    key={p.id}
+                    type="button"
+                    variant={selected ? 'default' : 'outline'}
+                    size="xs"
+                    aria-pressed={selected}
+                    onClick={() =>
+                      dispatchForm({
+                        type: 'field',
+                        field: 'projectIds',
+                        value: selected
+                          ? projectIds.filter((id) => id !== p.id)
+                          : [...projectIds, p.id],
+                      })
+                    }
+                  >
                     {p.name}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
+                  </Button>
+                );
+              })}
+            </div>
+            <div className="text-[11px] text-muted-foreground">
+              Runs once per selected repo, each in its own worktree.
+            </div>
           </div>
         )}
 

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -84,6 +84,7 @@ import {
   migrateV60,
   migrateV61,
   migrateV62,
+  migrateV63,
 } from './schema';
 
 export { ActivityQueries } from './queries/activity';
@@ -211,6 +212,7 @@ export function getDatabase(dataDir: string): DatabaseSync {
   migrateV60(db);
   migrateV61(db);
   migrateV62(db);
+  migrateV63(db);
 
   // Startup cleanup: reset unclaimed queued issues to todo on every launch.
   // An unclaimed queued issue has no active worker holding it — it's stale state

--- a/packages/db/src/migrations/v63-v80.ts
+++ b/packages/db/src/migrations/v63-v80.ts
@@ -1,0 +1,52 @@
+import type { DatabaseSync } from 'node:sqlite';
+import { transaction } from '../utils';
+
+export function migrateV63(db: DatabaseSync): void {
+  const row = db
+    .prepare('SELECT version FROM schema_version ORDER BY version DESC LIMIT 1')
+    .get() as { version: number } | undefined;
+  if (row && row.version >= 63) return;
+
+  transaction(db, () => {
+    // Multi-repo automations: an automation can target more than one project.
+    // automation_targets is the junction (one row per automation×project) and
+    // is the source of truth for fan-out. automations.project_id is retained as
+    // the "primary" target so existing single-project callers keep working;
+    // dropping it would require an FK-aware table rebuild (threads.automation_id
+    // references automations) and is deferred to a later cleanup.
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS automation_targets (
+        id            TEXT PRIMARY KEY,
+        automation_id TEXT NOT NULL REFERENCES automations(id) ON DELETE CASCADE,
+        project_id    TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+        created_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+        UNIQUE (automation_id, project_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_automation_targets_automation
+        ON automation_targets(automation_id);
+      CREATE INDEX IF NOT EXISTS idx_automation_targets_project
+        ON automation_targets(project_id);
+    `);
+
+    // Backfill exactly one target per existing automation from its current
+    // single project_id. Idempotent via the NOT EXISTS guard so re-running the
+    // migration (or running it on a partially-migrated DB) never duplicates.
+    db.exec(`
+      INSERT INTO automation_targets (id, automation_id, project_id, created_at)
+      SELECT lower(hex(randomblob(10))),
+             id,
+             project_id,
+             COALESCE(created_at, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        FROM automations
+       WHERE project_id IS NOT NULL
+         AND NOT EXISTS (
+           SELECT 1 FROM automation_targets t
+            WHERE t.automation_id = automations.id
+              AND t.project_id = automations.project_id
+         );
+    `);
+
+    db.exec(`INSERT OR REPLACE INTO schema_version (version) VALUES (63)`);
+  });
+}

--- a/packages/db/src/queries/automations.test.ts
+++ b/packages/db/src/queries/automations.test.ts
@@ -324,4 +324,114 @@ describe('AutomationQueries', () => {
     );
     getById.mockRestore();
   });
+
+  it('create backfills a single target equal to the primary project', () => {
+    const { dataDir, automations, project } = setup();
+    tempDirs.push(dataDir);
+
+    const a = automations.create({
+      projectId: project.id,
+      name: 'A',
+      prompt: 'p',
+      cronExpr: '0 * * * *',
+    });
+
+    expect(a.projectId).toBe(project.id);
+    expect(a.targets).toEqual([project.id]);
+    expect(automations.listTargets(a.id)).toEqual([project.id]);
+  });
+
+  it('create with explicit targets stores all and lists under any target', () => {
+    const { dataDir, projects, automations, project } = setup();
+    tempDirs.push(dataDir);
+    const projectB = projects.add(path.join(dataDir, 'project-b'));
+
+    const a = automations.create({
+      projectId: project.id,
+      targets: [project.id, projectB.id, project.id], // duplicate is deduped
+      name: 'Multi',
+      prompt: 'p',
+      cronExpr: '0 * * * *',
+    });
+
+    expect(a.projectId).toBe(project.id);
+    expect(a.targets).toEqual([project.id, projectB.id]);
+    expect(automations.list(project.id).map((x) => x.id)).toContain(a.id);
+    expect(automations.list(projectB.id).map((x) => x.id)).toContain(a.id);
+  });
+
+  it('addTarget and removeTarget mutate the set idempotently', () => {
+    const { dataDir, projects, automations, project } = setup();
+    tempDirs.push(dataDir);
+    const projectB = projects.add(path.join(dataDir, 'project-b'));
+
+    const a = automations.create({
+      projectId: project.id,
+      name: 'A',
+      prompt: 'p',
+      cronExpr: '0 * * * *',
+    });
+
+    automations.addTarget(a.id, projectB.id);
+    automations.addTarget(a.id, projectB.id); // idempotent
+    expect(automations.listTargets(a.id)).toEqual([project.id, projectB.id]);
+
+    automations.removeTarget(a.id, projectB.id);
+    expect(automations.listTargets(a.id)).toEqual([project.id]);
+  });
+
+  it('setTargets replaces the set and realigns the primary projectId', () => {
+    const { dataDir, projects, automations, project } = setup();
+    tempDirs.push(dataDir);
+    const projectB = projects.add(path.join(dataDir, 'project-b'));
+
+    const a = automations.create({
+      projectId: project.id,
+      name: 'A',
+      prompt: 'p',
+      cronExpr: '0 * * * *',
+    });
+
+    automations.setTargets(a.id, [projectB.id, project.id]);
+    const reloaded = automations.getById(a.id);
+    if (!reloaded) throw new Error('Expected automation after setTargets');
+    expect(reloaded.targets).toEqual([projectB.id, project.id]);
+    expect(reloaded.projectId).toBe(projectB.id);
+
+    expect(() => automations.setTargets(a.id, [])).toThrow('at least one target');
+  });
+
+  it('hydrates targets to [projectId] when no target rows exist', () => {
+    const { dataDir, db, automations, project } = setup();
+    tempDirs.push(dataDir);
+
+    const a = automations.create({
+      projectId: project.id,
+      name: 'A',
+      prompt: 'p',
+      cronExpr: '0 * * * *',
+    });
+    db.prepare('DELETE FROM automation_targets WHERE automation_id = ?').run(a.id);
+
+    expect(automations.getById(a.id)?.targets).toEqual([project.id]);
+  });
+
+  it('CASCADE: deleting an automation removes its targets', () => {
+    const { dataDir, db, automations, project } = setup();
+    tempDirs.push(dataDir);
+
+    const a = automations.create({
+      projectId: project.id,
+      name: 'A',
+      prompt: 'p',
+      cronExpr: '0 * * * *',
+    });
+    expect(automations.listTargets(a.id)).toHaveLength(1);
+
+    automations.delete(a.id);
+    const remaining = db
+      .prepare('SELECT COUNT(*) AS n FROM automation_targets WHERE automation_id = ?')
+      .get(a.id) as { n: number };
+    expect(remaining.n).toBe(0);
+  });
 });

--- a/packages/db/src/queries/automations.ts
+++ b/packages/db/src/queries/automations.ts
@@ -9,7 +9,7 @@ import {
   type UpdateAutomationInput,
 } from '@shipcode/shared';
 import { nanoid } from 'nanoid';
-import { asRow, asRows } from '../utils';
+import { asRow, asRows, transaction } from '../utils';
 
 interface AutomationRow {
   id: string;
@@ -30,10 +30,11 @@ interface AutomationRow {
   updated_at: string;
 }
 
-function mapAutomation(row: AutomationRow): Automation {
+function mapAutomation(row: AutomationRow, targets: string[]): Automation {
   return {
     id: row.id,
     projectId: row.project_id,
+    targets: targets.length > 0 ? targets : [row.project_id],
     name: row.name,
     prompt: row.prompt,
     cronExpr: row.cron_expr,
@@ -54,23 +55,43 @@ function mapAutomation(row: AutomationRow): Automation {
 export class AutomationQueries {
   constructor(private db: DatabaseSync) {}
 
-  list(projectId: string): Automation[] {
+  /** Target project ids for an automation, oldest first (primary first). */
+  listTargets(automationId: string): string[] {
     const rows = this.db
-      .prepare('SELECT * FROM automations WHERE project_id = ? ORDER BY created_at DESC')
+      .prepare(
+        'SELECT project_id FROM automation_targets WHERE automation_id = ? ORDER BY created_at ASC',
+      )
+      .all(automationId);
+    return asRows<{ project_id: string }>(rows).map((r) => r.project_id);
+  }
+
+  private hydrate(row: AutomationRow): Automation {
+    return mapAutomation(row, this.listTargets(row.id));
+  }
+
+  list(projectId: string): Automation[] {
+    // Automations that target this project (multi-repo aware), newest first.
+    const rows = this.db
+      .prepare(
+        `SELECT a.* FROM automations a
+            JOIN automation_targets t ON t.automation_id = a.id
+           WHERE t.project_id = ?
+           ORDER BY a.created_at DESC`,
+      )
       .all(projectId);
-    return asRows<AutomationRow>(rows).map(mapAutomation);
+    return asRows<AutomationRow>(rows).map((row) => this.hydrate(row));
   }
 
   listAll(): Automation[] {
     const rows = this.db.prepare('SELECT * FROM automations ORDER BY created_at DESC').all();
-    return asRows<AutomationRow>(rows).map(mapAutomation);
+    return asRows<AutomationRow>(rows).map((row) => this.hydrate(row));
   }
 
   listEnabled(): Automation[] {
     const rows = this.db
       .prepare('SELECT * FROM automations WHERE enabled = 1 ORDER BY created_at DESC')
       .all();
-    return asRows<AutomationRow>(rows).map(mapAutomation);
+    return asRows<AutomationRow>(rows).map((row) => this.hydrate(row));
   }
 
   /**
@@ -84,38 +105,91 @@ export class AutomationQueries {
         'SELECT * FROM automations WHERE enabled = 1 AND next_run_at IS NOT NULL AND next_run_at <= ?',
       )
       .all(nowIso);
-    return asRows<AutomationRow>(rows).map(mapAutomation);
+    return asRows<AutomationRow>(rows).map((row) => this.hydrate(row));
   }
 
   getById(id: string): Automation | null {
     const row = this.db.prepare('SELECT * FROM automations WHERE id = ?').get(id);
-    return row ? mapAutomation(asRow<AutomationRow>(row)) : null;
+    return row ? this.hydrate(asRow<AutomationRow>(row)) : null;
   }
 
   create(input: CreateAutomationInput): Automation {
     const id = nanoid();
-    this.db
-      .prepare(
-        `INSERT INTO automations (
-           id, project_id, name, prompt, cron_expr, enabled,
-           executor_provider, executor_model_id, executor_reasoning_effort,
-           run_count, created_at, updated_at
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ${ISO_NOW_SQL}, ${ISO_NOW_SQL})`,
-      )
-      .run(
-        id,
-        input.projectId,
-        input.name,
-        input.prompt,
-        input.cronExpr,
-        input.enabled === false ? 0 : 1,
-        input.executorProvider ?? null,
-        input.executorModelId ?? null,
-        input.executorReasoningEffort ?? null,
+    // Dedupe while preserving order; the first target becomes the primary
+    // project_id so single-project callers keep working unchanged.
+    const targets = [...new Set(input.targets?.length ? input.targets : [input.projectId])];
+    const primary = targets[0] ?? input.projectId;
+
+    transaction(this.db, () => {
+      this.db
+        .prepare(
+          `INSERT INTO automations (
+             id, project_id, name, prompt, cron_expr, enabled,
+             executor_provider, executor_model_id, executor_reasoning_effort,
+             run_count, created_at, updated_at
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 0, ${ISO_NOW_SQL}, ${ISO_NOW_SQL})`,
+        )
+        .run(
+          id,
+          primary,
+          input.name,
+          input.prompt,
+          input.cronExpr,
+          input.enabled === false ? 0 : 1,
+          input.executorProvider ?? null,
+          input.executorModelId ?? null,
+          input.executorReasoningEffort ?? null,
+        );
+
+      const insertTarget = this.db.prepare(
+        `INSERT OR IGNORE INTO automation_targets (id, automation_id, project_id, created_at)
+         VALUES (?, ?, ?, ${ISO_NOW_SQL})`,
       );
+      for (const projectId of targets) {
+        insertTarget.run(nanoid(), id, projectId);
+      }
+    });
+
     const automation = this.getById(id);
     if (!automation) throw new Error(`Failed to create automation ${id}`);
     return automation;
+  }
+
+  /** Add a target project (idempotent on the automation×project pair). */
+  addTarget(automationId: string, projectId: string): void {
+    this.db
+      .prepare(
+        `INSERT OR IGNORE INTO automation_targets (id, automation_id, project_id, created_at)
+         VALUES (?, ?, ?, ${ISO_NOW_SQL})`,
+      )
+      .run(nanoid(), automationId, projectId);
+  }
+
+  /** Remove a target project. */
+  removeTarget(automationId: string, projectId: string): void {
+    this.db
+      .prepare('DELETE FROM automation_targets WHERE automation_id = ? AND project_id = ?')
+      .run(automationId, projectId);
+  }
+
+  /** Replace the full target set, keeping `project_id` aligned to the first. */
+  setTargets(automationId: string, projectIds: string[]): void {
+    const targets = [...new Set(projectIds)];
+    if (targets.length === 0) throw new Error('An automation must have at least one target');
+
+    transaction(this.db, () => {
+      this.db.prepare('DELETE FROM automation_targets WHERE automation_id = ?').run(automationId);
+      const insertTarget = this.db.prepare(
+        `INSERT OR IGNORE INTO automation_targets (id, automation_id, project_id, created_at)
+         VALUES (?, ?, ?, ${ISO_NOW_SQL})`,
+      );
+      for (const projectId of targets) {
+        insertTarget.run(nanoid(), automationId, projectId);
+      }
+      this.db
+        .prepare(`UPDATE automations SET project_id = ?, updated_at = ${ISO_NOW_SQL} WHERE id = ?`)
+        .run(targets[0], automationId);
+    });
   }
 
   update(id: string, patch: UpdateAutomationInput): Automation {

--- a/packages/db/src/queries/threads.ts
+++ b/packages/db/src/queries/threads.ts
@@ -84,7 +84,17 @@ export class ThreadQueries {
     return asRows<ThreadRow>(rows).map(mapThread);
   }
 
-  hasActiveForAutomation(automationId: string): boolean {
+  hasActiveForAutomation(automationId: string, projectId?: string): boolean {
+    // When projectId is given, the guard is scoped to one target repo so a
+    // multi-repo automation can run a different target concurrently.
+    if (projectId !== undefined) {
+      const row = this.db
+        .prepare(
+          "SELECT 1 FROM threads WHERE automation_id = ? AND project_id = ? AND status NOT IN ('idle', 'completed', 'failed') LIMIT 1",
+        )
+        .get(automationId, projectId);
+      return !!row;
+    }
     const row = this.db
       .prepare(
         "SELECT 1 FROM threads WHERE automation_id = ? AND status NOT IN ('idle', 'completed', 'failed') LIMIT 1",

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -66,3 +66,4 @@ export {
   migrateV61,
   migrateV62,
 } from './migrations/v41-v62';
+export { migrateV63 } from './migrations/v63-v80';

--- a/packages/db/src/test-helpers.ts
+++ b/packages/db/src/test-helpers.ts
@@ -62,6 +62,7 @@ import {
   migrateV60,
   migrateV61,
   migrateV62,
+  migrateV63,
 } from './schema';
 
 export function createTestDb(): DatabaseSync {
@@ -128,5 +129,6 @@ export function createTestDb(): DatabaseSync {
   migrateV60(db);
   migrateV61(db);
   migrateV62(db);
+  migrateV63(db);
   return db;
 }

--- a/packages/shared/src/types/project.ts
+++ b/packages/shared/src/types/project.ts
@@ -65,7 +65,10 @@ export type AutomationLastStatus = 'running' | 'completed' | 'failed';
 
 export interface Automation {
   id: string;
+  /** Primary target project. Retained for back-compat; equals `targets[0]`. */
   projectId: string;
+  /** All target projects this automation fans out to (includes the primary). */
+  targets: string[];
   name: string;
   prompt: string;
   cronExpr: string;
@@ -83,7 +86,10 @@ export interface Automation {
 }
 
 export interface CreateAutomationInput {
+  /** Primary target project. Used as `targets[0]` when `targets` is omitted. */
   projectId: string;
+  /** Optional full target set. Defaults to `[projectId]` when omitted. */
+  targets?: string[];
   name: string;
   prompt: string;
   cronExpr: string;


### PR DESCRIPTION
Part of #262 (epic #258). Stacked on #267 (S3b) → base retargets to master as the stack lands.

## What
Makes the shipped S3 multi-repo backend reachable from the UI.

- **create-automation-modal**: the single-project `Select` becomes a **multi-select chip picker** (toggle `Button`s). Form state `projectId` → `projectIds`; create sends `projectId` (primary = `targets[0]`) plus the full `targets[]`. Edit mode unchanged (reads `existing.targets` defensively).
- **automations-view**: each card lists **all** target repo names, not just the primary.

## Verification (local)
- `@shipcode/desktop` automations suites: 42 passed — incl. a new `creates a multi-repo automation with all selected targets` test asserting the `targets` payload.
- Typecheck desktop clean. Biome clean.

## Scope
This completes the **usable** multi-repo feature (create → fan-out → worktree-per-repo). The full Codex-style **two-pane thread-view workspace** (AI Elements: Conversation/Task/Queue/ModelSelector, the wireframe) remains as S4 polish — a large net-new UI surface tracked separately under #262.

## Behavior
Single-repo automations unchanged. Selecting >1 repo creates one automation that fans out across them (S3b).