### PR TITLE
fix: preserve raw_output in v27, harden worktreeHasChanges, fix sidebar resize leak (#317)

### DIFF
--- a/apps/desktop/src/renderer/components/ProjectSidebar.test.tsx
+++ b/apps/desktop/src/renderer/components/ProjectSidebar.test.tsx
@@ -717,6 +717,39 @@ describe('ProjectSidebar', () => {
     expect(document.body).not.toHaveClass('cursor-col-resize', 'select-none');
   });
 
+  it('cleans up active resize listeners and body classes on unmount', async () => {
+    mockSidebarData(invokeMock);
+    const addListenerSpy = vi.spyOn(document, 'addEventListener');
+    const removeListenerSpy = vi.spyOn(document, 'removeEventListener');
+    const { unmount } = renderWithProviders();
+
+    const resizeHandle = await screen.findByRole('button', { name: 'Resize project sidebar' });
+    addListenerSpy.mockClear();
+    removeListenerSpy.mockClear();
+
+    fireEvent.mouseDown(resizeHandle, { clientX: 256 });
+
+    const mouseMoveListener = addListenerSpy.mock.calls.find(([type]) => type === 'mousemove')?.[1];
+    const mouseUpListener = addListenerSpy.mock.calls.find(([type]) => type === 'mouseup')?.[1];
+    expect(mouseMoveListener).toBeDefined();
+    expect(mouseUpListener).toBeDefined();
+    expect(document.body).toHaveClass('cursor-col-resize', 'select-none');
+
+    unmount();
+
+    expect(
+      removeListenerSpy.mock.calls.some(
+        ([type, listener]) => type === 'mousemove' && listener === mouseMoveListener,
+      ),
+    ).toBe(true);
+    expect(
+      removeListenerSpy.mock.calls.some(
+        ([type, listener]) => type === 'mouseup' && listener === mouseUpListener,
+      ),
+    ).toBe(true);
+    expect(document.body).not.toHaveClass('cursor-col-resize', 'select-none');
+  });
+
   it('handles missing project relink, pin, archive, remove confirmation, and unavailable open target', async () => {
     const missingProject: Project = {
       ...project,

--- a/apps/desktop/src/renderer/components/ProjectSidebar.tsx
+++ b/apps/desktop/src/renderer/components/ProjectSidebar.tsx
@@ -225,6 +225,7 @@ function useProjectSidebarView() {
 
   const [sidebarWidth, setSidebarWidth] = useState(SIDEBAR_DEFAULT);
   const dragRef = useRef<{ startX: number; startW: number } | null>(null);
+  const resizeCleanupRef = useRef<(() => void) | null>(null);
 
   useEffect(() => {
     const unsubFire = window.shipcode.on('notification:fire', () => {
@@ -242,6 +243,8 @@ function useProjectSidebarView() {
   const handleResizeMouseDown = useCallback(
     (e: React.MouseEvent) => {
       e.preventDefault();
+      resizeCleanupRef.current?.();
+      resizeCleanupRef.current = null;
       dragRef.current = { startX: e.clientX, startW: sidebarWidth };
       const onMove = (ev: MouseEvent) => {
         const drag = dragRef.current;
@@ -250,18 +253,31 @@ function useProjectSidebarView() {
         const next = Math.min(SIDEBAR_MAX, Math.max(SIDEBAR_MIN, drag.startW + delta));
         setSidebarWidth(next);
       };
-      const onUp = () => {
-        dragRef.current = null;
+      const cleanupResizeDrag = () => {
         document.removeEventListener('mousemove', onMove);
         document.removeEventListener('mouseup', onUp);
         document.body.classList.remove('cursor-col-resize', 'select-none');
       };
+      const onUp = () => {
+        dragRef.current = null;
+        cleanupResizeDrag();
+        resizeCleanupRef.current = null;
+      };
       document.addEventListener('mousemove', onMove);
       document.addEventListener('mouseup', onUp);
       document.body.classList.add('cursor-col-resize', 'select-none');
+      resizeCleanupRef.current = cleanupResizeDrag;
     },
     [sidebarWidth],
   );
+
+  useEffect(() => {
+    return () => {
+      resizeCleanupRef.current?.();
+      resizeCleanupRef.current = null;
+      dragRef.current = null;
+    };
+  }, []);
 
   // Pinned projects always float to top and remain alphabetical; unpinned
   // projects keep the user's selected sort order.

--- a/apps/desktop/src/renderer/components/issue-detail/useResizableDetailSidebar.test.tsx
+++ b/apps/desktop/src/renderer/components/issue-detail/useResizableDetailSidebar.test.tsx
@@ -1,0 +1,64 @@
+import '@testing-library/jest-dom/vitest';
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useResizableDetailSidebar } from './useResizableDetailSidebar';
+
+afterEach(() => {
+  cleanup();
+  document.body.classList.remove('cursor-col-resize', 'select-none');
+  vi.restoreAllMocks();
+});
+
+function mouseDownEvent(clientX: number) {
+  return { preventDefault: vi.fn(), clientX } as unknown as React.MouseEvent;
+}
+
+describe('useResizableDetailSidebar', () => {
+  it('cleans up active resize listeners and body classes on unmount mid-drag', () => {
+    const addListenerSpy = vi.spyOn(document, 'addEventListener');
+    const removeListenerSpy = vi.spyOn(document, 'removeEventListener');
+    const { result, unmount } = renderHook(() => useResizableDetailSidebar());
+
+    act(() => {
+      result.current.handleDetailResizeMouseDown(mouseDownEvent(400));
+    });
+
+    const mouseMoveListener = addListenerSpy.mock.calls.find(([type]) => type === 'mousemove')?.[1];
+    const mouseUpListener = addListenerSpy.mock.calls.find(([type]) => type === 'mouseup')?.[1];
+    expect(mouseMoveListener).toBeDefined();
+    expect(mouseUpListener).toBeDefined();
+    expect(document.body).toHaveClass('cursor-col-resize', 'select-none');
+
+    unmount();
+
+    expect(
+      removeListenerSpy.mock.calls.some(
+        ([type, listener]) => type === 'mousemove' && listener === mouseMoveListener,
+      ),
+    ).toBe(true);
+    expect(
+      removeListenerSpy.mock.calls.some(
+        ([type, listener]) => type === 'mouseup' && listener === mouseUpListener,
+      ),
+    ).toBe(true);
+    expect(document.body).not.toHaveClass('cursor-col-resize', 'select-none');
+  });
+
+  it('does not leak listeners across repeated mousedown starts', () => {
+    const removeListenerSpy = vi.spyOn(document, 'removeEventListener');
+    const { result, unmount } = renderHook(() => useResizableDetailSidebar());
+
+    act(() => {
+      result.current.handleDetailResizeMouseDown(mouseDownEvent(400));
+    });
+    act(() => {
+      result.current.handleDetailResizeMouseDown(mouseDownEvent(420));
+    });
+
+    // Starting a second drag tears down the first drag's listeners.
+    expect(removeListenerSpy.mock.calls.some(([type]) => type === 'mousemove')).toBe(true);
+
+    unmount();
+    expect(document.body).not.toHaveClass('cursor-col-resize', 'select-none');
+  });
+});

--- a/apps/desktop/src/renderer/components/issue-detail/useResizableDetailSidebar.ts
+++ b/apps/desktop/src/renderer/components/issue-detail/useResizableDetailSidebar.ts
@@ -1,4 +1,10 @@
-import { type MouseEvent as ReactMouseEvent, useCallback, useRef, useState } from 'react';
+import {
+  type MouseEvent as ReactMouseEvent,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 
 export const DETAIL_SIDEBAR_MIN = 320;
 export const DETAIL_SIDEBAR_MAX = 640;
@@ -7,10 +13,13 @@ const DETAIL_SIDEBAR_DEFAULT = 416; // matches previous w-[26rem]
 export function useResizableDetailSidebar() {
   const [detailSidebarWidth, setDetailSidebarWidth] = useState(DETAIL_SIDEBAR_DEFAULT);
   const detailDragRef = useRef<{ startX: number; startW: number } | null>(null);
+  const resizeCleanupRef = useRef<(() => void) | null>(null);
 
   const handleDetailResizeMouseDown = useCallback(
     (e: ReactMouseEvent) => {
       e.preventDefault();
+      resizeCleanupRef.current?.();
+      resizeCleanupRef.current = null;
       detailDragRef.current = { startX: e.clientX, startW: detailSidebarWidth };
 
       const onMove = (ev: MouseEvent) => {
@@ -24,19 +33,33 @@ export function useResizableDetailSidebar() {
         setDetailSidebarWidth(next);
       };
 
-      const onUp = () => {
-        detailDragRef.current = null;
+      const cleanupResizeDrag = () => {
         document.removeEventListener('mousemove', onMove);
         document.removeEventListener('mouseup', onUp);
         document.body.classList.remove('cursor-col-resize', 'select-none');
       };
 
+      const onUp = () => {
+        detailDragRef.current = null;
+        cleanupResizeDrag();
+        resizeCleanupRef.current = null;
+      };
+
       document.addEventListener('mousemove', onMove);
       document.addEventListener('mouseup', onUp);
       document.body.classList.add('cursor-col-resize', 'select-none');
+      resizeCleanupRef.current = cleanupResizeDrag;
     },
     [detailSidebarWidth],
   );
+
+  useEffect(() => {
+    return () => {
+      resizeCleanupRef.current?.();
+      resizeCleanupRef.current = null;
+      detailDragRef.current = null;
+    };
+  }, []);
 
   return { detailSidebarWidth, handleDetailResizeMouseDown };
 }

--- a/packages/db/src/migrations/v21-v40.ts
+++ b/packages/db/src/migrations/v21-v40.ts
@@ -141,22 +141,24 @@ export function migrateV27(db: DatabaseSync): void {
     const reviewFencePrefix = `\`\`\`${REVIEW_FENCE_TAG}\n`;
     const verificationFencePrefix = `\`\`\`${VERIFICATION_FENCE_TAG}\n`;
     const fenceSuffix = '\n```';
+    const rawStructuredSeparator = '\n\n';
+    const appendStructuredArtifact = (
+      table: 'plans' | 'reviews' | 'verifications',
+      fencePrefix: string,
+    ) => {
+      db.prepare(
+        `UPDATE ${table}
+            SET raw_output = CASE
+              WHEN COALESCE(raw_output, '') = '' THEN ? || structured || ?
+              ELSE raw_output || ? || ? || structured || ?
+            END
+          WHERE structured IS NOT NULL`,
+      ).run(fencePrefix, fenceSuffix, rawStructuredSeparator, fencePrefix, fenceSuffix);
+    };
 
-    db.prepare(
-      `UPDATE plans
-          SET raw_output = ? || structured || ?
-        WHERE structured IS NOT NULL`,
-    ).run(planFencePrefix, fenceSuffix);
-    db.prepare(
-      `UPDATE reviews
-          SET raw_output = ? || structured || ?
-        WHERE structured IS NOT NULL`,
-    ).run(reviewFencePrefix, fenceSuffix);
-    db.prepare(
-      `UPDATE verifications
-          SET raw_output = ? || structured || ?
-        WHERE structured IS NOT NULL`,
-    ).run(verificationFencePrefix, fenceSuffix);
+    appendStructuredArtifact('plans', planFencePrefix);
+    appendStructuredArtifact('reviews', reviewFencePrefix);
+    appendStructuredArtifact('verifications', verificationFencePrefix);
 
     db.prepare(
       `UPDATE plans

--- a/packages/db/src/schema.test.ts
+++ b/packages/db/src/schema.test.ts
@@ -658,6 +658,45 @@ describe('migrateV27', () => {
     expect(truncatedPlan.raw_output).toContain('suffix');
     expect(truncatedPlan.raw_output).toContain('[truncated historical raw_output]');
   });
+
+  it('preserves existing raw output when structured artifacts are fenced', () => {
+    db.prepare("INSERT INTO projects (id, name, path) VALUES ('p1', 'test', '/tmp/test')").run();
+    db.prepare(
+      "INSERT INTO threads (id, project_id, title, prompt) VALUES ('t1', 'p1', 'Issue', 'Prompt')",
+    ).run();
+
+    db.prepare(
+      `INSERT INTO plans (id, thread_id, version, raw_output, structured, status)
+       VALUES ('plan-raw', 't1', 1, 'planner transcript before JSON', '{"id":"p","threadId":"t1","version":1,"objective":"obj","files":[],"steps":[],"acceptanceCriteria":[],"outOfScope":[],"estimatedComplexity":"low","dependencies":[]}', 'draft')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO reviews (id, plan_id, decision, confidence, raw_output, structured)
+       VALUES ('review-raw', 'plan-raw', 'approve', 'high', 'reviewer transcript before JSON', '{"planId":"plan-raw","decision":"approve","confidence":"high","summary":"ok","findings":[],"suggestedChanges":[]}')`,
+    ).run();
+    db.prepare(
+      `INSERT INTO verifications (id, thread_id, plan_id, raw_output, structured, result, retry_count)
+       VALUES ('verification-raw', 't1', 'plan-raw', 'verifier transcript before JSON', '{"threadId":"t1","planId":"plan-raw","result":"passed","summary":"ok","criteriaResults":[],"issues":[]}', 'passed', 0)`,
+    ).run();
+
+    migrateV27(db);
+
+    const plan = db.prepare('SELECT raw_output FROM plans WHERE id = ?').get('plan-raw') as {
+      raw_output: string;
+    };
+    const review = db.prepare('SELECT raw_output FROM reviews WHERE id = ?').get('review-raw') as {
+      raw_output: string;
+    };
+    const verification = db
+      .prepare('SELECT raw_output FROM verifications WHERE id = ?')
+      .get('verification-raw') as { raw_output: string };
+
+    expect(plan.raw_output).toContain('planner transcript before JSON');
+    expect(plan.raw_output).toContain('```shipcode-plan');
+    expect(review.raw_output).toContain('reviewer transcript before JSON');
+    expect(review.raw_output).toContain('```shipcode-review');
+    expect(verification.raw_output).toContain('verifier transcript before JSON');
+    expect(verification.raw_output).toContain('```shipcode-verification');
+  });
 });
 
 describe('migrateV30', () => {

--- a/packages/pipeline/src/pipeline/execution-phase-utils.test.ts
+++ b/packages/pipeline/src/pipeline/execution-phase-utils.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PipelineContext } from '../types';
+import { worktreeHasChanges } from './execution-phase-utils';
+
+const { mockExecFileSync } = vi.hoisted(() => ({
+  mockExecFileSync: vi.fn(),
+}));
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:child_process')>();
+  return {
+    ...actual,
+    execFileSync: mockExecFileSync,
+  };
+});
+
+function makeContext(overrides: Partial<PipelineContext> = {}): PipelineContext {
+  return {
+    threadId: 'thread-1',
+    projectPath: '/repo',
+    worktreePath: '/repo-worktree',
+    forkPointSha: 'base',
+    baseBranch: 'main',
+    ...overrides,
+  } as PipelineContext;
+}
+
+describe('worktreeHasChanges', () => {
+  beforeEach(() => {
+    mockExecFileSync.mockReset();
+    vi.restoreAllMocks();
+  });
+
+  it('returns false for a clean worktree with no fork-point diff', () => {
+    mockExecFileSync.mockImplementation((_command: string, args: string[]) => {
+      if (args[0] === 'status') return '';
+      if (args[0] === 'rev-parse' && args[2] === 'base^{commit}') return 'base\n';
+      if (args[0] === 'diff') return '';
+      return '';
+    });
+
+    expect(worktreeHasChanges(makeContext())).toBe(false);
+  });
+
+  it('returns true for a dirty worktree', () => {
+    mockExecFileSync.mockImplementation((_command: string, args: string[]) => {
+      if (args[0] === 'status') return ' M src/a.ts\n';
+      return '';
+    });
+
+    expect(worktreeHasChanges(makeContext())).toBe(true);
+  });
+
+  it('logs probe failures and falls back to no confirmed changes', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('git unavailable\nfull stack should stay out of renderer-sized logs');
+    });
+
+    expect(worktreeHasChanges(makeContext())).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        '[pipeline] worktree change probe failed; treating as no confirmed changes',
+      ),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('git unavailable'));
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('full stack'));
+  });
+});

--- a/packages/pipeline/src/pipeline/execution-phase-utils.ts
+++ b/packages/pipeline/src/pipeline/execution-phase-utils.ts
@@ -212,9 +212,20 @@ export function worktreeHasChanges(context: PipelineContext): boolean {
     }
 
     return false;
-  } catch {
-    return true;
+  } catch (error) {
+    // A failed git probe is not evidence of a dirty tree; report no confirmed
+    // changes and leave the infrastructure failure visible in the process log.
+    const message = formatWorktreeProbeError(error);
+    console.warn(
+      `[pipeline] worktree change probe failed; treating as no confirmed changes for thread ${context.threadId}: ${message}`,
+    );
+    return false;
   }
+}
+
+function formatWorktreeProbeError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return message.split('\n')[0].slice(0, 280) || 'unknown error';
 }
 
 /**

--- a/packages/pipeline/src/pipeline/execution-phases.test.ts
+++ b/packages/pipeline/src/pipeline/execution-phases.test.ts
@@ -464,7 +464,7 @@ describe('execution phase helpers', () => {
     expect(extractImplicatedFiles('no test files mentioned')).toEqual([]);
   });
 
-  it('detects worktree changes from status, fork-point diff, and git failures', () => {
+  it('detects worktree changes from status and fork-point diff', () => {
     const context = {
       projectPath: '/project',
       worktreePath: '/worktree',
@@ -504,13 +504,6 @@ describe('execution phase helpers', () => {
         forkPointSha: '',
         baseBranch: 'main',
       } as PipelineContext),
-    ).toBe(true);
-
-    mockExecFileSync.mockImplementation(() => {
-      throw new Error('not a git repo');
-    });
-    expect(
-      worktreeHasChanges({ projectPath: '/project', forkPointSha: '' } as PipelineContext),
     ).toBe(true);
   });
 


### PR DESCRIPTION
## Summary
- Preserve existing `raw_output` in migration v27 when structured artifacts are fenced, with consistent append behavior for plans, reviews, and verifications.
- Harden `worktreeHasChanges` so git probe failures are logged and treated as no confirmed changes instead of dirty worktrees.
- Clean up ProjectSidebar resize listeners and body classes when the sidebar unmounts mid-drag.

## Tests
- Migration regression covers rows with both `raw_output` and `structured` populated so prior transcript content survives.
- Added focused `worktreeHasChanges` coverage for clean, dirty, and probe-failure paths.
- Added ProjectSidebar unmount cleanup coverage for active resize listeners and body classes.

Closes #317

## Focused commands run
- `bun --filter @shipcode/shared build`
- `bunx vitest run packages/db/src/schema.test.ts -t "preserves existing raw output"` (failed before fix, passed after fix)
- `bunx vitest run packages/pipeline/src/pipeline/execution-phase-utils.test.ts` (failed before fix, passed after fix)
- `bunx vitest run apps/desktop/src/renderer/components/ProjectSidebar.test.tsx -t "cleans up active resize listeners"` (failed before fix, passed after fix)
- `bunx vitest run packages/db/src/schema.test.ts`
- `bunx vitest run packages/pipeline/src/pipeline/execution-phase-utils.test.ts`
- `bun --filter @shipcode/agents build`
- `bun --filter @shipcode/git build`
- `bunx vitest run packages/pipeline/src/pipeline/execution-phases.test.ts -t "detects worktree changes"`
- `bunx vitest run apps/desktop/src/renderer/components/ProjectSidebar.test.tsx`
- `bunx biome check apps/desktop/src/renderer/components/ProjectSidebar.tsx apps/desktop/src/renderer/components/ProjectSidebar.test.tsx packages/db/src/migrations/v21-v40.ts packages/db/src/schema.test.ts packages/pipeline/src/pipeline/execution-phase-utils.ts packages/pipeline/src/pipeline/execution-phase-utils.test.ts packages/pipeline/src/pipeline/execution-phases.test.ts --assist-enabled=false`
- `bun --filter @shipcode/db typecheck`
- `bun --filter @shipcode/db build`
- `bun --filter @shipcode/pipeline typecheck`
- `bun --filter @shipcode/pipeline build`
- `bun --filter @shipcode/ui build`
- `bun --filter @shipcode/desktop typecheck`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved project sidebar resizing so drag listeners and temporary cursor/selection styles are always cleaned up, including when the panel is closed mid-resize.
  - Fixed a data migration edge case so existing text is preserved when structured content is added, without overwriting prior output.
  - Made change detection more reliable when version-control checks fail, avoiding false “dirty” states and reducing noisy error logging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->