### PR TITLE
Persist workflow steering turns

### DIFF
--- a/apps/desktop/src/main/ipc/register-pipeline-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/register-pipeline-handlers.test.ts
@@ -200,6 +200,10 @@ describe('registerPipelineHandlers', () => {
     promptTelemetry: {
       listByThread: ReturnType<typeof vi.fn>;
     };
+    agentConversations: {
+      insert: ReturnType<typeof vi.fn>;
+      listByThread: ReturnType<typeof vi.fn>;
+    };
     pipelineAnalytics: {
       getOverview: ReturnType<typeof vi.fn>;
       getThread: ReturnType<typeof vi.fn>;
@@ -372,6 +376,10 @@ describe('registerPipelineHandlers', () => {
         listByThread: vi.fn(() => []),
       },
       promptTelemetry: {
+        listByThread: vi.fn(() => []),
+      },
+      agentConversations: {
+        insert: vi.fn(() => ({ id: 'conversation-1' })),
         listByThread: vi.fn(() => []),
       },
       pipelineAnalytics: {
@@ -2080,6 +2088,14 @@ describe('registerPipelineHandlers', () => {
         'proc-1',
         '\n\n[USER INSTRUCTION]: Use the shared helper.\n\n',
       );
+      expect(queries.agentConversations.insert).toHaveBeenCalledWith({
+        threadId: 'thread-1',
+        runId: null,
+        phase: 'steering',
+        speaker: 'human',
+        role: 'prompt',
+        content: 'Use the shared helper.',
+      });
       expect(queries.terminalEvents.create).toHaveBeenCalledWith('thread-1', {
         kind: 'user_input',
         content: 'Use the shared helper.',
@@ -2087,7 +2103,7 @@ describe('registerPipelineHandlers', () => {
       expect(mainWindow.webContents.send).toHaveBeenCalledWith('terminal:event', createdEvent);
     });
 
-    it('returns stale when the thread is no longer executing', () => {
+    it('queues steering when the thread is active but not executing', () => {
       queries.threads.getById.mockReturnValue(makeThread({ status: 'reviewing' }));
       pipeline.listActive.mockReturnValue([]);
 
@@ -2096,15 +2112,27 @@ describe('registerPipelineHandlers', () => {
 
       expect(handler(undefined, { threadId: 'thread-1', instruction: 'Try this' })).toEqual({
         threadId: 'thread-1',
-        status: 'stale',
-        message: 'Task is not currently executing. Current phase: reviewing.',
+        status: 'queued',
+        message: 'Instruction saved for the next model turn. Current phase: reviewing.',
         processId: null,
       });
+      expect(queries.agentConversations.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: 'thread-1',
+          phase: 'steering',
+          speaker: 'human',
+          role: 'prompt',
+          content: 'Try this',
+        }),
+      );
       expect(processManager.write).not.toHaveBeenCalled();
-      expect(queries.terminalEvents.create).not.toHaveBeenCalled();
+      expect(queries.terminalEvents.create).toHaveBeenCalledWith('thread-1', {
+        kind: 'user_input',
+        content: 'Try this',
+      });
     });
 
-    it('rejects steering for non-Claude executor transports', () => {
+    it('queues steering for non-Claude executor transports', () => {
       queries.threads.getById.mockReturnValue(makeThread({ status: 'executing' }));
       pipeline.listActive.mockReturnValue([
         {
@@ -2127,11 +2155,21 @@ describe('registerPipelineHandlers', () => {
 
       expect(handler(undefined, { threadId: 'thread-1', instruction: 'Try this' })).toEqual({
         threadId: 'thread-1',
-        status: 'rejected',
-        message: 'Mid-execution steering currently supports Claude executor sessions only.',
+        status: 'queued',
+        message:
+          'Instruction saved for the next model turn. Live stdin delivery supports Claude executor sessions only.',
         processId: 'proc-1',
       });
       expect(processManager.write).not.toHaveBeenCalled();
+      expect(queries.agentConversations.insert).toHaveBeenCalledWith(
+        expect.objectContaining({
+          threadId: 'thread-1',
+          phase: 'steering',
+          speaker: 'human',
+          role: 'prompt',
+          content: 'Try this',
+        }),
+      );
     });
   });
 

--- a/apps/desktop/src/main/ipc/register-pipeline-handlers.ts
+++ b/apps/desktop/src/main/ipc/register-pipeline-handlers.ts
@@ -513,7 +513,7 @@ export function registerPipelineHandlers({
       { threadId, instruction }: { threadId: string; instruction: string },
     ): {
       threadId: string;
-      status: 'delivered' | 'stale' | 'rejected';
+      status: 'delivered' | 'queued' | 'stale' | 'rejected';
       message: string;
       processId: string | null;
     } => {
@@ -530,12 +530,32 @@ export function registerPipelineHandlers({
       const thread = queries.threads.getById(threadId);
       if (!thread) throw new Error(`Thread ${threadId} not found`);
 
+      try {
+        queries.agentConversations.insert({
+          threadId,
+          runId: thread.currentRunId ?? null,
+          phase: 'steering',
+          speaker: 'human',
+          role: 'prompt',
+          content: text,
+        });
+      } catch {
+        return {
+          threadId,
+          status: 'rejected',
+          message: 'Instruction could not be saved to the conversation thread.',
+          processId: null,
+        };
+      }
+
+      emitTerminalEvent(threadId, { kind: 'user_input', content: text });
+
       const active = pipeline.listActive().find((summary) => summary.threadId === threadId);
       if (!active || active.phase !== PIPELINE_PHASE.executing) {
         return {
           threadId,
-          status: 'stale',
-          message: `Task is not currently executing. Current phase: ${thread.status}.`,
+          status: 'queued',
+          message: `Instruction saved for the next model turn. Current phase: ${thread.status}.`,
           processId: null,
         };
       }
@@ -547,8 +567,9 @@ export function registerPipelineHandlers({
       if (liveProcess?.state !== 'running') {
         return {
           threadId,
-          status: 'stale',
-          message: 'Executor process is no longer running.',
+          status: 'queued',
+          message:
+            'Instruction saved for the next model turn. Executor process is no longer running.',
           processId: liveProcess?.id ?? active.activeProcessId ?? null,
         };
       }
@@ -556,8 +577,9 @@ export function registerPipelineHandlers({
       if (liveProcess.type !== 'claude') {
         return {
           threadId,
-          status: 'rejected',
-          message: 'Mid-execution steering currently supports Claude executor sessions only.',
+          status: 'queued',
+          message:
+            'Instruction saved for the next model turn. Live stdin delivery supports Claude executor sessions only.',
           processId: liveProcess.id,
         };
       }
@@ -566,13 +588,13 @@ export function registerPipelineHandlers({
       if (!delivered) {
         return {
           threadId,
-          status: 'rejected',
-          message: 'Executor stdin is no longer writable.',
+          status: 'queued',
+          message:
+            'Instruction saved for the next model turn. Executor stdin is no longer writable.',
           processId: liveProcess.id,
         };
       }
 
-      emitTerminalEvent(threadId, { kind: 'user_input', content: text });
       return {
         threadId,
         status: 'delivered',

--- a/apps/desktop/src/main/ipc/register-pipeline-handlers.ts
+++ b/apps/desktop/src/main/ipc/register-pipeline-handlers.ts
@@ -539,7 +539,8 @@ export function registerPipelineHandlers({
           role: 'prompt',
           content: text,
         });
-      } catch {
+      } catch (error) {
+        console.error('[ipc] pipeline:steer-execution failed to persist steering turn', error);
         return {
           threadId,
           status: 'rejected',

--- a/apps/desktop/src/renderer/components/issue-detail/ConsoleTab.test.tsx
+++ b/apps/desktop/src/renderer/components/issue-detail/ConsoleTab.test.tsx
@@ -1,7 +1,9 @@
 // @vitest-environment jsdom
 
 import '@testing-library/jest-dom/vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import type { ComponentProps } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ConsoleTab } from './ConsoleTab';
 
@@ -10,6 +12,31 @@ vi.mock('../terminal-transcript/ThreadConsoleTranscript', () => ({
 }));
 
 const invokeMock = vi.fn<(channel: string, args?: unknown) => Promise<unknown>>();
+
+function renderConsoleTab(props: ComponentProps<typeof ConsoleTab>) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  const view = render(
+    <QueryClientProvider client={queryClient}>
+      <ConsoleTab {...props} />
+    </QueryClientProvider>,
+  );
+
+  return {
+    ...view,
+    rerenderConsoleTab: (nextProps: ComponentProps<typeof ConsoleTab>) =>
+      view.rerender(
+        <QueryClientProvider client={queryClient}>
+          <ConsoleTab {...nextProps} />
+        </QueryClientProvider>,
+      ),
+  };
+}
 
 beforeEach(() => {
   window.shipcode ??= {} as typeof window.shipcode;
@@ -28,38 +55,40 @@ afterEach(() => {
 });
 
 describe('ConsoleTab steering', () => {
-  it('shows the steering input only while the thread is executing', () => {
-    const { rerender } = render(
-      <ConsoleTab
-        activeThreadId="thread-1"
-        approvedAwaitingExecution={false}
-        threadPhase="reviewing"
-      />,
-    );
+  it('shows the steering input while the workflow can receive steering', () => {
+    const { rerenderConsoleTab } = renderConsoleTab({
+      activeThreadId: 'thread-1',
+      approvedAwaitingExecution: false,
+      threadPhase: 'reviewing',
+    });
 
-    expect(screen.queryByRole('textbox', { name: 'Steer executor' })).not.toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'Steer workflow' })).toBeInTheDocument();
 
-    rerender(
-      <ConsoleTab
-        activeThreadId="thread-1"
-        approvedAwaitingExecution={false}
-        threadPhase="executing"
-      />,
-    );
+    rerenderConsoleTab({
+      activeThreadId: 'thread-1',
+      approvedAwaitingExecution: false,
+      threadPhase: 'completed',
+    });
 
-    expect(screen.getByRole('textbox', { name: 'Steer executor' })).toBeInTheDocument();
+    expect(screen.queryByRole('textbox', { name: 'Steer workflow' })).not.toBeInTheDocument();
+
+    rerenderConsoleTab({
+      activeThreadId: 'thread-1',
+      approvedAwaitingExecution: false,
+      threadPhase: 'executing',
+    });
+
+    expect(screen.getByRole('textbox', { name: 'Steer workflow' })).toBeInTheDocument();
   });
 
   it('sends steering instructions to the running executor', async () => {
-    render(
-      <ConsoleTab
-        activeThreadId="thread-1"
-        approvedAwaitingExecution={false}
-        threadPhase="executing"
-      />,
-    );
+    renderConsoleTab({
+      activeThreadId: 'thread-1',
+      approvedAwaitingExecution: false,
+      threadPhase: 'executing',
+    });
 
-    fireEvent.change(screen.getByRole('textbox', { name: 'Steer executor' }), {
+    fireEvent.change(screen.getByRole('textbox', { name: 'Steer workflow' }), {
       target: { value: 'Focus on the IPC receipt state.' },
     });
     fireEvent.click(screen.getByRole('button', { name: 'Send steering instruction' }));

--- a/apps/desktop/src/renderer/components/issue-detail/ConsoleTab.tsx
+++ b/apps/desktop/src/renderer/components/issue-detail/ConsoleTab.tsx
@@ -1,5 +1,7 @@
 import type { PipelinePhase } from '@shipcode/shared';
+import { PIPELINE_PHASE } from '@shipcode/shared';
 import { Button, Textarea } from '@shipshitdev/ui';
+import { useQueryClient } from '@tanstack/react-query';
 import { SendHorizontal } from 'lucide-react';
 import { useCallback, useState } from 'react';
 import { toast } from '../../stores/toast-store';
@@ -11,14 +13,31 @@ interface ConsoleTabProps {
   threadPhase: PipelinePhase | 'idle';
 }
 
+const STEERABLE_PHASES = new Set<PipelinePhase>([
+  PIPELINE_PHASE.planning,
+  PIPELINE_PHASE.clarifying,
+  PIPELINE_PHASE.reviewing,
+  PIPELINE_PHASE.revising,
+  PIPELINE_PHASE.approval,
+  PIPELINE_PHASE.executing,
+  PIPELINE_PHASE.testing,
+  PIPELINE_PHASE.verifying,
+  PIPELINE_PHASE.shipping,
+  PIPELINE_PHASE.paused,
+]);
+
 export function ConsoleTab({
   activeThreadId,
   approvedAwaitingExecution,
   threadPhase,
 }: ConsoleTabProps) {
+  const queryClient = useQueryClient();
   const [instruction, setInstruction] = useState('');
   const [isSending, setIsSending] = useState(false);
-  const canSteer = activeThreadId !== null && threadPhase === 'executing';
+  const canSteer =
+    activeThreadId !== null &&
+    threadPhase !== 'idle' &&
+    STEERABLE_PHASES.has(threadPhase as PipelinePhase);
 
   const handleSubmit = useCallback(async () => {
     if (!activeThreadId || isSending) return;
@@ -28,7 +47,7 @@ export function ConsoleTab({
     setIsSending(true);
     try {
       const result = await window.shipcode.invoke<{
-        status: 'delivered' | 'stale' | 'rejected';
+        status: 'delivered' | 'queued' | 'stale' | 'rejected';
         message: string;
       }>('pipeline:steer-execution', {
         threadId: activeThreadId,
@@ -37,6 +56,11 @@ export function ConsoleTab({
       if (result.status === 'delivered') {
         setInstruction('');
         toast.success('Instruction delivered');
+        queryClient.invalidateQueries({ queryKey: ['agent-conversations', activeThreadId] });
+      } else if (result.status === 'queued') {
+        setInstruction('');
+        toast.success('Instruction saved', result.message);
+        queryClient.invalidateQueries({ queryKey: ['agent-conversations', activeThreadId] });
       } else {
         toast.error(
           result.status === 'stale' ? 'Instruction stale' : 'Instruction rejected',
@@ -48,7 +72,7 @@ export function ConsoleTab({
     } finally {
       setIsSending(false);
     }
-  }, [activeThreadId, instruction, isSending]);
+  }, [activeThreadId, instruction, isSending, queryClient]);
 
   if (!activeThreadId) {
     return (
@@ -70,11 +94,11 @@ export function ConsoleTab({
         <div className="border-t border-border bg-elevated/95 p-3">
           <div className="flex items-end gap-2">
             <Textarea
-              aria-label="Steer executor"
+              aria-label="Steer workflow"
               value={instruction}
               rows={2}
               className="min-h-[44px] flex-1 resize-none font-mono text-[12px]"
-              placeholder="Inject an instruction into the running executor..."
+              placeholder="Add a steering instruction..."
               disabled={isSending}
               onChange={(event) => setInstruction(event.target.value)}
               onKeyDown={(event) => {

--- a/apps/desktop/src/renderer/components/issue-detail/ConversationsTab.tsx
+++ b/apps/desktop/src/renderer/components/issue-detail/ConversationsTab.tsx
@@ -12,16 +12,26 @@ const PHASE_COLORS: Record<string, string> = {
   execute: 'bg-green-500/15 text-green-400',
   verify: 'bg-cyan-500/15 text-cyan-400',
   issue_chat: 'bg-sky-500/15 text-sky-400',
+  steering: 'bg-rose-500/15 text-rose-400',
 };
 
 const SPEAKER_COLORS: Record<string, string> = {
   pipeline: 'bg-zinc-500/15 text-zinc-400',
+  human: 'bg-rose-500/15 text-rose-400',
   claude: 'bg-orange-500/15 text-orange-400',
   codex: 'bg-emerald-500/15 text-emerald-400',
   openrouter: 'bg-violet-500/15 text-violet-400',
 };
 
-const ALL_PHASES = ['plan', 'review', 'revision', 'execute', 'verify', 'issue_chat'] as const;
+const ALL_PHASES = [
+  'plan',
+  'review',
+  'revision',
+  'execute',
+  'verify',
+  'steering',
+  'issue_chat',
+] as const;
 const COLLAPSE_LINE_THRESHOLD = 30;
 type GithubPostState = 'hidden' | 'idle' | 'posting' | 'posted';
 

--- a/packages/pipeline/src/pipeline/runtime.test.ts
+++ b/packages/pipeline/src/pipeline/runtime.test.ts
@@ -189,6 +189,7 @@ function makeDeps(provider?: AgentProvider) {
     },
     agentConversations: {
       insert: vi.fn(() => ({ id: 'conv-1' })),
+      listByThread: vi.fn(() => []),
     },
   } as unknown as PipelineDeps;
 
@@ -979,6 +980,68 @@ describe('createPipelineRuntime', () => {
     );
     expect(deps.promptTelemetry?.create).toHaveBeenCalledWith(
       expect.objectContaining({ threadId: 'thread-1', runId: 'run-1', phase: 'plan' }),
+    );
+  });
+
+  it('appends human steering turns to provider prompts', async () => {
+    const provider: AgentProvider = {
+      id: 'claude-cli',
+      supports: new Set(['plan']),
+      generate: vi.fn(async () => ({
+        rawOutput: 'done',
+        exitCode: 0,
+      })),
+      healthCheck: vi.fn(async () => ({ ok: true })),
+    };
+    const { deps } = makeDeps(provider);
+    const agentConversations = deps.agentConversations as NonNullable<
+      PipelineDeps['agentConversations']
+    >;
+    vi.mocked(agentConversations.listByThread).mockReturnValue([
+      {
+        id: 'steer-1',
+        threadId: 'thread-1',
+        runId: 'run-1',
+        phase: 'steering',
+        round: 0,
+        speaker: 'human',
+        role: 'prompt',
+        parentId: null,
+        provider: null,
+        model: null,
+        content: 'Prefer the shared IPC helper.',
+        tokensIn: null,
+        tokensOut: null,
+        costUsd: null,
+        createdAt: '2026-07-06T10:00:00.000Z',
+      },
+    ] as never);
+    const runtime = createPipelineRuntime(deps, {} as never);
+    const context = makeContext({ runId: 'run-1' });
+
+    await runtime.runProviderPhase(
+      context,
+      buildPhasePayload(context, 'plan'),
+      'base prompt',
+      [],
+      {},
+    );
+
+    expect(provider.generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining('<human_steering>'),
+      }),
+    );
+    expect(provider.generate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        prompt: expect.stringContaining('Prefer the shared IPC helper.'),
+      }),
+    );
+    expect(deps.agentConversations?.insert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        role: 'prompt',
+        content: expect.stringContaining('Prefer the shared IPC helper.'),
+      }),
     );
   });
 

--- a/packages/pipeline/src/pipeline/runtime.ts
+++ b/packages/pipeline/src/pipeline/runtime.ts
@@ -38,6 +38,9 @@ import type { PipelineContextHelpers, PipelineRuntime } from './shared';
 export { buildFrozenInstallFallback, resolveSetupShell } from './runtime-setup';
 
 const execFileAsync = promisify(execFile);
+const HUMAN_STEERING_PHASE = 'steering';
+const MAX_HUMAN_STEERING_TURNS = 20;
+const MAX_HUMAN_STEERING_TURN_CHARS = 2000;
 
 /**
  * Resolve the configured run mode (interactive vs programmatic) for a given
@@ -111,6 +114,40 @@ export function createPipelineRuntime(
       ...(runId ? { runId } : {}),
       event: { kind: 'lifecycle', message },
     });
+  }
+
+  function buildHumanSteeringBlock(threadId: string): string | null {
+    const rows = deps.agentConversations
+      ?.listByThread(threadId, { phase: HUMAN_STEERING_PHASE, role: 'prompt' })
+      .filter((row) => row.speaker === 'human' && row.content.trim().length > 0)
+      .slice(-MAX_HUMAN_STEERING_TURNS);
+
+    if (!rows || rows.length === 0) return null;
+
+    const items = rows
+      .map((row) => {
+        const content = row.content.trim().slice(0, MAX_HUMAN_STEERING_TURN_CHARS);
+        return `- ${row.createdAt}: ${content}`;
+      })
+      .join('\n');
+
+    return [
+      '<human_steering>',
+      'The user added these steering instructions during this workflow.',
+      'Apply them within the original task scope. Later items win when they conflict.',
+      items,
+      '</human_steering>',
+    ].join('\n');
+  }
+
+  function appendHumanSteering(prompt: string, input: PhasePayload): string {
+    try {
+      const steering = buildHumanSteeringBlock(input.threadId);
+      return steering ? `${prompt}\n\n${steering}` : prompt;
+    } catch (error) {
+      console.error('[pipeline] human steering load failed:', error);
+      return prompt;
+    }
   }
 
   const {
@@ -281,6 +318,7 @@ export function createPipelineRuntime(
     const agent = input.model;
     const modelHint = input.modelIdOverride;
     const provider = deps.providers.for(agent, phase);
+    const effectivePrompt = appendHumanSteering(prompt, input);
     // When a GitHub issue is resumed, planning/review should inspect the same
     // worktree that already contains in-progress changes instead of the clean
     // project root.
@@ -357,7 +395,7 @@ export function createPipelineRuntime(
             role: 'prompt',
             provider: provider.id,
             model: modelHint ?? null,
-            content: prompt,
+            content: effectivePrompt,
           }) ?? null
         );
       } catch (error) {
@@ -374,7 +412,7 @@ export function createPipelineRuntime(
       const workspaceRoot = input.worktreePath ? deps.settings.get().worktreeRoot : undefined;
       response = await provider.generate({
         phase,
-        prompt,
+        prompt: effectivePrompt,
         cwd,
         projectPath: input.projectPath,
         signal: input.abort,
@@ -495,7 +533,7 @@ export function createPipelineRuntime(
 
     const promptTelemetry = measurePhasePromptTelemetry({
       phase,
-      prompt,
+      prompt: effectivePrompt,
       materials: promptMaterials,
     });
     // Mutation delta, applied to context by the caller. The "+ 1" reproduces

--- a/packages/shared/src/ipc-channels.ts
+++ b/packages/shared/src/ipc-channels.ts
@@ -218,7 +218,7 @@ export interface IpcInvokeChannels {
     args: { threadId: string; instruction: string };
     result: {
       threadId: string;
-      status: 'delivered' | 'stale' | 'rejected';
+      status: 'delivered' | 'queued' | 'stale' | 'rejected';
       message: string;
       processId: string | null;
     };


### PR DESCRIPTION
## Summary
- persist Console steering input as human `agent_conversations` turns
- append recent human steering turns to every provider prompt so Claude/Codex/OpenRouter can honor them on the next model turn
- widen Console steering beyond execution and show steering turns in the Conversations tab

## Verification
- `bunx biome check apps/desktop/src/main/ipc/register-pipeline-handlers.ts apps/desktop/src/main/ipc/register-pipeline-handlers.test.ts apps/desktop/src/renderer/components/issue-detail/ConsoleTab.tsx apps/desktop/src/renderer/components/issue-detail/ConsoleTab.test.tsx apps/desktop/src/renderer/components/issue-detail/ConversationsTab.tsx packages/pipeline/src/pipeline/runtime.ts packages/pipeline/src/pipeline/runtime.test.ts packages/shared/src/ipc-channels.ts --assist-enabled=false --files-ignore-unknown=true`
- `git diff --check`

Focused Vitest files were attempted locally, but this checkout's package Vitest configs resolve workspace packages through built `dist` exports; local `dist` was absent. Per repo guidance, package build/test should run in PR CI rather than local full build gates.