### PR TITLE
chore: prepare 0.1.4 release

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipshitdev/shipcode",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Autonomous AI coding pipeline. GitHub issues in, pull requests out.",
   "type": "module",
   "repository": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -70,5 +70,5 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
-  "version": "0.1.3"
+  "version": "0.1.4"
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -20,5 +20,5 @@
     "coverage": "vitest run --coverage",
     "start": "next start"
   },
-  "version": "0.1.3"
+  "version": "0.1.4"
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/web",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3000",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/cli": {
       "name": "@shipshitdev/shipcode",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "bin": {
         "shipcode": "dist/index.js",
       },
@@ -42,7 +42,7 @@
     },
     "apps/desktop": {
       "name": "@shipcode/desktop",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.55",
         "@fontsource/dm-sans": "5.2.8",
@@ -94,7 +94,7 @@
     },
     "apps/docs": {
       "name": "@shipcode/docs",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@shipcode/ui": "workspace:*",
         "next": "16.2.7",
@@ -110,7 +110,7 @@
     },
     "apps/web": {
       "name": "@shipcode/web",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@shipcode/shared": "workspace:*",
         "@shipcode/ui": "workspace:*",
@@ -146,7 +146,7 @@
     },
     "packages/agents": {
       "name": "@shipcode/agents",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.55",
         "@shipcode/shared": "workspace:*",
@@ -160,7 +160,7 @@
     },
     "packages/db": {
       "name": "@shipcode/db",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@shipcode/shared": "workspace:*",
         "nanoid": "5.1.11",
@@ -171,7 +171,7 @@
     },
     "packages/git": {
       "name": "@shipcode/git",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@shipcode/shared": "workspace:*",
         "simple-git": "3.36.0",
@@ -182,7 +182,7 @@
     },
     "packages/pipeline": {
       "name": "@shipcode/pipeline",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@shipcode/agents": "workspace:*",
         "@shipcode/db": "workspace:*",
@@ -199,7 +199,7 @@
     },
     "packages/shared": {
       "name": "@shipcode/shared",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "zod": "4.4.3",
       },
@@ -209,7 +209,7 @@
     },
     "packages/ui": {
       "name": "@shipcode/ui",
-      "version": "0.1.3",
+      "version": "0.1.4",
       "dependencies": {
         "@dnd-kit/core": "6.3.1",
         "@radix-ui/react-dropdown-menu": "2.1.16",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/agents",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/db",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/git",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/pipeline",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/shared",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/ui",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "private": true,
   "description": "ShipCode-specific UI components for the ShipCode monorepo.",
   "type": "module",


### PR DESCRIPTION
Bumps all workspace packages `0.1.3` → `0.1.4` and refreshes `bun.lock`. Version-only change; no code touched.

## What v0.1.4 ships (since v0.1.3, cut 2026-06-29)

- **Workflow steering persistence** (#321) — Console steering saved as conversation turns and replayed into every provider prompt (Claude / Codex / OpenRouter); steering widened beyond the execute phase; turns visible in the Conversations tab.
- **Data-loss fix: migration v27** (#317) — `raw_output` is now preserved when structured artifacts are fenced instead of being overwritten. Ships in v0.1.3, so this stops the spread on any upgrade path.
- **`worktreeHasChanges` hardening** (#317) — a failed git probe no longer reads as a dirty worktree; the failure is logged (clamped) and treated as no confirmed changes.
- **Sidebar resize-listener leaks** (#317 + review follow-up) — both `ProjectSidebar` and the `useResizableDetailSidebar` hook now tear down `mousemove`/`mouseup` listeners and body classes on unmount mid-drag.

Docs/audit/memory-hygiene commits (#272, #273, #315, #316) are also included but change nothing at runtime.

## Orchestration
Opus 4.8 is fully wired (native Claude CLI + OpenRouter catalog + `opus` alias). This is the recommended orchestration target for the 2026-07-08 main-model switch.

## Release steps after merge
1. Tag `v0.1.4` on master.
2. Publish the GitHub release → `publish.yml` builds mac/linux installers, updates the Homebrew cask, publishes the CLI to npm, and deploys web.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated app and package versions from `0.1.3` to `0.1.4` across the workspace.
  * Applies to the CLI, desktop, docs, web, agents, database, git, pipeline, shared, and UI packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->