### PR TITLE
feat(models): Opus combo budget preset (S2 recovery, #260)

### DIFF
--- a/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx
@@ -4,9 +4,9 @@ import {
   buildAppSettingsModelPresetPatch,
   type ExecutorModel,
   formatReasoningEffortLabel,
+  GLOBAL_MODEL_CONFIG_PRESETS,
   getCapabilitySupportedReasoningEfforts,
   type IntegrationStatus,
-  MODEL_CONFIG_PRESETS,
   type ModelConfigPresetKey,
   resolveProviderReasoningEffort,
 } from '@shipcode/shared';
@@ -446,7 +446,7 @@ function pipelineSettingsSection({
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="start" className="min-w-[260px]">
-                {MODEL_CONFIG_PRESETS.map((preset) => (
+                {GLOBAL_MODEL_CONFIG_PRESETS.map((preset) => (
                   <DropdownMenuItem
                     key={preset.key}
                     onSelect={() => applyPreset(preset.key)}

--- a/packages/shared/src/model-config-presets.test.ts
+++ b/packages/shared/src/model-config-presets.test.ts
@@ -1,9 +1,13 @@
 import { describe, expect, it } from 'vitest';
+import { DEFAULT_SETTINGS } from './constants';
 import {
   buildAppSettingsModelPresetPatch,
   buildProjectModelPresetOverrides,
+  GLOBAL_MODEL_CONFIG_PRESETS,
   getModelConfigPreset,
+  MODEL_CONFIG_PRESETS,
 } from './model-config-presets';
+import { resolvePhaseModel, resolvePhaseModelId } from './model-resolution';
 
 describe('model config presets', () => {
   it('builds the hybrid app settings patch from the shared preset definition', () => {
@@ -44,5 +48,42 @@ describe('model config presets', () => {
       executorReasoningEffortOverride: 'medium',
       verifierReasoningEffortOverride: 'high',
     });
+  });
+
+  it('builds opus-combo overrides: Opus 4.8 plans, GPT-5.5 codes, GPT-5.4 Mini verifies', () => {
+    const preset = getModelConfigPreset('opus-combo');
+    expect(preset.label).toBe('Opus combo');
+    expect(preset.appliesTo).toBe('project');
+
+    expect(buildProjectModelPresetOverrides('opus-combo')).toEqual({
+      plannerModelOverride: 'claude',
+      reviewerModelOverride: 'codex',
+      executorModelOverride: 'codex',
+      verifierModelOverride: 'codex',
+      plannerModelIdOverride: 'claude-opus-4-8',
+      reviewerModelIdOverride: 'gpt-5.5',
+      executorModelIdOverride: 'gpt-5.5',
+      verifierModelIdOverride: 'gpt-5.4-mini',
+      // claude clamps xhigh -> high (CLI has no xhigh); codex keeps its tiers.
+      plannerReasoningEffortOverride: 'high',
+      reviewerReasoningEffortOverride: 'high',
+      executorReasoningEffortOverride: 'medium',
+      verifierReasoningEffortOverride: 'high',
+    });
+  });
+
+  it('hides project-only presets from the global preset picker', () => {
+    expect(MODEL_CONFIG_PRESETS.map((p) => p.key)).toContain('opus-combo');
+    expect(GLOBAL_MODEL_CONFIG_PRESETS.map((p) => p.key)).not.toContain('opus-combo');
+    expect(GLOBAL_MODEL_CONFIG_PRESETS.every((p) => p.appliesTo === 'all')).toBe(true);
+  });
+
+  it('honors the opus-combo Opus 4.8 model id end-to-end via project overrides', () => {
+    const overrides = buildProjectModelPresetOverrides('opus-combo');
+    // The global path pins the claude model, so the planner model id only
+    // resolves to Opus 4.8 through the per-project override path.
+    expect(resolvePhaseModel(DEFAULT_SETTINGS, overrides, 'planner')).toBe('claude');
+    expect(resolvePhaseModelId(DEFAULT_SETTINGS, overrides, 'planner')).toBe('claude-opus-4-8');
+    expect(resolvePhaseModelId(DEFAULT_SETTINGS, overrides, 'verifier')).toBe('gpt-5.4-mini');
   });
 });

--- a/packages/shared/src/model-config-presets.ts
+++ b/packages/shared/src/model-config-presets.ts
@@ -1,9 +1,16 @@
-import { CLAUDE_MODEL_IDS, PINNED_MODEL_DEFAULTS } from './model-catalog';
+import { CLAUDE_MODEL_IDS, CODEX_FALLBACK_MODEL_IDS, PINNED_MODEL_DEFAULTS } from './model-catalog';
 import type { ResolvedPhaseModel } from './model-resolution';
 import { resolveProviderReasoningEffort } from './reasoning-effort';
 import type { AppSettings, ExecutorModel, Project, ReasoningEffort } from './types';
 
-export type ModelConfigPresetKey = 'claude' | 'codex' | 'hybrid';
+export type ModelConfigPresetKey = 'claude' | 'codex' | 'hybrid' | 'opus-combo';
+
+// Where a preset can be applied. The global AppSettings path only carries a
+// phase *provider* (the concrete claude/codex model stays pinned), so a preset
+// whose value comes from per-phase model ids — like opus-combo running Opus 4.8
+// for planning — is only honored through per-project overrides. 'project'-scoped
+// presets are therefore hidden from the global settings preset list.
+export type ModelPresetScope = 'all' | 'project';
 
 interface PhasePreset {
   provider: ExecutorModel;
@@ -15,6 +22,7 @@ export interface ModelConfigPreset {
   key: ModelConfigPresetKey;
   label: string;
   description: string;
+  appliesTo: ModelPresetScope;
   phases: Record<ResolvedPhaseModel, PhasePreset>;
   prdRewrite: {
     cli: AppSettings['prdRewriteCli'];
@@ -73,6 +81,7 @@ export const MODEL_CONFIG_PRESETS: readonly ModelConfigPreset[] = [
     key: 'claude',
     label: 'Claude',
     description: 'Anthropic across planning, review, execution, and verification.',
+    appliesTo: 'all',
     phases: {
       planner: makePhasePreset('claude', CLAUDE_MODEL_IDS.sonnet46, 'planner'),
       reviewer: makePhasePreset('claude', CLAUDE_MODEL_IDS.sonnet46, 'reviewer'),
@@ -89,6 +98,7 @@ export const MODEL_CONFIG_PRESETS: readonly ModelConfigPreset[] = [
     key: 'codex',
     label: 'Codex',
     description: 'OpenAI across planning, review, execution, and verification.',
+    appliesTo: 'all',
     phases: {
       planner: makePhasePreset('codex', SHARED_PHASE_MODELS.codex, 'planner'),
       reviewer: makePhasePreset('codex', SHARED_PHASE_MODELS.codex, 'reviewer'),
@@ -105,6 +115,7 @@ export const MODEL_CONFIG_PRESETS: readonly ModelConfigPreset[] = [
     key: 'hybrid',
     label: 'Hybrid',
     description: 'Claude plans, Codex reviews, executes, and verifies.',
+    appliesTo: 'all',
     phases: {
       planner: makePhasePreset('claude', SHARED_PHASE_MODELS.claude, 'planner'),
       reviewer: makePhasePreset('codex', SHARED_PHASE_MODELS.codex, 'reviewer'),
@@ -117,7 +128,35 @@ export const MODEL_CONFIG_PRESETS: readonly ModelConfigPreset[] = [
       reasoningEffort: 'none',
     },
   },
+  {
+    // Budget combo: Opus 4.8 plans on the Claude subscription (the one step
+    // that benefits from deep reasoning), then GPT-5.5 reviews + executes and
+    // GPT-5.4 Mini verifies — keeping the token-heavy lanes off the Claude
+    // weekly quota. Project-scoped because the Opus/Mini model ids are only
+    // honored through per-project overrides (the global path pins the model).
+    key: 'opus-combo',
+    label: 'Opus combo',
+    description: 'Opus 4.8 plans, GPT-5.5 reviews and executes, GPT-5.4 Mini verifies.',
+    appliesTo: 'project',
+    phases: {
+      planner: makePhasePreset('claude', CLAUDE_MODEL_IDS.opus48, 'planner'),
+      reviewer: makePhasePreset('codex', SHARED_PHASE_MODELS.codex, 'reviewer'),
+      executor: makePhasePreset('codex', SHARED_PHASE_MODELS.codex, 'executor'),
+      verifier: makePhasePreset('codex', CODEX_FALLBACK_MODEL_IDS.gpt54Mini, 'verifier'),
+    },
+    prdRewrite: {
+      cli: 'codex',
+      modelId: SHARED_PRD_MODELS.codex,
+      reasoningEffort: 'low',
+    },
+  },
 ] as const;
+
+// Presets offered in the global settings preset picker. Project-scoped presets
+// (whose per-phase model ids only resolve through project overrides) are
+// excluded so the global picker never silently applies a pinned-model downgrade.
+export const GLOBAL_MODEL_CONFIG_PRESETS: readonly ModelConfigPreset[] =
+  MODEL_CONFIG_PRESETS.filter((preset) => preset.appliesTo === 'all');
 
 const PRESET_BY_KEY = Object.fromEntries(
   MODEL_CONFIG_PRESETS.map((preset) => [preset.key, preset]),


### PR DESCRIPTION
Re-lands S2 (closes #260). The original PR #265 was auto-closed when its base branch was deleted during the stack merge; this cherry-picks the same S2 commit onto clean master (which now has S1's opus48).

Opt-in 'Opus combo' preset: Opus 4.8 plans, GPT-5.5 reviews/executes, GPT-5.4 Mini verifies. Project-scoped (hidden from global picker to avoid a pinned-Sonnet footgun). No default change.

Verified: shared preset tests 5 passed; typecheck shared+desktop clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new project-only model preset, **opus-combo**, with tailored model selections for different workflow phases.
  * Updated the model preset picker to show only presets meant for general use, improving the options list.

* **Bug Fixes**
  * Preset selection now correctly distinguishes between global and project-specific presets.
  * Model resolution for the new preset is covered end-to-end to ensure consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->