### PR TITLE
chore(agents): sync shared skills from skills library

### DIFF
--- a/.agents/skills/api-design-expert/SKILL.md
+++ b/.agents/skills/api-design-expert/SKILL.md
@@ -1,14 +1,12 @@
 ---
 name: api-design-expert
-description: Expert in RESTful API design, OpenAPI/Swagger documentation, versioning, error handling, and API best practices for NestJS applications
+description: Expert in RESTful API design, OpenAPI/Swagger documentation, versioning, error handling, and API best practices for NestJS applications. Use when designing API endpoints, building RESTful APIs, writing OpenAPI/Swagger docs, implementing versioning, or designing error responses and DTOs.
 metadata:
   version: "1.0.0"
   tags: "api, rest, design"
 ---
 
 # API Design Expert Skill
-
-Expert in RESTful API design, OpenAPI/Swagger documentation, versioning strategies, error handling, and API best practices for NestJS applications.
 
 ## When to Use
 

--- a/.agents/skills/audit/SKILL.md
+++ b/.agents/skills/audit/SKILL.md
@@ -13,7 +13,8 @@ metadata:
   license: Apache-2.0
 ---
 
-Run systematic **technical** quality checks and generate a comprehensive report. Don't fix issues — document them for other commands to address.
+Run systematic **technical** quality checks and generate the report below. Do
+not fix issues in this skill.
 
 Before scanning, read the existing design system (CSS / tokens / theme and a representative component) so "correct" is measured against the project's own conventions, not generic defaults. If the repo carries design context (`PRODUCT.md`, `DESIGN.md`, `.impeccable.md`, or a `## Design Context` block in `.github/copilot-instructions.md`), read it too.
 
@@ -21,7 +22,8 @@ This is a code-level audit, not a design critique. Check what's measurable and v
 
 ## Diagnostic Scan
 
-Run comprehensive checks across 5 dimensions. Score each dimension 0-4 using the criteria below.
+Run checks across 5 dimensions. Score each dimension 0-4 using the criteria
+below.
 
 ### 1. Accessibility (A11y)
 
@@ -131,7 +133,8 @@ Identify recurring problems that indicate systemic gaps rather than one-off mist
 
 ### Positive Findings
 
-Note what's working well — good practices to maintain and replicate.
+List 1-3 implementation practices worth preserving, with file/component
+evidence. Omit this section when there is no concrete positive finding.
 
 ## Recommended Actions
 
@@ -148,14 +151,12 @@ After presenting the summary, tell the user:
 >
 > Re-run `/audit` after fixes to see your score improve.
 
-**IMPORTANT**: Be thorough but actionable. Too many P3 issues creates noise. Focus on what actually matters.
+Limit P3 findings to the top five unless the user asks for a complete backlog.
 
 **NEVER**:
 
 - Report issues without explaining impact (why does this matter?)
-- Provide generic recommendations (be specific and actionable)
+- Provide recommendations without file/component evidence and a fix path
 - Skip positive findings (celebrate what works)
 - Forget to prioritize (everything can't be P0)
 - Report false positives without verification
-
-Remember: You're a technical quality auditor. Document systematically, prioritize ruthlessly, cite specific code locations, and provide clear paths to improvement.

--- a/.agents/skills/biome-validator/SKILL.md
+++ b/.agents/skills/biome-validator/SKILL.md
@@ -2,13 +2,11 @@
 name: biome-validator
 description: Validate Biome 2.3+ configuration and detect outdated patterns. Ensures proper schema version, domains, assists, and recommended rules. Use before any linting work or when auditing existing projects.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: biome, linter, formatter, validation, code-quality
 ---
 
 # Biome Validator
-
-Validates Biome 2.3+ configuration and prevents outdated patterns. Ensures type-aware linting, domains, and modern Biome features are properly configured.
 
 ## When This Activates
 
@@ -27,226 +25,18 @@ python3 scripts/validate.py --root . --strict
 
 ## What Gets Checked
 
-### 1. Biome Version & Schema
+| Check | Good (2.3+) | Bad (legacy) |
+|---|---|---|
+| Schema version | `"$schema": ".../2.3.12/schema.json"` | `.../1.9.0/schema.json` or older |
+| Package version | `"@biomejs/biome": "^2.3.0"` | `"^1.9.0"` or 2.0-2.2 |
+| Linter config | `linter.rules.recommended: true` | missing or legacy `rules` shape |
+| Assist actions | `assist.actions.source.organizeImports` | top-level `organizeImports.enabled` |
+| Domains | `linter.domains.react` / `.next: "on"` | no domains configured |
+| Suppression comments | `// biome-ignore lint/<rule>: reason` | `// eslint-disable`, `// @ts-ignore` |
 
-**GOOD - Biome 2.3+:**
+Biome 2.0+ also adds type-aware linting (no TypeScript compiler required) and multi-file lint analysis.
 
-```json
-{
-  "$schema": "https://biomejs.dev/schemas/2.3.12/schema.json"
-}
-```
-
-**BAD - Old schema:**
-
-```json
-{
-  "$schema": "https://biomejs.dev/schemas/1.9.0/schema.json"
-}
-```
-
-### 2. Package Version
-
-```json
-// GOOD: v2.3+
-"@biomejs/biome": "^2.3.0"
-
-// BAD: v1.x or v2.0-2.2
-"@biomejs/biome": "^1.9.0"
-```
-
-### 3. Linter Configuration
-
-**GOOD - Biome 2.x:**
-
-```json
-{
-  "linter": {
-    "enabled": true,
-    "rules": {
-      "recommended": true,
-      "suspicious": {
-        "noExplicitAny": "warn"
-      }
-    }
-  }
-}
-```
-
-### 4. Biome Assist (2.0+)
-
-**GOOD - Using assist:**
-
-```json
-{
-  "assist": {
-    "actions": {
-      "source": {
-        "organizeImports": "on"
-      }
-    }
-  }
-}
-```
-
-**BAD - Old organizeImports location:**
-
-```json
-{
-  "organizeImports": {
-    "enabled": true
-  }
-}
-```
-
-### 5. Domains (2.0+)
-
-**GOOD - Using domains for framework-specific rules:**
-
-```json
-{
-  "linter": {
-    "domains": {
-      "react": "on",
-      "next": "on"
-    }
-  }
-}
-```
-
-### 6. Suppression Comments
-
-**GOOD - Biome 2.0+ comments:**
-
-```typescript
-// biome-ignore lint/suspicious/noExplicitAny: legacy code
-// biome-ignore-all lint/style/useConst
-// biome-ignore-start lint/complexity
-// biome-ignore-end
-```
-
-**BAD - Wrong format:**
-
-```typescript
-// @ts-ignore  // Not Biome
-// eslint-disable  // Wrong tool
-```
-
-## Biome 2.3+ Features
-
-### Type-Aware Linting
-
-Biome 2.0+ includes type inference without requiring TypeScript compiler:
-
-```json
-{
-  "linter": {
-    "rules": {
-      "correctness": {
-        "noUndeclaredVariables": "error",
-        "useAwaitThenable": "error"
-      }
-    }
-  }
-}
-```
-
-### Assist Actions
-
-```json
-{
-  "assist": {
-    "actions": {
-      "source": {
-        "organizeImports": "on",
-        "useSortedKeys": "on"
-      }
-    }
-  }
-}
-```
-
-### Multi-file Analysis
-
-Lint rules can query information from other files for more powerful analysis.
-
-### Framework Domains
-
-```json
-{
-  "linter": {
-    "domains": {
-      "react": "on",       // React-specific rules
-      "next": "on",        // Next.js rules
-      "test": "on"         // Testing framework rules
-    }
-  }
-}
-```
-
-## Recommended Configuration
-
-```json
-{
-  "$schema": "https://biomejs.dev/schemas/2.3.12/schema.json",
-  "assist": {
-    "actions": {
-      "source": {
-        "organizeImports": "on"
-      }
-    }
-  },
-  "linter": {
-    "enabled": true,
-    "rules": {
-      "recommended": true,
-      "complexity": {
-        "noForEach": "off"
-      },
-      "style": {
-        "noNonNullAssertion": "off"
-      },
-      "suspicious": {
-        "noArrayIndexKey": "off",
-        "noExplicitAny": "warn"
-      },
-      "correctness": {
-        "useAwaitThenable": "error",
-        "noLeakedRender": "error"
-      }
-    },
-    "domains": {
-      "react": "on",
-      "next": "on"
-    }
-  },
-  "formatter": {
-    "enabled": true,
-    "indentStyle": "space",
-    "indentWidth": 2,
-    "lineWidth": 100
-  },
-  "javascript": {
-    "formatter": {
-      "quoteStyle": "single",
-      "trailingCommas": "es5",
-      "semicolons": "always"
-    }
-  },
-  "files": {
-    "ignore": [
-      "node_modules",
-      "dist",
-      "build",
-      ".next",
-      "out",
-      ".cache",
-      ".turbo",
-      "coverage"
-    ]
-  }
-}
-```
+See `references/full-guide.md` (§ What Gets Checked, § Biome 2.3+ Features, § Recommended Configuration) for full GOOD/BAD config examples and a complete recommended `biome.json`.
 
 ## Deprecated Patterns
 
@@ -257,97 +47,17 @@ Lint rules can query information from other files for more powerful analysis.
 | `@biomejs/biome` < 2.3 | `@biomejs/biome@latest` |
 | No domains config | Use `linter.domains` for frameworks |
 
-## Validation Output
-
-```
-=== Biome 2.3+ Validation Report ===
-
-Package Version: @biomejs/biome@2.3.11 ✓
-
-Configuration:
-  ✓ Schema version: 2.3.11
-  ✓ Linter enabled with recommended rules
-  ✓ Using assist.actions for imports
-  ✗ No domains configured (consider enabling react, next)
-  ✓ Formatter configured
-
-Rules:
-  ✓ noExplicitAny: warn
-  ✓ useAwaitThenable: error
-  ✗ noLeakedRender not enabled (recommended)
-
-Summary: 2 issues found
-```
+See `references/full-guide.md` (§ Validation Output) for a sample validation report.
 
 ## Migration from ESLint
 
-### Step 1: Install Biome
+1. Remove ESLint/Prettier packages, add `@biomejs/biome@latest`
+2. Generate config: `bunx biome init`
+3. Port existing rules: `bunx biome migrate eslint --write`
+4. Update `package.json` lint/format scripts to call `biome`
+5. Delete old `.eslintrc*` / `.prettierrc*` / `.eslintignore` / `.prettierignore`
 
-```bash
-bun remove eslint prettier eslint-config-* eslint-plugin-*
-bun add -D @biomejs/biome@latest
-```
-
-### Step 2: Create biome.json
-
-```bash
-bunx biome init
-```
-
-### Step 3: Migrate rules
-
-```bash
-bunx biome migrate eslint --write
-```
-
-### Step 4: Update scripts
-
-```json
-{
-  "scripts": {
-    "lint": "biome lint .",
-    "lint:fix": "biome lint --write .",
-    "format": "biome format --write .",
-    "check": "biome check .",
-    "check:fix": "biome check --write ."
-  }
-}
-```
-
-### Step 5: Remove old configs
-
-```bash
-rm .eslintrc* .prettierrc* .eslintignore .prettierignore
-```
-
-## VS Code Integration
-
-```json
-// .vscode/settings.json
-{
-  "editor.formatOnSave": true,
-  "editor.defaultFormatter": "biomejs.biome",
-  "editor.codeActionsOnSave": {
-    "source.organizeImports.biome": "explicit",
-    "quickfix.biome": "explicit"
-  }
-}
-```
-
-## CI/CD Integration
-
-```yaml
-# .github/workflows/lint.yml
-- name: Validate Biome Config
-  run: |
-    python3 scripts/validate.py \
-      --root . \
-      --strict \
-      --ci
-
-- name: Lint
-  run: bunx biome check --error-on-warnings .
-```
+See `references/full-guide.md` (§ Migration from ESLint) for the exact commands per step, plus VS Code editor settings and a CI/CD workflow snippet.
 
 ## Integration
 

--- a/.agents/skills/biome-validator/plugin.json
+++ b/.agents/skills/biome-validator/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "biome-validator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Validate Biome 2.3+ configuration and detect outdated patterns",
   "author": {
     "name": "Ship Shit Dev",

--- a/.agents/skills/biome-validator/references/full-guide.md
+++ b/.agents/skills/biome-validator/references/full-guide.md
@@ -1,0 +1,316 @@
+# Biome Validator - Full Guide
+
+## What Gets Checked
+
+### 1. Biome Version & Schema
+
+**GOOD - Biome 2.3+:**
+
+```json
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.12/schema.json"
+}
+```
+
+**BAD - Old schema:**
+
+```json
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.0/schema.json"
+}
+```
+
+### 2. Package Version
+
+```json
+// GOOD: v2.3+
+"@biomejs/biome": "^2.3.0"
+
+// BAD: v1.x or v2.0-2.2
+"@biomejs/biome": "^1.9.0"
+```
+
+### 3. Linter Configuration
+
+**GOOD - Biome 2.x:**
+
+```json
+{
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "suspicious": {
+        "noExplicitAny": "warn"
+      }
+    }
+  }
+}
+```
+
+### 4. Biome Assist (2.0+)
+
+**GOOD - Using assist:**
+
+```json
+{
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  }
+}
+```
+
+**BAD - Old organizeImports location:**
+
+```json
+{
+  "organizeImports": {
+    "enabled": true
+  }
+}
+```
+
+### 5. Domains (2.0+)
+
+**GOOD - Using domains for framework-specific rules:**
+
+```json
+{
+  "linter": {
+    "domains": {
+      "react": "on",
+      "next": "on"
+    }
+  }
+}
+```
+
+### 6. Suppression Comments
+
+**GOOD - Biome 2.0+ comments:**
+
+```typescript
+// biome-ignore lint/suspicious/noExplicitAny: legacy code
+// biome-ignore-all lint/style/useConst
+// biome-ignore-start lint/complexity
+// biome-ignore-end
+```
+
+**BAD - Wrong format:**
+
+```typescript
+// @ts-ignore  // Not Biome
+// eslint-disable  // Wrong tool
+```
+
+## Biome 2.3+ Features
+
+### Type-Aware Linting
+
+Biome 2.0+ includes type inference without requiring TypeScript compiler:
+
+```json
+{
+  "linter": {
+    "rules": {
+      "correctness": {
+        "noUndeclaredVariables": "error",
+        "useAwaitThenable": "error"
+      }
+    }
+  }
+}
+```
+
+### Assist Actions
+
+```json
+{
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on",
+        "useSortedKeys": "on"
+      }
+    }
+  }
+}
+```
+
+### Multi-file Analysis
+
+Lint rules can query information from other files.
+
+### Framework Domains
+
+```json
+{
+  "linter": {
+    "domains": {
+      "react": "on",       // React-specific rules
+      "next": "on",        // Next.js rules
+      "test": "on"         // Testing framework rules
+    }
+  }
+}
+```
+
+## Recommended Configuration
+
+```json
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.12/schema.json",
+  "assist": {
+    "actions": {
+      "source": {
+        "organizeImports": "on"
+      }
+    }
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "complexity": {
+        "noForEach": "off"
+      },
+      "style": {
+        "noNonNullAssertion": "off"
+      },
+      "suspicious": {
+        "noArrayIndexKey": "off",
+        "noExplicitAny": "warn"
+      },
+      "correctness": {
+        "useAwaitThenable": "error",
+        "noLeakedRender": "error"
+      }
+    },
+    "domains": {
+      "react": "on",
+      "next": "on"
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingCommas": "es5",
+      "semicolons": "always"
+    }
+  },
+  "files": {
+    "ignore": [
+      "node_modules",
+      "dist",
+      "build",
+      ".next",
+      "out",
+      ".cache",
+      ".turbo",
+      "coverage"
+    ]
+  }
+}
+```
+
+## Validation Output
+
+```
+=== Biome 2.3+ Validation Report ===
+
+Package Version: @biomejs/biome@2.3.11 ✓
+
+Configuration:
+  ✓ Schema version: 2.3.11
+  ✓ Linter enabled with recommended rules
+  ✓ Using assist.actions for imports
+  ✗ No domains configured (consider enabling react, next)
+  ✓ Formatter configured
+
+Rules:
+  ✓ noExplicitAny: warn
+  ✓ useAwaitThenable: error
+  ✗ noLeakedRender not enabled (recommended)
+
+Summary: 2 issues found
+```
+
+## Migration from ESLint
+
+### Step 1: Install Biome
+
+```bash
+bun remove eslint prettier eslint-config-* eslint-plugin-*
+bun add -D @biomejs/biome@latest
+```
+
+### Step 2: Create biome.json
+
+```bash
+bunx biome init
+```
+
+### Step 3: Migrate rules
+
+```bash
+bunx biome migrate eslint --write
+```
+
+### Step 4: Update scripts
+
+```json
+{
+  "scripts": {
+    "lint": "biome lint .",
+    "lint:fix": "biome lint --write .",
+    "format": "biome format --write .",
+    "check": "biome check .",
+    "check:fix": "biome check --write ."
+  }
+}
+```
+
+### Step 5: Remove old configs
+
+```bash
+rm .eslintrc* .prettierrc* .eslintignore .prettierignore
+```
+
+## VS Code Integration
+
+```json
+// .vscode/settings.json
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "biomejs.biome",
+  "editor.codeActionsOnSave": {
+    "source.organizeImports.biome": "explicit",
+    "quickfix.biome": "explicit"
+  }
+}
+```
+
+## CI/CD Integration
+
+```yaml
+# .github/workflows/lint.yml
+- name: Validate Biome Config
+  run: |
+    python3 scripts/validate.py \
+      --root . \
+      --strict \
+      --ci
+
+- name: Lint
+  run: bunx biome check --error-on-warnings .
+```

--- a/.agents/skills/bun-validator/SKILL.md
+++ b/.agents/skills/bun-validator/SKILL.md
@@ -1,14 +1,12 @@
 ---
 name: bun-validator
-description: Validate Bun workspace configuration and detect common monorepo issues. Ensures proper workspace setup, dependency catalogs, isolated installs, and Bun 1.3+ best practices.
+description: Validate Bun workspace configuration and detect common monorepo issues. Ensures proper workspace setup, dependency catalogs, isolated installs, and Bun 1.3+ best practices. Use when setting up a Bun monorepo, before adding workspace dependencies, auditing an existing Bun workspace, or validating package.json in CI.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: bun, monorepo, workspace, validation, package-manager
 ---
 
 # Bun Validator
-
-Validates Bun workspace configuration and prevents common monorepo issues. Ensures Bun 1.3+ patterns and proper workspace isolation.
 
 ## When This Activates
 
@@ -62,23 +60,7 @@ bun --version  # 1.2.x
 
 ### 3. Workspace Structure
 
-**GOOD:**
-
-```
-my-monorepo/
-├── package.json          # Root with workspaces, private: true
-├── bun.lockb             # Single lockfile at root
-├── apps/
-│   ├── web/
-│   │   └── package.json  # Own dependencies
-│   └── api/
-│       └── package.json  # Own dependencies
-└── packages/
-    ├── ui/
-    │   └── package.json  # Shared package
-    └── config/
-        └── package.json  # Shared config
-```
+**GOOD:** See `references/full-guide.md` (§ Workspace Structure Example) for the full tree — root `package.json` + `bun.lockb`, each app/package owns its own `package.json`.
 
 **BAD:**
 
@@ -159,18 +141,7 @@ Packages can only access dependencies they explicitly declare.
 
 ### Dependency Catalogs
 
-Centralize version management:
-
-```json
-// Root package.json
-{
-  "catalog": {
-    "react": "^19.0.0",
-    "next": "^16.0.0",
-    "typescript": "^5.7.0"
-  }
-}
-```
+See § Dependency Catalogs (Bun 1.3+) above for the catalog syntax.
 
 ### Interactive Updates
 
@@ -236,67 +207,15 @@ bun install  # From root only
 
 ## Validation Output
 
-```
-=== Bun Workspace Validation Report ===
-
-Bun Version: 1.3.2 ✓
-
-Root package.json:
-  ✓ private: true
-  ✓ workspaces defined
-  ✗ Found dependencies in root (should be empty)
-
-Workspace Structure:
-  ✓ apps/web - valid workspace
-  ✓ apps/api - valid workspace
-  ✓ packages/ui - valid workspace
-  ✗ apps/web/bun.lockb - lockfile should only be at root
-
-Dependencies:
-  ✓ Using workspace:* protocol
-  ✗ @myorg/ui uses hardcoded version "1.0.0"
-
-Catalogs:
-  ✗ No dependency catalog found (recommended for Bun 1.3+)
-
-Summary: 3 issues found
-```
+See `references/full-guide.md` (§ Validation Output Example) for a sample report.
 
 ## Best Practices
 
-### 1. Always use workspace protocol
-
-```json
-"@myorg/shared": "workspace:*"
-```
-
-### 2. Use --cwd for workspace operations
-
-```bash
-bun add lodash --cwd apps/web  # NOT: cd apps/web && bun add
-```
-
-### 3. Single lockfile at root
-
-```bash
-# Only run bun install from root
-bun install
-```
-
-### 4. Use catalogs for shared dependencies
-
-```json
-{
-  "catalog": {
-    "typescript": "^5.7.0",
-    "vitest": "^3.0.0"
-  }
-}
-```
-
-### 5. Declare all dependencies explicitly
-
-Each workspace should list all its dependencies - don't rely on hoisting.
+- Always use the workspace protocol: `"@myorg/shared": "workspace:*"`
+- Use `--cwd` for workspace operations: `bun add lodash --cwd apps/web` (not `cd apps/web && bun add`)
+- Run `bun install` only from the root — keep a single lockfile
+- Use dependency catalogs for shared versions (see § Dependency Catalogs above)
+- Declare all dependencies explicitly per workspace — don't rely on hoisting
 
 ## CI/CD Integration
 

--- a/.agents/skills/bun-validator/plugin.json
+++ b/.agents/skills/bun-validator/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "bun-validator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Validate Bun workspace configuration and detect common monorepo issues",
   "author": {
     "name": "Ship Shit Dev",

--- a/.agents/skills/bun-validator/references/full-guide.md
+++ b/.agents/skills/bun-validator/references/full-guide.md
@@ -1,0 +1,47 @@
+# Bun Validator — Full Examples
+
+## Workspace Structure Example (GOOD)
+
+```
+my-monorepo/
+├── package.json          # Root with workspaces, private: true
+├── bun.lockb             # Single lockfile at root
+├── apps/
+│   ├── web/
+│   │   └── package.json  # Own dependencies
+│   └── api/
+│       └── package.json  # Own dependencies
+└── packages/
+    ├── ui/
+    │   └── package.json  # Shared package
+    └── config/
+        └── package.json  # Shared config
+```
+
+## Validation Output Example
+
+```
+=== Bun Workspace Validation Report ===
+
+Bun Version: 1.3.2 ✓
+
+Root package.json:
+  ✓ private: true
+  ✓ workspaces defined
+  ✗ Found dependencies in root (should be empty)
+
+Workspace Structure:
+  ✓ apps/web - valid workspace
+  ✓ apps/api - valid workspace
+  ✓ packages/ui - valid workspace
+  ✗ apps/web/bun.lockb - lockfile should only be at root
+
+Dependencies:
+  ✓ Using workspace:* protocol
+  ✗ @myorg/ui uses hardcoded version "1.0.0"
+
+Catalogs:
+  ✗ No dependency catalog found (recommended for Bun 1.3+)
+
+Summary: 3 issues found
+```

--- a/.agents/skills/clarify/SKILL.md
+++ b/.agents/skills/clarify/SKILL.md
@@ -13,8 +13,6 @@ metadata:
   license: Apache-2.0
 ---
 
-Identify and improve unclear, confusing, or poorly written interface text to make the product easier to understand and use.
-
 ## Context Gathering
 
 Before assessing copy, gather the context that determines what "clear" means here:
@@ -42,8 +40,6 @@ Identify what makes the text unclear or ineffective:
    - What's the action? (What do we want users to do?)
    - What's the constraint? (Character limits? Space limitations?)
 
-**CRITICAL**: Clear copy helps users succeed. Unclear copy creates frustration, errors, and support tickets.
-
 ## Plan Copy Improvements
 
 Create a strategy for clearer communication:
@@ -52,8 +48,6 @@ Create a strategy for clearer communication:
 - **Action needed**: What should users do next (if anything)?
 - **Tone**: How should this feel? (Helpful? Apologetic? Encouraging?)
 - **Constraints**: Length limits, brand voice, localization considerations
-
-**IMPORTANT**: Good UX writing is invisible. Users should understand immediately without noticing the words.
 
 ## Improve Copy Systematically
 
@@ -208,4 +202,4 @@ Test that copy improvements work:
 - **Consistency**: Does it match terminology elsewhere?
 - **Tone**: Is it appropriate for the situation?
 
-Remember: You're a clarity expert with excellent communication skills. Write like you're explaining to a smart friend who's unfamiliar with the product. Be clear, be helpful, be human.
+Write like you're explaining to a smart friend who's unfamiliar with the product.

--- a/.agents/skills/component-library/SKILL.md
+++ b/.agents/skills/component-library/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: component-library
-description: Expert React/Next.js component architect specializing in creating consistent, reusable, and maintainable components for monorepo projects
+description: Expert React/Next.js component architect specializing in creating consistent, reusable, and maintainable components for monorepo projects. Use when creating or refactoring UI components, reviewing component architecture, or setting up shared component patterns in a monorepo.
 metadata:
   version: "1.0.0"
   tags: react, nextjs, components, design-system, typescript, performance, patterns
@@ -8,9 +8,7 @@ metadata:
 
 # Component Library Standards Skill
 
-Expert React/Next.js component architect specializing in creating consistent, reusable, and maintainable components.
-
-## When to Use This Skill
+## When to Use
 
 Use when you're:
 

--- a/.agents/skills/critique/SKILL.md
+++ b/.agents/skills/critique/SKILL.md
@@ -37,7 +37,7 @@ Read the relevant source files (HTML, CSS, JS/TS) and, if browser automation is 
 document.title = '[LLM] ' + document.title;
 ```
 
-Think like a design director. Evaluate:
+Evaluate these dimensions:
 
 **AI Slop Detection (CRITICAL)**: Does this look like every other AI-generated interface? Check for the generic indigo/violet palette, gradient text, dark glows, glassmorphism, hero-metric layouts, identical card grids, and generic geometric fonts. **The test**: If someone said "AI made this," would you believe them immediately?
 
@@ -92,7 +92,7 @@ Return: scan findings with file locations and counts, and any false positives no
 
 Synthesize both assessments into a single report. Do NOT simply concatenate. Weave the findings together, noting where the LLM review and detector agree, where the detector caught issues the LLM missed, and where detector findings are false positives.
 
-Structure your feedback as a design director would:
+Structure your feedback as a design director would. Be direct and don't soften criticism — developers need honest feedback to ship great design, and vague or hedged notes waste everyone's time.
 
 #### Design Health Score
 >
@@ -114,7 +114,9 @@ Present the Nielsen's 10 heuristics scores as a table:
 | 10 | Help and Documentation | ? | |
 | **Total** | | **??/40** | **[Rating band]** |
 
-Be honest with scores. A 4 means genuinely excellent. Most real interfaces score 20-32.
+Assign a score of 4 only when the interface has no material issue for that
+heuristic. Use 20-32 as the normal range for production interfaces with
+ordinary gaps.
 
 #### Anti-Patterns Verdict
 
@@ -128,11 +130,12 @@ Be honest with scores. A 4 means genuinely excellent. Most real interfaces score
 
 #### Overall Impression
 
-A brief gut reaction: what works, what doesn't, and the single biggest opportunity.
+One paragraph: what works, what fails, and the single biggest opportunity.
 
 #### What's Working
 
-Highlight 2-3 things done well. Be specific about why they work.
+Highlight 2-3 things done well with element names, visible behavior, and why
+they work.
 
 #### Priority Issues
 
@@ -163,6 +166,9 @@ Be specific. Name the exact elements and interactions that fail each persona. Do
 
 Quick notes on smaller issues worth addressing.
 
+Each priority issue must name the element, user impact, and fix. Limit minor
+observations to findings with a visible location or source reference.
+
 #### Questions to Consider
 
 Provocative questions that might unlock better solutions:
@@ -170,15 +176,6 @@ Provocative questions that might unlock better solutions:
 - "What if the primary action were more prominent?"
 - "Does this need to feel this complex?"
 - "What would a confident version of this look like?"
-
-**Remember**:
-
-- Be direct. Vague feedback wastes everyone's time.
-- Be specific. "The submit button," not "some elements."
-- Say what's wrong AND why it matters to users.
-- Give concrete suggestions, not just "consider exploring..."
-- Prioritize ruthlessly. If everything is important, nothing is.
-- Don't soften criticism. Developers need honest feedback to ship great design.
 
 ### Step 4: Ask the User
 

--- a/.agents/skills/docker-expert/SKILL.md
+++ b/.agents/skills/docker-expert/SKILL.md
@@ -8,13 +8,7 @@ metadata:
 
 # Docker Expert
 
-## Overview
-
-This skill enables AI assistants to help with Docker containerization, docker-compose setups, and container orchestration for micro startup infrastructure.
-
-## When to Use This Skill
-
-This skill activates when users need:
+## When to Use
 
 - Dockerfile creation for NestJS/Next.js
 - docker-compose configuration

--- a/.agents/skills/error-handling-expert/SKILL.md
+++ b/.agents/skills/error-handling-expert/SKILL.md
@@ -1,14 +1,12 @@
 ---
 name: error-handling-expert
-description: Expert in error handling patterns, exception management, error responses, logging, and error recovery strategies for React, Next.js, and NestJS applications
+description: Expert in error handling patterns, exception management, error responses, logging, and error recovery strategies for React, Next.js, and NestJS applications. Use when implementing error handling, exception filters, error responses, error logging, or recovery strategies.
 metadata:
   version: "1.0.0"
   tags: "errors, reliability, architecture"
 ---
 
 # Error Handling Expert Skill
-
-Expert in error handling patterns, exception management, error responses, logging, and error recovery strategies for React, Next.js, and NestJS applications.
 
 ## When to Use
 

--- a/.agents/skills/layout/SKILL.md
+++ b/.agents/skills/layout/SKILL.md
@@ -121,5 +121,3 @@ Create a systematic plan:
 - **Breathing room**: Does the layout feel comfortable, not cramped or wasteful?
 - **Consistency**: Is the spacing system applied uniformly?
 - **Responsiveness**: Does the layout adapt gracefully across screen sizes?
-
-Remember: Space is the most underused design tool. A layout with the right rhythm and hierarchy can make even simple content feel polished and intentional.

--- a/.agents/skills/mcp-builder/README.md
+++ b/.agents/skills/mcp-builder/README.md
@@ -14,6 +14,6 @@ Derived from **[anthropics/skills](https://github.com/anthropics/skills)** (Apac
 | Last synced | 2026-06-12 |
 | License | Apache-2.0 |
 
-**Local modifications:** Vendored from Anthropic's official skills repo as a standalone marketplace plugin. No behavioral changes beyond provenance metadata.
+**Local modifications:** Vendored from Anthropic's official skills repo as a standalone marketplace plugin. One behavioral change: `scripts/evaluation.py` and `references/evaluation.md` no longer pin a specific model default — the eval model now comes from the `ANTHROPIC_MODEL` env var (or `-m`), so the skill never ships a version that goes stale. On re-sync, re-apply this de-pinning if upstream still hardcodes a model ID; restructured 2026-07-10: long examples moved to references/.
 
 **Checking for upstream changes:** when upstream has moved ahead of the synced marker above, diff [`skills/mcp-builder/SKILL.md`](https://github.com/anthropics/skills/blob/main/skills/mcp-builder/SKILL.md) on `main` since commit `ef740771ac90`, port anything worth bringing home, then bump `metadata.upstream_commit` (or `metadata.upstream_version`) and `metadata.last_synced` in `SKILL.md` and this table.

--- a/.agents/skills/mcp-builder/SKILL.md
+++ b/.agents/skills/mcp-builder/SKILL.md
@@ -1,14 +1,14 @@
 ---
 name: mcp-builder
 description: >-
-  Creates high-quality MCP (Model Context Protocol) servers that enable LLMs to interact with
+  Creates MCP (Model Context Protocol) servers that enable LLMs to interact with
   external services through well-designed tools. Activates on: "build an MCP server", "create
-  MCP tools", "integrate API via MCP", "write a FastMCP server", "add MCP to Claude", or any
+  MCP tools", "integrate API via MCP", "write a FastMCP server", "add an MCP server to an agent", or any
   request to wrap an external API as LLM-callable tools in Python or Node/TypeScript.
 disable-model-invocation: true
 license: Complete terms in LICENSE.txt
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   source: https://github.com/anthropics/skills/blob/main/skills/mcp-builder/SKILL.md
   upstream_repo: anthropics/skills
   upstream_ref: main
@@ -19,45 +19,39 @@ metadata:
 ---
 # MCP Server Development Guide
 
-## Overview
-
-To create high-quality MCP (Model Context Protocol) servers that enable LLMs to effectively interact with external services, use this skill. An MCP server provides tools that allow LLMs to access external services and APIs. The quality of an MCP server is measured by how well it enables LLMs to accomplish real-world tasks using the tools provided.
-
----
-
 # Process
 
-## 🚀 High-Level Workflow
+## High-Level Workflow
 
-Creating a high-quality MCP server involves four main phases:
+Build an MCP server in four phases:
 
 ### Phase 1: Deep Research and Planning
 
 #### 1.1 Understand Agent-Centric Design Principles
 
-Before diving into implementation, understand how to design tools for AI agents by reviewing these principles:
+Before implementation, design tools around agent workflows:
 
 **Build for Workflows, Not Just API Endpoints:**
 
-- Don't simply wrap existing API endpoints - build thoughtful, high-impact workflow tools
+- Do not mirror every API endpoint by default. Group endpoints into workflow
+  tools when one user task requires multiple API calls.
 - Consolidate related operations (e.g., `schedule_event` that both checks availability and creates event)
-- Focus on tools that enable complete tasks, not just individual API calls
-- Consider what workflows agents actually need to accomplish
+- List the top user workflows and map each tool to one workflow.
 
 **Optimize for Limited Context:**
 
-- Agents have constrained context windows - make every token count
+- Return only fields needed for the task by default.
 - Return high-signal information, not exhaustive data dumps
 - Provide "concise" vs "detailed" response format options
 - Default to human-readable identifiers over technical codes (names over IDs)
-- Consider the agent's context budget as a scarce resource
+- Add pagination, field selection, or truncation for large responses.
 
 **Design Actionable Error Messages:**
 
-- Error messages should guide agents toward correct usage patterns
+- Error messages include the failed field or operation, the cause, and the next
+  valid action.
 - Suggest specific next steps: "Try using filter='active_only' to reduce results"
-- Make errors educational, not just diagnostic
-- Help agents learn proper tool usage through clear feedback
+- Never return raw provider errors without a tool-level explanation.
 
 **Follow Natural Task Subdivisions:**
 
@@ -73,9 +67,9 @@ Before diving into implementation, understand how to design tools for AI agents 
 
 #### 1.2 Study MCP Protocol Documentation
 
-**Fetch the latest MCP protocol documentation:**
+**Fetch the MCP protocol documentation:**
 
-Use WebFetch to load: `https://modelcontextprotocol.io/llms-full.txt`
+Fetch: `https://modelcontextprotocol.io/llms-full.txt`
 
 This document contains the complete MCP specification. Note: the URL may change as the spec evolves — if the fetch fails, search for the current MCP docs URL.
 
@@ -87,17 +81,20 @@ This document contains the complete MCP specification. Note: the URL may change 
 
 **For Python implementations, also load:**
 
-- **Python SDK Documentation**: Use WebFetch to load `https://py.sdk.modelcontextprotocol.io/`
+- **Python SDK Documentation**: Fetch `https://py.sdk.modelcontextprotocol.io/`
 - [🐍 Python Implementation Guide](./references/python_mcp_server.md) - Python-specific best practices and examples
 
 **For Node/TypeScript implementations, also load:**
 
-- **TypeScript SDK Documentation**: Use WebFetch to load `https://ts.sdk.modelcontextprotocol.io/`
+- **TypeScript SDK Documentation**: Fetch `https://ts.sdk.modelcontextprotocol.io/`
 - [⚡ TypeScript Implementation Guide](./references/node_mcp_server.md) - Node/TypeScript-specific best practices and examples
 
-#### 1.4 Exhaustively Study API Documentation
+#### 1.4 Study API Documentation
 
-To integrate a service, read through **ALL** available API documentation:
+To integrate a service, read the API documentation for the selected workflows.
+Scope endpoint and parameter coverage to those workflows, but read the
+cross-cutting concerns (auth, rate limits, error handling, data models) in full
+— they apply across every tool you expose:
 
 - Official API reference documentation
 - Authentication and authorization requirements
@@ -106,11 +103,11 @@ To integrate a service, read through **ALL** available API documentation:
 - Available endpoints and their parameters
 - Data models and schemas
 
-**To gather comprehensive information, use web search and the WebFetch tool as needed.**
+Search or fetch documentation only for gaps that block the selected workflow.
 
-#### 1.5 Create a Comprehensive Implementation Plan
+#### 1.5 Create an Implementation Plan
 
-Based on your research, create a detailed plan that includes:
+Create a plan with these sections:
 
 **Tool Selection:**
 
@@ -135,7 +132,8 @@ Based on your research, create a detailed plan that includes:
 **Error Handling Strategy:**
 
 - Plan graceful failure modes
-- Design clear, actionable, LLM-friendly, natural language error messages which prompt further action
+- Define each error shape with: error code, human-readable cause, retryability,
+  and next valid action.
 - Consider rate limiting and timeout scenarios
 - Handle authentication and authorization errors
 
@@ -143,7 +141,8 @@ Based on your research, create a detailed plan that includes:
 
 ### Phase 2: Implementation
 
-Now that you have a comprehensive plan, begin implementation following language-specific best practices.
+After the plan exists, implement the shared infrastructure before individual
+tools.
 
 #### 2.1 Set Up Project Structure
 
@@ -155,7 +154,7 @@ Now that you have a comprehensive plan, begin implementation following language-
 
 **For Node/TypeScript:**
 
-- Create proper project structure (see [⚡ TypeScript Guide](./references/node_mcp_server.md))
+- Create the project structure from [⚡ TypeScript Guide](./references/node_mcp_server.md)
 - Set up `package.json` and `tsconfig.json`
 - Use MCP TypeScript SDK
 - Define Zod schemas for input validation
@@ -177,16 +176,16 @@ For each tool in the plan:
 **Define Input Schema:**
 
 - Use Pydantic (Python) or Zod (TypeScript) for validation
-- Include proper constraints (min/max length, regex patterns, min/max values, ranges)
-- Provide clear, descriptive field descriptions
+- Include constraints (min/max length, regex patterns, min/max values, ranges)
+- Describe field purpose, accepted values, and defaults
 - Include diverse examples in field descriptions
 
-**Write Comprehensive Docstrings/Descriptions:**
+**Write Tool Docstrings/Descriptions:**
 
 - One-line summary of what the tool does
-- Detailed explanation of purpose and functionality
+- Purpose and functionality
 - Explicit parameter types with examples
-- Complete return type schema
+- Return type schema
 - Usage examples (when to use, when not to use)
 - Error handling documentation, which outlines how to proceed given specific errors
 
@@ -194,7 +193,7 @@ For each tool in the plan:
 
 - Use shared utilities to avoid code duplication
 - Follow async/await patterns for all I/O
-- Implement proper error handling
+- Implement the planned error shapes
 - Support multiple response formats (JSON and Markdown)
 - Respect pagination parameters
 - Check character limits and truncate appropriately
@@ -208,25 +207,7 @@ For each tool in the plan:
 
 #### 2.4 Follow Language-Specific Best Practices
 
-**At this point, load the appropriate language guide:**
-
-**For Python: Load [🐍 Python Implementation Guide](./references/python_mcp_server.md) and ensure the following:**
-
-- Using MCP Python SDK with proper tool registration
-- Pydantic v2 models with `model_config`
-- Type hints throughout
-- Async/await for all I/O operations
-- Proper imports organization
-- Module-level constants (CHARACTER_LIMIT, API_BASE_URL)
-
-**For Node/TypeScript: Load [⚡ TypeScript Implementation Guide](./references/node_mcp_server.md) and ensure the following:**
-
-- Using `server.registerTool` properly
-- Zod schemas with `.strict()`
-- TypeScript strict mode enabled
-- No `any` types - use proper types
-- Explicit Promise<T> return types
-- Build process configured (`bun run build`)
+Load the matching guide before finishing implementation — [🐍 Python Implementation Guide](./references/python_mcp_server.md) or [⚡ TypeScript Implementation Guide](./references/node_mcp_server.md) — and follow its patterns: proper SDK tool registration (`@mcp.tool` / `server.registerTool`), strict input validation (Pydantic v2 `model_config` / Zod `.strict()`), full type coverage with no `any`, async/await for all I/O, module-level constants for shared values (e.g. `CHARACTER_LIMIT`, `API_BASE_URL`), and — for TypeScript — a working `bun run build`.
 
 ---
 
@@ -236,38 +217,24 @@ After initial implementation:
 
 #### 3.1 Code Quality Review
 
-To ensure quality, review the code for:
+Review the code for:
 
 - **DRY Principle**: No duplicated code between tools
 - **Composability**: Shared logic extracted into functions
 - **Consistency**: Similar operations return similar formats
 - **Error Handling**: All external calls have error handling
 - **Type Safety**: Full type coverage (Python type hints, TypeScript types)
-- **Documentation**: Every tool has comprehensive docstrings/descriptions
+- **Documentation**: Every tool has summary, parameters, return shape, examples,
+  and error behavior
 
 #### 3.2 Test and Build
 
-**Important:** MCP servers are long-running processes that wait for requests over stdio/stdin or sse/http. Running them directly in your main process (e.g., `python server.py` or `node dist/index.js`) will cause your process to hang indefinitely.
+**Important:** MCP servers are long-running processes that wait for requests over stdio/stdin or sse/http. Running them directly in the main process (e.g., `python server.py` or `node dist/index.js`) hangs it indefinitely.
 
-**Safe ways to test the server:**
+Safe ways to test: run the server in tmux to keep it out of the main process, use a timeout (`timeout 5s python server.py`), or let the evaluation harness (Phase 4) manage the server subprocess directly for stdio transport.
 
-- Use the evaluation harness (see Phase 4) - recommended approach
-- Run the server in tmux to keep it outside your main process
-- Use a timeout when testing: `timeout 5s python server.py`
-
-**For Python:**
-
-- Verify Python syntax: `python -m py_compile your_server.py`
-- Check imports work correctly by reviewing the file
-- To manually test: Run server in tmux, then test with evaluation harness in main process
-- Or use the evaluation harness directly (it manages the server for stdio transport)
-
-**For Node/TypeScript:**
-
-- Run `bun run build` and ensure it completes without errors
-- Verify dist/index.js is created
-- To manually test: Run server in tmux, then test with evaluation harness in main process
-- Or use the evaluation harness directly (it manages the server for stdio transport)
+- **Python:** verify syntax with `python -m py_compile your_server.py` and review imports.
+- **Node/TypeScript:** run `bun run build`, confirm it completes without errors, and verify `dist/index.js` is created.
 
 #### 3.3 Use Quality Checklist
 
@@ -280,7 +247,8 @@ To verify implementation quality, load the appropriate checklist from the langua
 
 ### Phase 4: Create Evaluations
 
-After implementing your MCP server, create comprehensive evaluations to test its effectiveness.
+After implementing the MCP server, create evaluations that test whether agents
+can answer realistic questions with the tools.
 
 **Load [✅ Evaluation Guide](./references/evaluation.md) for complete evaluation guidelines.**
 
@@ -290,7 +258,7 @@ Evaluations test whether LLMs can effectively use your MCP server to answer real
 
 #### 4.2 Create 10 Evaluation Questions
 
-To create effective evaluations, follow the process outlined in the evaluation guide:
+Follow the process outlined in the evaluation guide:
 
 1. **Tool Inspection**: List available tools and understand their capabilities
 2. **Content Exploration**: Use READ-ONLY operations to explore available data
@@ -327,7 +295,7 @@ Create an XML file with this structure:
 ## Gotchas
 
 - **Running the server directly hangs the process.** MCP servers block on stdio/stdin waiting for requests indefinitely. Never run `python server.py` or `node dist/index.js` in your main process. Use `tmux` to background the server, or use the evaluation harness which manages the server subprocess.
-- **Live URL references can go stale.** The MCP protocol documentation URL (`modelcontextprotocol.io/llms-full.txt`) and the GitHub SDK README URLs may move between versions. If a WebFetch fails, search for the current URL rather than assuming the skill path is correct.
+- **Live URL references can go stale.** The MCP protocol documentation URL (`modelcontextprotocol.io/llms-full.txt`) and the GitHub SDK README URLs may move between versions. If a fetch fails, search for the current URL rather than assuming the skill path is correct.
 - **TypeScript builds must be re-run after every source change.** `dist/index.js` is the artifact the MCP runtime loads. Editing `.ts` files without running `bun run build` means the runtime is still running the old version.
 - **Tool annotations are hints, not enforced contracts.** `readOnlyHint: true` does not prevent a tool from writing data — it only signals intent to the LLM. Enforce safety in the tool implementation itself.
 
@@ -335,47 +303,13 @@ Create an XML file with this structure:
 
 # Reference Files
 
-## 📚 Documentation Library
+Load only the resources required by the implementation language and phase.
 
-Load these resources as needed during development:
+| File | Load during | Covers |
+|---|---|---|
+| `references/mcp_best_practices.md` | Phase 1.3 (load first) | naming conventions, response formats (JSON vs Markdown), pagination, character limits/truncation, security and error-handling standards |
+| `references/python_mcp_server.md` | Phase 2 (Python) | server init, Pydantic models, `@mcp.tool` registration, working examples, quality checklist |
+| `references/node_mcp_server.md` | Phase 2 (TypeScript) | project structure, Zod schemas, `server.registerTool`, working examples, quality checklist |
+| `references/evaluation.md` | Phase 4 | question-creation and answer-verification guidelines, XML format, example Q&A, running evaluations |
 
-### Core MCP Documentation (Load First)
-
-- **MCP Protocol**: Fetch from `https://modelcontextprotocol.io/llms-full.txt` - Complete MCP specification
-- [📋 MCP Best Practices](./references/mcp_best_practices.md) - Universal MCP guidelines including:
-  - Server and tool naming conventions
-  - Response format guidelines (JSON vs Markdown)
-  - Pagination best practices
-  - Character limits and truncation strategies
-  - Tool development guidelines
-  - Security and error handling standards
-
-### SDK Documentation (Load During Phase 1/2)
-
-- **Python SDK**: Fetch from `https://py.sdk.modelcontextprotocol.io/`
-- **TypeScript SDK**: Fetch from `https://ts.sdk.modelcontextprotocol.io/`
-
-### Language-Specific Implementation Guides (Load During Phase 2)
-
-- [🐍 Python Implementation Guide](./references/python_mcp_server.md) - Complete Python/FastMCP guide with:
-  - Server initialization patterns
-  - Pydantic model examples
-  - Tool registration with `@mcp.tool`
-  - Complete working examples
-  - Quality checklist
-
-- [⚡ TypeScript Implementation Guide](./references/node_mcp_server.md) - Complete TypeScript guide with:
-  - Project structure
-  - Zod schema patterns
-  - Tool registration with `server.registerTool`
-  - Complete working examples
-  - Quality checklist
-
-### Evaluation Guide (Load During Phase 4)
-
-- [✅ Evaluation Guide](./references/evaluation.md) - Complete evaluation creation guide with:
-  - Question creation guidelines
-  - Answer verification strategies
-  - XML format specifications
-  - Example questions and answers
-  - Running an evaluation with the provided scripts
+Also fetch the live protocol/SDK docs as needed: MCP protocol spec (`https://modelcontextprotocol.io/llms-full.txt`), Python SDK (`https://py.sdk.modelcontextprotocol.io/`), TypeScript SDK (`https://ts.sdk.modelcontextprotocol.io/`).

--- a/.agents/skills/mcp-builder/plugin.json
+++ b/.agents/skills/mcp-builder/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-builder",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Guide for creating high-quality MCP (Model Context Protocol) servers that enable LLMs to interact wi",
   "author": {
     "name": "Ship Shit Dev",

--- a/.agents/skills/mcp-builder/references/evaluation.md
+++ b/.agents/skills/mcp-builder/references/evaluation.md
@@ -510,7 +510,7 @@ positional arguments:
 optional arguments:
   -h, --help            Show help message
   -t, --transport       Transport type: stdio, sse, or http (default: stdio)
-  -m, --model           Claude model to use (default: claude-3-7-sonnet-20250219)
+  -m, --model           Model to use (defaults to the ANTHROPIC_MODEL env var; required if unset)
   -o, --output          Output file for report (default: print to stdout)
 
 stdio options:
@@ -624,7 +624,7 @@ If many evaluations fail:
 
 If tasks are timing out:
 
-- Use a more capable model (e.g., `claude-3-7-sonnet-20250219`)
+- Use a more capable model (set `ANTHROPIC_MODEL` or pass `-m`)
 - Check if tools are returning too much data
 - Verify pagination is working correctly
 - Consider simplifying complex questions

--- a/.agents/skills/mcp-builder/scripts/evaluation.py
+++ b/.agents/skills/mcp-builder/scripts/evaluation.py
@@ -6,6 +6,7 @@ This script evaluates MCP servers by running test questions against them using C
 import argparse
 import asyncio
 import json
+import os
 import re
 import sys
 import time
@@ -17,6 +18,10 @@ from typing import Any
 from anthropic import Anthropic
 
 from connections import create_connection
+
+# Model is not pinned to a version here — it goes stale on every release. Set the
+# ANTHROPIC_MODEL env var (or pass -m/--model) to your current model of choice.
+DEFAULT_MODEL = os.environ.get("ANTHROPIC_MODEL", "")
 
 EVALUATION_PROMPT = """You are an AI assistant with access to tools.
 
@@ -220,7 +225,7 @@ TASK_TEMPLATE = """
 async def run_evaluation(
     eval_path: Path,
     connection: Any,
-    model: str = "claude-3-7-sonnet-20250219",
+    model: str = DEFAULT_MODEL,
 ) -> str:
     """Run evaluation with MCP server tools."""
     print("🚀 Starting Evaluation")
@@ -314,14 +319,14 @@ Examples:
   # Evaluate an SSE MCP server
   python evaluation.py -t sse -u https://example.com/mcp -H "Authorization: Bearer token" eval.xml
 
-  # Evaluate an HTTP MCP server with custom model
-  python evaluation.py -t http -u https://example.com/mcp -m claude-3-5-sonnet-20241022 eval.xml
+  # Evaluate an HTTP MCP server with a specific model
+  python evaluation.py -t http -u https://example.com/mcp -m <your-model> eval.xml
         """,
     )
 
     parser.add_argument("eval_file", type=Path, help="Path to evaluation XML file")
     parser.add_argument("-t", "--transport", choices=["stdio", "sse", "http"], default="stdio", help="Transport type (default: stdio)")
-    parser.add_argument("-m", "--model", default="claude-3-7-sonnet-20250219", help="Claude model to use (default: claude-3-7-sonnet-20250219)")
+    parser.add_argument("-m", "--model", default=DEFAULT_MODEL, help="Model to use (defaults to the ANTHROPIC_MODEL env var; required if that is unset)")
 
     stdio_group = parser.add_argument_group("stdio options")
     stdio_group.add_argument("-c", "--command", help="Command to run MCP server (stdio only)")
@@ -335,6 +340,9 @@ Examples:
     parser.add_argument("-o", "--output", type=Path, help="Output file for evaluation report (default: stdout)")
 
     args = parser.parse_args()
+
+    if not args.model:
+        parser.error("no model set — pass -m/--model or set the ANTHROPIC_MODEL env var")
 
     if not args.eval_file.exists():
         print(f"Error: Evaluation file not found: {args.eval_file}")

--- a/.agents/skills/package-architect/SKILL.md
+++ b/.agents/skills/package-architect/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: package-architect
-description: Design and maintain TypeScript packages in a monorepo, including exports and build configuration.
+description: Design and maintain TypeScript packages in a monorepo, including exports and build configuration. Use when creating or restructuring monorepo packages, defining package.json exports, or setting up tsconfig references.
 metadata:
   version: "1.0.0"
   tags: "packages, monorepo, typescript"
@@ -8,7 +8,7 @@ metadata:
 
 # Package Architect
 
-You design reusable TypeScript packages in monorepos (Bun, pnpm, or npm workspaces).
+Design reusable TypeScript packages in monorepos (Bun, pnpm, or npm workspaces).
 
 ## When to Use
 

--- a/.agents/skills/polish/SKILL.md
+++ b/.agents/skills/polish/SKILL.md
@@ -13,7 +13,7 @@ metadata:
   license: Apache-2.0
 ---
 
-Perform a meticulous final pass to catch all the small details that separate good work from great work. The difference between shipped and polished.
+Perform a meticulous final pass to catch the small details that separate good work from great work.
 
 ## Design System Discovery
 

--- a/.agents/skills/prd-quality-gate/SKILL.md
+++ b/.agents/skills/prd-quality-gate/SKILL.md
@@ -8,8 +8,7 @@ metadata:
 
 <prd_quality_gate>
 A well-formed PRD (or the issue body that serves as one) must contain ALL of the
-following sections as markdown headings (## or ###). Missing sections reduce plan
-quality and risk hallucinated scope.
+following sections as markdown headings (## or ###).
 
 Required sections:
 

--- a/.agents/skills/prompt-engineering/SKILL.md
+++ b/.agents/skills/prompt-engineering/SKILL.md
@@ -8,8 +8,6 @@ metadata:
 
 # Prompt Engineering Patterns
 
-Advanced prompt engineering techniques to maximize LLM performance, reliability, and controllability.
-
 ## Core Capabilities
 
 ### 1. Few-Shot Learning

--- a/.agents/skills/quieter/SKILL.md
+++ b/.agents/skills/quieter/SKILL.md
@@ -35,7 +35,7 @@ Analyze what makes the design feel too intense:
 
 If any of these are unclear from the codebase, ask the user directly to clarify what you cannot infer.
 
-**CRITICAL**: "Quieter" doesn't mean boring or generic. It means refined, sophisticated, and easier on the eyes. Think luxury, not laziness.
+"Quieter" doesn't mean boring or generic. It means refined, sophisticated, and easier on the eyes. Think luxury, not laziness.
 
 ## Plan Refinement
 
@@ -46,7 +46,7 @@ Create a strategy to reduce intensity while maintaining impact:
 - **Simplification approach**: What can be removed entirely?
 - **Sophistication approach**: How can we signal quality through restraint?
 
-**IMPORTANT**: Great quiet design is harder than great bold design. Subtlety requires precision.
+Great quiet design is harder than great bold design. Subtlety requires precision.
 
 ## Refine the Design
 

--- a/.agents/skills/react-component-performance/SKILL.md
+++ b/.agents/skills/react-component-performance/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-component-performance
-description: Diagnose slow React components and suggest targeted performance fixes.
+description: Diagnose slow React components and suggest targeted performance fixes. Use when profiling or improving a slow React component, or reducing re-renders, list lag, or expensive render work.
 metadata:
   version: "1.0.0"
   source: https://github.com/Dimillian/Skills/blob/main/react-component-performance/SKILL.md
@@ -14,8 +14,6 @@ metadata:
   date_added: "2026-03-25"
 ---
 # React Component Performance
-
-## Overview
 
 Identify render hotspots, isolate expensive updates, and apply targeted optimizations without changing UI behavior.
 

--- a/.agents/skills/react-hook-form/SKILL.md
+++ b/.agents/skills/react-hook-form/SKILL.md
@@ -14,11 +14,9 @@ metadata:
 
 # React Hook Form Best Practices
 
-Comprehensive performance optimization guide for React Hook Form applications. Contains 41 rules across 8 categories, prioritized by impact to guide form development, automated refactoring, and code generation.
+41 rules across 8 categories for React Hook Form, prioritized by impact to guide form development, automated refactoring, and code generation.
 
 ## When to Apply
-
-Reference these guidelines when:
 
 - Writing new forms with React Hook Form
 - Configuring useForm options (mode, defaultValues, validation)

--- a/.agents/skills/react-patterns/SKILL.md
+++ b/.agents/skills/react-patterns/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: react-patterns
-description: Modern React patterns and principles. Hooks, composition, performance, TypeScript best practices.
+description: Modern React patterns and principles. Hooks, composition, performance, TypeScript best practices. Use when writing or reviewing React components, applying hooks and composition patterns, or improving React performance and TypeScript usage.
 metadata:
   risk: safe
   date_added: '2026-02-27'
@@ -9,10 +9,6 @@ metadata:
 ---
 
 # React Patterns
-
-> Principles for building production-ready React applications.
-
----
 
 ## 1. Component Design Principles
 

--- a/.agents/skills/react-refactor/SKILL.md
+++ b/.agents/skills/react-refactor/SKILL.md
@@ -13,7 +13,7 @@ metadata:
 
 # React Refactor Best Practices
 
-Architectural refactoring guide for React applications. Contains 40 rules across 7 categories, prioritized by impact from critical (component and state architecture) to incremental (refactoring safety).
+40 rules across 7 categories for React refactoring, prioritized by impact from critical (component and state architecture) to incremental (refactoring safety).
 
 ## When to Apply
 

--- a/.agents/skills/react-testing-library/SKILL.md
+++ b/.agents/skills/react-testing-library/SKILL.md
@@ -8,11 +8,9 @@ metadata:
 
 # React Testing Library Best Practices
 
-Comprehensive testing guide for React components using Testing Library, designed for AI agents and LLMs. Contains 43 rules across 9 categories, prioritized by impact to guide test writing and code review.
+43 rules across 9 categories for testing React components with Testing Library, prioritized by impact to guide test writing and code review.
 
 ## When to Apply
-
-Reference these guidelines when:
 
 - Writing new component tests with React Testing Library
 - Selecting queries (getByRole, getByLabelText, etc.)

--- a/.agents/skills/security-audit/SKILL.md
+++ b/.agents/skills/security-audit/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: security-audit
-description: Run a self-contained security audit workflow for web applications and APIs, covering scoping, reconnaissance, manual testing, API review, hardening, and reporting.
+description: Run a self-contained security audit workflow for web applications and APIs, covering scoping, reconnaissance, manual testing, API review, hardening, and reporting. Use when auditing a web app or API for security issues, reviewing auth or session handling, checking input validation and injection risk, or hardening before release.
 metadata:
   version: "1.0.0"
   tags: "security, audit, web, api, hardening"
@@ -8,11 +8,7 @@ metadata:
 
 # Security Audit
 
-Standalone workflow for reviewing a web application or API without depending on other skills.
-
 ## When to Use
-
-Use this skill when:
 
 - auditing a web application or API for security issues
 - reviewing authentication, authorization, or session handling

--- a/.agents/skills/security-expert/SKILL.md
+++ b/.agents/skills/security-expert/SKILL.md
@@ -1,16 +1,14 @@
 ---
 name: security-expert
-description: Expert in application security, OWASP Top 10, authentication, authorization, data protection, and security best practices for React, Next.js, and NestJS applications
+description: Expert in application security, OWASP Top 10, authentication, authorization, data protection, and security best practices for React, Next.js, and NestJS applications. Use when implementing authentication or authorization, reviewing code for vulnerabilities, handling sensitive data, or implementing encryption or hashing.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "security, owasp, application-security"
 ---
 
 # Security Expert Skill
 
-Expert in application security for React, Next.js, and NestJS applications.
-
-## When to Use This Skill
+## When to Use
 
 - Implementing authentication or authorization
 - Reviewing code for security vulnerabilities
@@ -24,7 +22,7 @@ Expert in application security for React, Next.js, and NestJS applications.
 ## Project Context Discovery
 
 1. Check `.agents/memory/` for security architecture notes and project facts
-2. Review `CLAUDE.md` (repo-level and global) for security rules and "never do" constraints
+2. Review the agent instruction files (`AGENTS.md`/`CLAUDE.md`/`CODEX.md`, repo-level and global) for security rules and "never do" constraints
 3. Identify security patterns and tools
 4. Check for `[project]-security-expert` skill
 

--- a/.agents/skills/security-expert/plugin.json
+++ b/.agents/skills/security-expert/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "security-expert",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Expert in application security, OWASP Top 10, authentication, authorization, data protection, and se",
   "author": {
     "name": "Ship Shit Dev",

--- a/.agents/skills/shadcn-setup/SKILL.md
+++ b/.agents/skills/shadcn-setup/SKILL.md
@@ -7,13 +7,13 @@ description: >-
   and adds the cn() utility. Use when starting a new Next.js or React project
   that needs a shadcn component library, or migrating from shadcn + Tailwind v3.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "shadcn, ui, components, tailwind, react, nextjs"
 ---
 
 # shadcn/ui Setup
 
-Sets up shadcn/ui with proper Tailwind CSS v4 configuration. This skill ensures you get the modern CSS-first setup, not the deprecated v3 approach.
+Sets up shadcn/ui with the modern CSS-first Tailwind v4 setup, not the deprecated v3 approach.
 
 ## Contract
 
@@ -87,38 +87,11 @@ bunx shadcn@latest add button card input label dialog dropdown-menu toast
 
 ### Dependencies
 
-```json
-{
-  "dependencies": {
-    "class-variance-authority": "^0.7.0",
-    "clsx": "^2.1.0",
-    "tailwind-merge": "^2.2.0",
-    "lucide-react": "^0.400.0"
-  },
-  "devDependencies": {
-    "tailwindcss": "^4.0.0",
-    "@tailwindcss/postcss": "^4.0.0"
-  }
-}
-```
+See `references/examples.md` (§ Dependency Versions Example) for the full dependency block.
 
 ### File Structure
 
-```
-project/
-├── src/
-│   ├── app/
-│   │   └── globals.css           # Tailwind v4 + shadcn theme
-│   ├── components/
-│   │   └── ui/                   # shadcn components
-│   │       ├── button.tsx
-│   │       ├── card.tsx
-│   │       └── ...
-│   └── lib/
-│       └── utils.ts              # cn() utility
-├── components.json               # shadcn config
-└── postcss.config.mjs            # PostCSS with @tailwindcss/postcss
-```
+See `references/examples.md` (§ Generated File Structure) for the full tree.
 
 ## Tailwind v4 + shadcn CSS Configuration
 
@@ -161,31 +134,7 @@ bunx shadcn@latest add card table tabs badge avatar dropdown-menu sheet sidebar
 
 ## components.json Configuration
 
-```json
-{
-  "$schema": "https://ui.shadcn.com/schema.json",
-  "style": "default",
-  "rsc": true,
-  "tsx": true,
-  "tailwind": {
-    "config": "",
-    "css": "src/app/globals.css",
-    "baseColor": "zinc",
-    "cssVariables": true,
-    "prefix": ""
-  },
-  "aliases": {
-    "components": "@/components",
-    "utils": "@/lib/utils",
-    "ui": "@/components/ui",
-    "lib": "@/lib",
-    "hooks": "@/hooks"
-  },
-  "iconLibrary": "lucide"
-}
-```
-
-**Note**: The `tailwind.config` is empty because we use CSS-first configuration in v4.
+See `references/examples.md` (§ components.json Full Example) for the full config. The `tailwind.config` field stays empty because setup uses CSS-first configuration in v4.
 
 ## Utils File
 
@@ -213,58 +162,11 @@ bunx shadcn@latest add card dialog dropdown-menu
 
 ### Using Components
 
-```tsx
-import { Button } from '@/components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-
-export function MyComponent() {
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle>Welcome</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <Button>Click me</Button>
-      </CardContent>
-    </Card>
-  );
-}
-```
+See `references/examples.md` (§ Using Components Example) for a sample composition.
 
 ## Dark Mode Support
 
-The CSS uses `prefers-color-scheme` by default. For manual toggle:
-
-```tsx
-// Add to layout.tsx or a theme provider
-'use client';
-
-import { useEffect, useState } from 'react';
-
-export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<'light' | 'dark'>('light');
-
-  useEffect(() => {
-    document.documentElement.classList.toggle('dark', theme === 'dark');
-  }, [theme]);
-
-  return (
-    <ThemeContext.Provider value={{ theme, setTheme }}>
-      {children}
-    </ThemeContext.Provider>
-  );
-}
-```
-
-Update CSS to use class-based dark mode:
-
-```css
-/* Replace @media (prefers-color-scheme: dark) with: */
-.dark {
-  --color-background: hsl(222.2 84% 4.9%);
-  /* ... rest of dark theme variables */
-}
-```
+The CSS uses `prefers-color-scheme` by default. For manual toggle, see `references/examples.md` (§ Dark Mode — Manual Toggle Provider) for the provider component and class-based CSS override.
 
 ## Troubleshooting
 

--- a/.agents/skills/shadcn-setup/plugin.json
+++ b/.agents/skills/shadcn-setup/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shadcn-setup",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Set up shadcn/ui component library with Tailwind CSS v4 configuration",
   "author": {
     "name": "Ship Shit Dev",

--- a/.agents/skills/shadcn-setup/references/examples.md
+++ b/.agents/skills/shadcn-setup/references/examples.md
@@ -1,0 +1,117 @@
+# shadcn/ui Setup — Additional Examples
+
+## Dependency Versions Example
+
+```json
+{
+  "dependencies": {
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.0",
+    "tailwind-merge": "^2.2.0",
+    "lucide-react": "^0.400.0"
+  },
+  "devDependencies": {
+    "tailwindcss": "^4.0.0",
+    "@tailwindcss/postcss": "^4.0.0"
+  }
+}
+```
+
+## Generated File Structure
+
+```
+project/
+├── src/
+│   ├── app/
+│   │   └── globals.css           # Tailwind v4 + shadcn theme
+│   ├── components/
+│   │   └── ui/                   # shadcn components
+│   │       ├── button.tsx
+│   │       ├── card.tsx
+│   │       └── ...
+│   └── lib/
+│       └── utils.ts              # cn() utility
+├── components.json               # shadcn config
+└── postcss.config.mjs            # PostCSS with @tailwindcss/postcss
+```
+
+## components.json Full Example
+
+```json
+{
+  "$schema": "https://ui.shadcn.com/schema.json",
+  "style": "default",
+  "rsc": true,
+  "tsx": true,
+  "tailwind": {
+    "config": "",
+    "css": "src/app/globals.css",
+    "baseColor": "zinc",
+    "cssVariables": true,
+    "prefix": ""
+  },
+  "aliases": {
+    "components": "@/components",
+    "utils": "@/lib/utils",
+    "ui": "@/components/ui",
+    "lib": "@/lib",
+    "hooks": "@/hooks"
+  },
+  "iconLibrary": "lucide"
+}
+```
+
+**Note**: The `tailwind.config` is empty because we use CSS-first configuration in v4.
+
+## Using Components Example
+
+```tsx
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+
+export function MyComponent() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Welcome</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <Button>Click me</Button>
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+## Dark Mode — Manual Toggle Provider
+
+```tsx
+// Add to layout.tsx or a theme provider
+'use client';
+
+import { useEffect, useState } from 'react';
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<'light' | 'dark'>('light');
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('dark', theme === 'dark');
+  }, [theme]);
+
+  return (
+    <ThemeContext.Provider value={{ theme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+```
+
+Update CSS to use class-based dark mode:
+
+```css
+/* Replace @media (prefers-color-scheme: dark) with: */
+.dark {
+  --color-background: hsl(222.2 84% 4.9%);
+  /* ... rest of dark theme variables */
+}
+```

--- a/.agents/skills/shadcn/SKILL.md
+++ b/.agents/skills/shadcn/SKILL.md
@@ -17,11 +17,9 @@ metadata:
 ---
 # shadcn/ui Community Best Practices
 
-Comprehensive best practices guide for shadcn/ui applications, maintained by the shadcn/ui community. Contains 58 rules across 10 categories, prioritized by impact to guide automated refactoring and code generation.
+58 rules across 10 categories for shadcn/ui, prioritized by impact to guide automated refactoring and code generation.
 
 ## When to Apply
-
-Reference these guidelines when:
 
 - Installing and configuring shadcn/ui in a project
 - Writing new shadcn/ui components or composing primitives

--- a/.agents/skills/shape/SKILL.md
+++ b/.agents/skills/shape/SKILL.md
@@ -27,10 +27,6 @@ Before the interview, ground yourself in the project so the brief reflects what 
 - **Existing system** — read the established design system (CSS / tokens / theme and one representative component or page) to learn the conventions in play. Use what's there; branch out only when the UX wins.
 - **Register** — decide whether design *is* the product (marketing, landing, portfolio → identity and boldness lead) or design *serves* the product (app, dashboard, tool → clarity and restraint lead). This frames every direction choice below.
 
-## Philosophy
-
-Most AI-generated UIs fail not because of bad code, but because of skipped thinking. They jump to "here's a card grid" without asking "what is the user trying to accomplish?" This skill inverts that: understand deeply first, so implementation is precise.
-
 ## Phase 1: Discovery Interview
 
 **Do NOT write any code or make any design decisions during this phase.** Your only job is to understand the feature deeply enough to make excellent design decisions later.

--- a/.agents/skills/tailwind-validator/SKILL.md
+++ b/.agents/skills/tailwind-validator/SKILL.md
@@ -2,17 +2,15 @@
 name: tailwind-validator
 description: Validate Tailwind CSS v4 configuration and detect/prevent Tailwind v3 patterns. Use this skill when setting up Tailwind, auditing CSS configuration, or when you suspect outdated Tailwind patterns are being used. Ensures CSS-first configuration with @theme blocks.
 metadata:
-  version: "1.0.0"
+  version: "1.0.1"
   tags: tailwind, css, validation, frontend, configuration
 ---
 
 # Tailwind 4 Validator
 
-Validates that a project uses Tailwind CSS v4 with proper CSS-first configuration. Detects and flags Tailwind v3 patterns that should be migrated.
-
 ## Purpose
 
-**CRITICAL**: Claude and other AI assistants often default to Tailwind v3 patterns. This skill ensures:
+Ensures:
 
 - Projects use Tailwind v4 CSS-first configuration
 - Old `tailwind.config.js` patterns are detected and flagged
@@ -30,206 +28,32 @@ Validates that a project uses Tailwind CSS v4 with proper CSS-first configuratio
 ## Quick Start
 
 ```bash
-# Validate current project
 python3 scripts/validate.py --root .
-
-# Validate with auto-fix suggestions
 python3 scripts/validate.py --root . --suggest-fixes
-
-# Strict mode (fail on any v3 pattern)
 python3 scripts/validate.py --root . --strict
 ```
 
 ## What Gets Checked
 
-### 1. Package Version
+| Check | Good (v4) | Bad (v3) |
+|---|---|---|
+| Package version | `"tailwindcss": "^4.0.0"` | `"^3.4.0"` |
+| CSS config | `@import "tailwindcss";` + `@theme { --color-primary: ...; }` | `@tailwind base/components/utilities;` |
+| Config files | none - config lives in CSS | `tailwind.config.{js,ts,mjs,cjs}` (deprecated in v4) |
+| PostCSS | `plugins: { '@tailwindcss/postcss': {} }` only | `tailwindcss` + `autoprefixer` as separate plugins |
+| Imports | `@import "tailwindcss/preflight"` / `.../utilities` | `@tailwind` directives |
 
-```json
-// GOOD: v4+
-"tailwindcss": "^4.0.0"
+See `references/full-guide.md` (§ What Gets Checked, § Validation Output) for full GOOD/BAD examples and a sample validation report.
 
-// BAD: v3
-"tailwindcss": "^3.4.0"
-```
+## Migration Guide (v3 to v4)
 
-### 2. CSS Configuration (v4 CSS-first)
+1. Swap packages: remove `tailwindcss`/`autoprefixer`, add `tailwindcss@latest` + `@tailwindcss/postcss`
+2. Point `postcss.config.js` at the `@tailwindcss/postcss` plugin only
+3. Convert `tailwind.config.js` theme/extend values into an `@theme { --color-*, --font-*, ... }` block in CSS
+4. Replace `@tailwind` directives with `@import "tailwindcss"`
+5. Delete `tailwind.config.{js,ts,mjs,cjs}`
 
-**GOOD - Tailwind v4:**
-
-```css
-/* app.css or globals.css */
-@import "tailwindcss";
-
-@theme {
-  --color-primary: #3b82f6;
-  --color-secondary: #64748b;
-  --font-sans: "Inter", sans-serif;
-  --breakpoint-3xl: 1920px;
-}
-```
-
-**BAD - Tailwind v3:**
-
-```css
-/* Old v3 directives */
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-```
-
-### 3. Config Files
-
-**BAD - Should not exist in v4:**
-
-- `tailwind.config.js`
-- `tailwind.config.ts`
-- `tailwind.config.mjs`
-- `tailwind.config.cjs`
-
-**Note**: These files are deprecated in v4. All configuration should be in CSS using `@theme`.
-
-### 4. PostCSS Configuration
-
-**GOOD - v4:**
-
-```js
-// postcss.config.js (minimal or not needed)
-export default {
-  plugins: {
-    '@tailwindcss/postcss': {},
-  },
-};
-```
-
-**BAD - v3:**
-
-```js
-// postcss.config.js
-module.exports = {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-};
-```
-
-### 5. Import Patterns
-
-**GOOD:**
-
-```css
-@import "tailwindcss";
-@import "tailwindcss/preflight";
-@import "tailwindcss/utilities";
-```
-
-**BAD:**
-
-```css
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-```
-
-## Validation Output
-
-```
-=== Tailwind 4 Validation Report ===
-
-Package Version: tailwindcss@4.0.14 ✓
-
-CSS Configuration:
-  ✓ Found @import "tailwindcss" in src/app/globals.css
-  ✓ Found @theme block with 12 custom properties
-  ✗ Found @tailwind directive in src/styles/legacy.css (line 3)
-
-Config Files:
-  ✗ Found tailwind.config.ts - should migrate to CSS @theme
-
-PostCSS:
-  ✓ Using @tailwindcss/postcss plugin
-
-Summary: 2 issues found
-  - Migrate tailwind.config.ts to @theme in CSS
-  - Remove @tailwind directives from src/styles/legacy.css
-```
-
-## Migration Guide
-
-### From Tailwind v3 to v4
-
-1. **Update package.json:**
-
-```bash
-bun remove tailwindcss autoprefixer
-bun add tailwindcss@latest @tailwindcss/postcss
-```
-
-1. **Update postcss.config.js:**
-
-```js
-export default {
-  plugins: {
-    '@tailwindcss/postcss': {},
-  },
-};
-```
-
-1. **Convert tailwind.config.js to CSS @theme:**
-
-**Before (v3):**
-
-```js
-// tailwind.config.js
-module.exports = {
-  theme: {
-    extend: {
-      colors: {
-        primary: '#3b82f6',
-        secondary: '#64748b',
-      },
-      fontFamily: {
-        sans: ['Inter', 'sans-serif'],
-      },
-    },
-  },
-};
-```
-
-**After (v4):**
-
-```css
-/* globals.css */
-@import "tailwindcss";
-
-@theme {
-  --color-primary: #3b82f6;
-  --color-secondary: #64748b;
-  --font-sans: "Inter", sans-serif;
-}
-```
-
-1. **Replace @tailwind directives:**
-
-**Before:**
-
-```css
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-```
-
-**After:**
-
-```css
-@import "tailwindcss";
-```
-
-1. **Delete old config files:**
-
-```bash
-rm tailwind.config.js tailwind.config.ts
-```
+See `references/full-guide.md` (§ Migration Guide, § CI/CD Integration) for the exact before/after code per step and a CI workflow snippet.
 
 ## Common v3 Patterns to Avoid
 
@@ -244,106 +68,11 @@ rm tailwind.config.js tailwind.config.ts
 | `content: ['./src/**/*.tsx']` | Not needed (auto-detected) |
 | `plugins: [require('@tailwindcss/forms')]` | `@plugin "@tailwindcss/forms"` |
 
-## v4 @theme Reference
-
-```css
-@import "tailwindcss";
-
-@theme {
-  /* Colors */
-  --color-primary: #3b82f6;
-  --color-primary-50: #eff6ff;
-  --color-primary-900: #1e3a8a;
-
-  /* Typography */
-  --font-sans: "Inter", system-ui, sans-serif;
-  --font-mono: "JetBrains Mono", monospace;
-
-  /* Spacing (extends default scale) */
-  --spacing-128: 32rem;
-
-  /* Breakpoints */
-  --breakpoint-3xl: 1920px;
-
-  /* Animations */
-  --animate-fade-in: fade-in 0.3s ease-out;
-
-  /* Shadows */
-  --shadow-glow: 0 0 20px rgba(59, 130, 246, 0.5);
-
-  /* Border radius */
-  --radius-4xl: 2rem;
-}
-
-@keyframes fade-in {
-  from { opacity: 0; }
-  to { opacity: 1; }
-}
-```
-
-## Using with shadcn/ui
-
-shadcn/ui v2+ supports Tailwind v4. After running the shadcn CLI:
-
-1. Verify `components.json` uses CSS variables
-2. Check that generated components use v4 patterns
-3. Ensure `@theme` includes shadcn color tokens:
-
-```css
-@theme {
-  --color-background: hsl(0 0% 100%);
-  --color-foreground: hsl(222.2 84% 4.9%);
-  --color-card: hsl(0 0% 100%);
-  --color-card-foreground: hsl(222.2 84% 4.9%);
-  --color-popover: hsl(0 0% 100%);
-  --color-popover-foreground: hsl(222.2 84% 4.9%);
-  --color-primary: hsl(222.2 47.4% 11.2%);
-  --color-primary-foreground: hsl(210 40% 98%);
-  --color-secondary: hsl(210 40% 96.1%);
-  --color-secondary-foreground: hsl(222.2 47.4% 11.2%);
-  --color-muted: hsl(210 40% 96.1%);
-  --color-muted-foreground: hsl(215.4 16.3% 46.9%);
-  --color-accent: hsl(210 40% 96.1%);
-  --color-accent-foreground: hsl(222.2 47.4% 11.2%);
-  --color-destructive: hsl(0 84.2% 60.2%);
-  --color-destructive-foreground: hsl(210 40% 98%);
-  --color-border: hsl(214.3 31.8% 91.4%);
-  --color-input: hsl(214.3 31.8% 91.4%);
-  --color-ring: hsl(222.2 84% 4.9%);
-  --radius-sm: 0.25rem;
-  --radius-md: 0.375rem;
-  --radius-lg: 0.5rem;
-}
-```
-
-## CI/CD Integration
-
-Add to your CI pipeline:
-
-```yaml
-# .github/workflows/lint.yml
-- name: Validate Tailwind v4
-  run: |
-    python3 scripts/validate.py \
-      --root . \
-      --strict \
-      --ci
-```
+See `references/full-guide.md` (§ v4 @theme Reference, § Using with shadcn/ui) for a full `@theme` token example and shadcn/ui token setup.
 
 ## Troubleshooting
 
-### "Found tailwind.config.js but using v4"
-
-Some tools still generate v3 configs. Delete the file and use `@theme` instead.
-
-### "@tailwind directives found"
-
-Replace with `@import "tailwindcss"`. The old directives are not supported in v4.
-
-### "autoprefixer in postcss.config"
-
-Remove autoprefixer - it's built into `@tailwindcss/postcss`.
-
-### "content array in config"
-
-v4 auto-detects content files. Remove the `content` config entirely.
+- **"Found tailwind.config.js but using v4"** - some tools still generate v3 configs. Delete the file and use `@theme` instead.
+- **"@tailwind directives found"** - replace with `@import "tailwindcss"`. The old directives are not supported in v4.
+- **"autoprefixer in postcss.config"** - remove autoprefixer; it's built into `@tailwindcss/postcss`.
+- **"content array in config"** - v4 auto-detects content files. Remove the `content` config entirely.

--- a/.agents/skills/tailwind-validator/plugin.json
+++ b/.agents/skills/tailwind-validator/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "tailwind-validator",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Validate Tailwind CSS v4 configuration and detect/prevent Tailwind v3 patterns",
   "author": {
     "name": "Ship Shit Dev",

--- a/.agents/skills/tailwind-validator/references/full-guide.md
+++ b/.agents/skills/tailwind-validator/references/full-guide.md
@@ -1,0 +1,276 @@
+# Tailwind Validator - Full Guide
+
+## What Gets Checked
+
+### 1. Package Version
+
+```json
+// GOOD: v4+
+"tailwindcss": "^4.0.0"
+
+// BAD: v3
+"tailwindcss": "^3.4.0"
+```
+
+### 2. CSS Configuration (v4 CSS-first)
+
+**GOOD - Tailwind v4:**
+
+```css
+/* app.css or globals.css */
+@import "tailwindcss";
+
+@theme {
+  --color-primary: #3b82f6;
+  --color-secondary: #64748b;
+  --font-sans: "Inter", sans-serif;
+  --breakpoint-3xl: 1920px;
+}
+```
+
+**BAD - Tailwind v3:**
+
+```css
+/* Old v3 directives */
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+### 3. Config Files
+
+**BAD - Should not exist in v4:**
+
+- `tailwind.config.js`
+- `tailwind.config.ts`
+- `tailwind.config.mjs`
+- `tailwind.config.cjs`
+
+**Note**: These files are deprecated in v4. All configuration should be in CSS using `@theme`.
+
+### 4. PostCSS Configuration
+
+**GOOD - v4:**
+
+```js
+// postcss.config.js (minimal or not needed)
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};
+```
+
+**BAD - v3:**
+
+```js
+// postcss.config.js
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};
+```
+
+### 5. Import Patterns
+
+**GOOD:**
+
+```css
+@import "tailwindcss";
+@import "tailwindcss/preflight";
+@import "tailwindcss/utilities";
+```
+
+**BAD:**
+
+```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+## Validation Output
+
+```
+=== Tailwind 4 Validation Report ===
+
+Package Version: tailwindcss@4.0.14 ✓
+
+CSS Configuration:
+  ✓ Found @import "tailwindcss" in src/app/globals.css
+  ✓ Found @theme block with 12 custom properties
+  ✗ Found @tailwind directive in src/styles/legacy.css (line 3)
+
+Config Files:
+  ✗ Found tailwind.config.ts - should migrate to CSS @theme
+
+PostCSS:
+  ✓ Using @tailwindcss/postcss plugin
+
+Summary: 2 issues found
+  - Migrate tailwind.config.ts to @theme in CSS
+  - Remove @tailwind directives from src/styles/legacy.css
+```
+
+## Migration Guide
+
+### From Tailwind v3 to v4
+
+1. **Update package.json:**
+
+```bash
+bun remove tailwindcss autoprefixer
+bun add tailwindcss@latest @tailwindcss/postcss
+```
+
+1. **Update postcss.config.js:**
+
+```js
+export default {
+  plugins: {
+    '@tailwindcss/postcss': {},
+  },
+};
+```
+
+1. **Convert tailwind.config.js to CSS @theme:**
+
+**Before (v3):**
+
+```js
+// tailwind.config.js
+module.exports = {
+  theme: {
+    extend: {
+      colors: {
+        primary: '#3b82f6',
+        secondary: '#64748b',
+      },
+      fontFamily: {
+        sans: ['Inter', 'sans-serif'],
+      },
+    },
+  },
+};
+```
+
+**After (v4):**
+
+```css
+/* globals.css */
+@import "tailwindcss";
+
+@theme {
+  --color-primary: #3b82f6;
+  --color-secondary: #64748b;
+  --font-sans: "Inter", sans-serif;
+}
+```
+
+1. **Replace @tailwind directives:**
+
+**Before:**
+
+```css
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+```
+
+**After:**
+
+```css
+@import "tailwindcss";
+```
+
+1. **Delete old config files:**
+
+```bash
+rm tailwind.config.js tailwind.config.ts
+```
+
+## v4 @theme Reference
+
+```css
+@import "tailwindcss";
+
+@theme {
+  /* Colors */
+  --color-primary: #3b82f6;
+  --color-primary-50: #eff6ff;
+  --color-primary-900: #1e3a8a;
+
+  /* Typography */
+  --font-sans: "Inter", system-ui, sans-serif;
+  --font-mono: "JetBrains Mono", monospace;
+
+  /* Spacing (extends default scale) */
+  --spacing-128: 32rem;
+
+  /* Breakpoints */
+  --breakpoint-3xl: 1920px;
+
+  /* Animations */
+  --animate-fade-in: fade-in 0.3s ease-out;
+
+  /* Shadows */
+  --shadow-glow: 0 0 20px rgba(59, 130, 246, 0.5);
+
+  /* Border radius */
+  --radius-4xl: 2rem;
+}
+
+@keyframes fade-in {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+```
+
+## Using with shadcn/ui
+
+shadcn/ui v2+ supports Tailwind v4. After running the shadcn CLI:
+
+1. Verify `components.json` uses CSS variables
+2. Check that generated components use v4 patterns
+3. Ensure `@theme` includes shadcn color tokens:
+
+```css
+@theme {
+  --color-background: hsl(0 0% 100%);
+  --color-foreground: hsl(222.2 84% 4.9%);
+  --color-card: hsl(0 0% 100%);
+  --color-card-foreground: hsl(222.2 84% 4.9%);
+  --color-popover: hsl(0 0% 100%);
+  --color-popover-foreground: hsl(222.2 84% 4.9%);
+  --color-primary: hsl(222.2 47.4% 11.2%);
+  --color-primary-foreground: hsl(210 40% 98%);
+  --color-secondary: hsl(210 40% 96.1%);
+  --color-secondary-foreground: hsl(222.2 47.4% 11.2%);
+  --color-muted: hsl(210 40% 96.1%);
+  --color-muted-foreground: hsl(215.4 16.3% 46.9%);
+  --color-accent: hsl(210 40% 96.1%);
+  --color-accent-foreground: hsl(222.2 47.4% 11.2%);
+  --color-destructive: hsl(0 84.2% 60.2%);
+  --color-destructive-foreground: hsl(210 40% 98%);
+  --color-border: hsl(214.3 31.8% 91.4%);
+  --color-input: hsl(214.3 31.8% 91.4%);
+  --color-ring: hsl(222.2 84% 4.9%);
+  --radius-sm: 0.25rem;
+  --radius-md: 0.375rem;
+  --radius-lg: 0.5rem;
+}
+```
+
+## CI/CD Integration
+
+```yaml
+# .github/workflows/lint.yml
+- name: Validate Tailwind v4
+  run: |
+    python3 scripts/validate.py \
+      --root . \
+      --strict \
+      --ci
+```

--- a/.agents/skills/tailwind/SKILL.md
+++ b/.agents/skills/tailwind/SKILL.md
@@ -18,11 +18,9 @@ metadata:
 ---
 # Community Tailwind CSS v4 Best Practices
 
-Comprehensive performance optimization guide for Tailwind CSS v4 applications. Contains 44 rules across 8 categories, prioritized by impact to guide automated refactoring and code generation.
+44 rules across 8 categories for Tailwind CSS v4, prioritized by impact to guide automated refactoring and code generation.
 
 ## When to Apply
-
-Reference these guidelines when:
 
 - Configuring Tailwind CSS v4 build tooling (Vite plugin, PostCSS, CLI)
 - Writing or migrating styles using v4's CSS-first approach

--- a/.agents/skills/testing-expert/SKILL.md
+++ b/.agents/skills/testing-expert/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: testing-expert
-description: Expert in testing strategies for React, Next.js, and NestJS applications covering unit tests, integration tests, E2E tests, and testing best practices
+description: Expert in testing strategies for React, Next.js, and NestJS applications covering unit tests, integration tests, E2E tests, and testing best practices. Use when writing unit, integration, or E2E tests, testing React components, or testing API endpoints.
 metadata:
   version: "1.0.0"
   tags: "testing, quality, fullstack"
@@ -8,9 +8,7 @@ metadata:
 
 # Testing Expert Skill
 
-Expert in testing strategies for React, Next.js, and NestJS applications.
-
-## When to Use This Skill
+## When to Use
 
 - Writing unit tests
 - Creating integration tests

--- a/.agents/skills/typescript-expert/SKILL.md
+++ b/.agents/skills/typescript-expert/SKILL.md
@@ -10,19 +10,17 @@ metadata:
   category: framework
   risk: critical
   date_added: '2026-02-27'
-  version: "1.0.0"
+  version: "1.0.1"
   tags: "typescript, javascript, tooling"
 ---
 
 # TypeScript Expert
 
-You are an advanced TypeScript expert with deep, practical knowledge of type-level programming, performance optimization, and real-world problem solving based on current best practices.
-
 ## When invoked
 
 1. Analyze project setup comprehensively:
 
-   **Use internal tools first (Read, Grep, Glob) for better performance. Shell commands are fallbacks.**
+   **Prefer built-in file-reading and search capabilities for performance. Shell commands are fallbacks.**
 
    ```bash
    # Core versions and configuration
@@ -42,7 +40,7 @@ You are an advanced TypeScript expert with deep, practical knowledge of type-lev
 
 2. Identify the specific problem category and complexity level
 
-3. Apply the appropriate solution strategy from my expertise
+3. Apply the appropriate solution strategy from the expertise below
 
 4. Validate thoroughly:
 
@@ -60,70 +58,21 @@ You are an advanced TypeScript expert with deep, practical knowledge of type-lev
 
 ### Type-Level Programming Patterns
 
-**Branded Types for Domain Modeling**
+**Branded Types for Domain Modeling** — nominal types (`type UserId = Brand<string, 'UserId'>`) prevent accidentally mixing domain primitives that share a base type. Use for critical domain primitives, API boundaries, currency/units. See `references/typescript-cheatsheet.md` (§ Branded Types) for the full pattern. Resource: https://egghead.io/blog/using-branded-types-in-typescript
 
-```typescript
-// Create nominal types to prevent primitive obsession
-type Brand<K, T> = K & { __brand: T };
-type UserId = Brand<string, 'UserId'>;
-type OrderId = Brand<string, 'OrderId'>;
+**Advanced Conditional Types** — recursive type manipulation (e.g. `DeepReadonly<T>`) and template-literal event-source APIs. Use for library APIs, type-safe event systems, compile-time validation. Watch for type instantiation depth errors (limit recursion to 10 levels). See `references/typescript-cheatsheet.md` (§ Conditional Types, § Mapped Types, § Template Literal Types).
 
-// Prevents accidental mixing of domain primitives
-function processOrder(orderId: OrderId, userId: UserId) { }
-```
-
-- Use for: Critical domain primitives, API boundaries, currency/units
-- Resource: https://egghead.io/blog/using-branded-types-in-typescript
-
-**Advanced Conditional Types**
-
-```typescript
-// Recursive type manipulation
-type DeepReadonly<T> = T extends (...args: any[]) => any 
-  ? T 
-  : T extends object 
-    ? { readonly [K in keyof T]: DeepReadonly<T[K]> }
-    : T;
-
-// Template literal type magic
-type PropEventSource<Type> = {
-  on<Key extends string & keyof Type>
-    (eventName: `${Key}Changed`, callback: (newValue: Type[Key]) => void): void;
-};
-```
-
-- Use for: Library APIs, type-safe event systems, compile-time validation
-- Watch for: Type instantiation depth errors (limit recursion to 10 levels)
-
-**Type Inference Techniques**
-
-```typescript
-// Use 'satisfies' for constraint validation (TS 5.0+)
-const config = {
-  api: "https://api.example.com",
-  timeout: 5000
-} satisfies Record<string, string | number>;
-// Preserves literal types while ensuring constraints
-
-// Const assertions for maximum inference
-const routes = ['/home', '/about', '/contact'] as const;
-type Route = typeof routes[number]; // '/home' | '/about' | '/contact'
-```
+**Type Inference Techniques** — use `satisfies` (TS 5.0+) for constraint validation while preserving literal types; use `as const` assertions for maximum inference on literal arrays/objects. See `references/typescript-cheatsheet.md` (§ Best Practices).
 
 ### Performance Optimization Strategies
 
 **Type Checking Performance**
 
 ```bash
-# Diagnose slow type checking
 bunx tsc --extendedDiagnostics --incremental false | grep -E "Check time|Files:|Lines:|Nodes:"
-
-# Common fixes for "Type instantiation is excessively deep"
-# 1. Replace type intersections with interfaces
-# 2. Split large union types (>100 members)
-# 3. Avoid circular generic constraints
-# 4. Use type aliases to break recursion
 ```
+
+Common fixes for "Type instantiation is excessively deep": replace type intersections with interfaces, split large union types (>100 members), avoid circular generic constraints, use type aliases to break recursion.
 
 **Build Performance Patterns**
 
@@ -139,83 +88,41 @@ bunx tsc --extendedDiagnostics --incremental false | grep -E "Check time|Files:|
 **"The inferred type of X cannot be named"**
 
 - Cause: Missing type export or circular dependency
-- Fix priority:
-  1. Export the required type explicitly
-  2. Use `ReturnType<typeof function>` helper
-  3. Break circular dependencies with type-only imports
+- Fix priority: export the required type explicitly; use `ReturnType<typeof function>` helper; break circular dependencies with type-only imports
 - Resource: https://github.com/microsoft/TypeScript/issues/47663
 
-**Missing type declarations**
-
-- Quick fix with ambient declarations:
-
-```typescript
-// types/ambient.d.ts
-declare module 'some-untyped-package' {
-  const value: unknown;
-  export default value;
-  export = value; // if CJS interop is needed
-}
-```
-
-- For more details: [Declaration Files Guide](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html)
+**Missing type declarations** — add an ambient `.d.ts` module declaration for untyped packages. See `references/typescript-cheatsheet.md` (§ Module Declarations). For more detail: [Declaration Files Guide](https://www.typescriptlang.org/docs/handbook/declaration-files/introduction.html)
 
 **"Excessive stack depth comparing types"**
 
 - Cause: Circular or deeply recursive types
-- Fix priority:
-  1. Limit recursion depth with conditional types
-  2. Use `interface` extends instead of type intersection
-  3. Simplify generic constraints
+- Fix priority: limit recursion depth with conditional types; use `interface` extends instead of type intersection; simplify generic constraints
 
 ```typescript
 // Bad: Infinite recursion
 type InfiniteArray<T> = T | InfiniteArray<T>[];
 
 // Good: Limited recursion
-type NestedArray<T, D extends number = 5> = 
+type NestedArray<T, D extends number = 5> =
   D extends 0 ? T : T | NestedArray<T, [-1, 0, 1, 2, 3, 4][D]>[];
 ```
 
-**Module Resolution Mysteries**
+**Module Resolution Mysteries** — "Cannot find module" despite the file existing:
 
-- "Cannot find module" despite file existing:
-  1. Check `moduleResolution` matches your bundler
-  2. Verify `baseUrl` and `paths` alignment
-  3. For monorepos: Ensure workspace protocol (workspace:*)
-  4. Try clearing cache: `rm -rf node_modules/.cache .tsbuildinfo`
+1. Check `moduleResolution` matches your bundler
+2. Verify `baseUrl` and `paths` alignment
+3. For monorepos: Ensure workspace protocol (`workspace:*`)
+4. Try clearing cache: `rm -rf node_modules/.cache .tsbuildinfo`
 
-**Path Mapping at Runtime**
+**Path Mapping at Runtime** — TypeScript paths only work at compile time, not runtime:
 
-- TypeScript paths only work at compile time, not runtime
-- Node.js runtime solutions:
-  - ts-node: Use `ts-node -r tsconfig-paths/register`
-  - Node ESM: Use loader alternatives or avoid TS paths at runtime
-  - Production: Pre-compile with resolved paths
+- ts-node: use `ts-node -r tsconfig-paths/register`
+- Node ESM: use loader alternatives or avoid TS paths at runtime
+- Production: pre-compile with resolved paths
 
 ### Migration Expertise
 
-**JavaScript to TypeScript Migration**
-
-```bash
-# Incremental migration strategy
-# 1. Enable allowJs and checkJs (merge into existing tsconfig.json):
-# Add to existing tsconfig.json:
-# {
-#   "compilerOptions": {
-#     "allowJs": true,
-#     "checkJs": true
-#   }
-# }
-
-# 2. Rename files gradually (.js → .ts)
-# 3. Add types file by file using AI assistance
-# 4. Enable strict mode features one by one
-
-# Automated helpers (if installed/needed)
-command -v ts-migrate >/dev/null 2>&1 && bunx ts-migrate migrate . --sources 'src/**/*.js'
-command -v typesync >/dev/null 2>&1 && bunx typesync  # Install missing @types packages
-```
+**JavaScript to TypeScript Migration** — incremental strategy: enable `allowJs`/`checkJs` in the existing tsconfig, rename files gradually (`.js` → `.ts`), add types file by file, enable strict mode features one by one. See `references/full-guide.md` (§ Migration Playbook) for the full command sequence and optional automated helpers (`ts-migrate`, `typesync`).
 
 **Tool Migration Decisions**
 
@@ -234,118 +141,33 @@ command -v typesync >/dev/null 2>&1 && bunx typesync  # Install missing @types p
 - Choose **Nx** if: Complex dependencies, need visualization, plugins required
 - Performance: Nx often performs better on large monorepos (>50 packages)
 
-**TypeScript Monorepo Configuration**
-
-```json
-// Root tsconfig.json
-{
-  "references": [
-    { "path": "./packages/core" },
-    { "path": "./packages/ui" },
-    { "path": "./apps/web" }
-  ],
-  "compilerOptions": {
-    "composite": true,
-    "declaration": true,
-    "declarationMap": true
-  }
-}
-```
+**TypeScript Monorepo Configuration** — root tsconfig `references` array plus `composite`/`declaration`/`declarationMap` per package. See `references/full-guide.md` (§ Monorepo TypeScript Configuration) for the full config.
 
 ## Modern Tooling Expertise
 
 ### Biome vs ESLint
 
-**Use Biome when:**
+**Use Biome when:** speed is critical, want a single tool for lint + format, TypeScript-first project, okay with 64 TS rules vs 100+ in typescript-eslint.
 
-- Speed is critical (often faster than traditional setups)
-- Want single tool for lint + format
-- TypeScript-first project
-- Okay with 64 TS rules vs 100+ in typescript-eslint
-
-**Stay with ESLint when:**
-
-- Need specific rules/plugins
-- Have complex custom rules
-- Working with Vue/Angular (limited Biome support)
-- Need type-aware linting (Biome doesn't have this yet)
+**Stay with ESLint when:** need specific rules/plugins, have complex custom rules, working with Vue/Angular (limited Biome support), need type-aware linting (Biome doesn't have this yet).
 
 ### Type Testing Strategies
 
-**Vitest Type Testing (Recommended)**
+**Vitest Type Testing (Recommended)** — write `.test-d.ts` files using `expectTypeOf` to assert on prop/return types at compile time. See `references/full-guide.md` (§ Vitest Type Testing) for a full example.
 
-```typescript
-// in avatar.test-d.ts
-import { expectTypeOf } from 'vitest'
-import type { Avatar } from './avatar'
-
-test('Avatar props are correctly typed', () => {
-  expectTypeOf<Avatar>().toHaveProperty('size')
-  expectTypeOf<Avatar['size']>().toEqualTypeOf<'sm' | 'md' | 'lg'>()
-})
-```
-
-**When to Test Types:**
-
-- Publishing libraries
-- Complex generic functions
-- Type-level utilities
-- API contracts
+**When to Test Types:** publishing libraries, complex generic functions, type-level utilities, API contracts.
 
 ## Debugging Mastery
 
-### CLI Debugging Tools
+**CLI Debugging Tools** — trace module resolution (`tsc --traceResolution`), profile type-check performance (`tsc --generateTrace`), debug files directly with `tsx`/`ts-node --inspect-brk`. See `references/full-guide.md` (§ CLI Debugging Tools) for the full command set.
 
-```bash
-# Debug TypeScript files directly (if tools installed)
-command -v tsx >/dev/null 2>&1 && bunx tsx --inspect src/file.ts
-command -v ts-node >/dev/null 2>&1 && bunx ts-node --inspect-brk src/file.ts
-
-# Trace module resolution issues
-bunx tsc --traceResolution > resolution.log 2>&1
-grep "Module resolution" resolution.log
-
-# Debug type checking performance (use --incremental false for clean trace)
-bunx tsc --generateTrace trace --incremental false
-# Analyze trace (if installed)
-command -v @typescript/analyze-trace >/dev/null 2>&1 && bunx @typescript/analyze-trace trace
-
-# Memory usage analysis
-node --max-old-space-size=8192 node_modules/typescript/lib/tsc.js
-```
-
-### Custom Error Classes
-
-```typescript
-// Proper error class with stack preservation
-class DomainError extends Error {
-  constructor(
-    message: string,
-    public code: string,
-    public statusCode: number
-  ) {
-    super(message);
-    this.name = 'DomainError';
-    Error.captureStackTrace(this, this.constructor);
-  }
-}
-```
+**Custom Error Classes** — extend `Error`, set `this.name`, and call `Error.captureStackTrace` to preserve the stack. See `references/full-guide.md` (§ Custom Error Classes) for the full pattern.
 
 ## Current Best Practices
 
 ### Strict by Default
 
-```json
-{
-  "compilerOptions": {
-    "strict": true,
-    "noUncheckedIndexedAccess": true,
-    "noImplicitOverride": true,
-    "exactOptionalPropertyTypes": true,
-    "noPropertyAccessFromIndexSignature": true
-  }
-}
-```
+Use `strict: true` plus `noUncheckedIndexedAccess`, `noImplicitOverride`, `exactOptionalPropertyTypes`, `noPropertyAccessFromIndexSignature`. See `references/tsconfig-strict.json` for a full production-ready strict config.
 
 ### ESM-First Approach
 
@@ -354,18 +176,15 @@ class DomainError extends Error {
 - Configure `"moduleResolution": "bundler"` for modern tools
 - Use dynamic imports for CJS: `const pkg = await import('cjs-package')`
   - Note: `await import()` requires async function or top-level await in ESM
-  - For CJS packages in ESM: May need `(await import('pkg')).default` depending on the package's export structure and your compiler settings
+  - For CJS packages in ESM: may need `(await import('pkg')).default` depending on the package's export structure and compiler settings
 
 ### AI-Assisted Development
 
-- GitHub Copilot excels at TypeScript generics
-- Use AI for boilerplate type definitions
+- AI coding assistants excel at TypeScript generics and boilerplate type definitions
 - Validate AI-generated types with type tests
 - Document complex types for AI context
 
 ## Code Review Checklist
-
-When reviewing TypeScript/JavaScript code, focus on these domain-specific aspects:
 
 ### Type Safety
 
@@ -395,17 +214,14 @@ When reviewing TypeScript/JavaScript code, focus on these domain-specific aspect
 
 ### Module System
 
-- [ ] Consistent import/export patterns
-- [ ] No circular dependencies
+- [ ] Consistent import/export patterns, no circular dependencies
 - [ ] Proper use of barrel exports (avoid over-bundling)
-- [ ] ESM/CJS compatibility handled correctly
-- [ ] Dynamic imports for code splitting
+- [ ] ESM/CJS compatibility handled correctly, dynamic imports for code splitting
 
 ### Error Handling Patterns
 
 - [ ] Result types or discriminated unions for errors
-- [ ] Custom error classes with proper inheritance
-- [ ] Type-safe error boundaries
+- [ ] Custom error classes with proper inheritance, type-safe error boundaries
 - [ ] Exhaustive switch cases with `never` type
 
 ### Code Organization
@@ -417,19 +233,15 @@ When reviewing TypeScript/JavaScript code, focus on these domain-specific aspect
 
 ## Quick Decision Trees
 
-### "Which tool should I use?"
-
 ```
+"Which tool should I use?"
 Type checking only? → tsc
-Type checking + linting speed critical? → Biome  
+Type checking + linting speed critical? → Biome
 Type checking + comprehensive linting? → ESLint + typescript-eslint
 Type testing? → Vitest expectTypeOf
 Build tool? → Project size <10 packages? Turborepo. Else? Nx
-```
 
-### "How do I fix this performance issue?"
-
-```
+"How do I fix this performance issue?"
 Slow type checking? → skipLibCheck, incremental, project references
 Slow builds? → Check bundler config, enable caching
 Slow tests? → Vitest with threads, avoid type checking in tests
@@ -438,25 +250,9 @@ Slow language server? → Exclude node_modules, limit files in tsconfig
 
 ## Expert Resources
 
-### Performance
-
-- [TypeScript Wiki Performance](https://github.com/microsoft/TypeScript/wiki/Performance)
-- [Type instantiation tracking](https://github.com/microsoft/TypeScript/pull/48077)
-
-### Advanced Patterns
-
-- [Type Challenges](https://github.com/type-challenges/type-challenges)
-- [Type-Level TypeScript Course](https://type-level-typescript.com)
-
-### Tools
-
-- [Biome](https://biomejs.dev) - Fast linter/formatter
-- [TypeStat](https://github.com/JoshuaKGoldberg/TypeStat) - Auto-fix TypeScript types
-- [ts-migrate](https://github.com/airbnb/ts-migrate) - Migration toolkit
-
-### Testing
-
-- [Vitest Type Testing](https://vitest.dev/guide/testing-types)
-- [tsd](https://github.com/tsdjs/tsd) - Standalone type testing
+- Performance: [TypeScript Wiki Performance](https://github.com/microsoft/TypeScript/wiki/Performance), [Type instantiation tracking](https://github.com/microsoft/TypeScript/pull/48077)
+- Advanced patterns: [Type Challenges](https://github.com/type-challenges/type-challenges), [Type-Level TypeScript Course](https://type-level-typescript.com)
+- Tools: [Biome](https://biomejs.dev) (linter/formatter), [TypeStat](https://github.com/JoshuaKGoldberg/TypeStat) (auto-fix types), [ts-migrate](https://github.com/airbnb/ts-migrate) (migration toolkit)
+- Testing: [Vitest Type Testing](https://vitest.dev/guide/testing-types), [tsd](https://github.com/tsdjs/tsd) (standalone type testing)
 
 Always validate changes don't break existing functionality before considering the issue resolved.

--- a/.agents/skills/typescript-expert/plugin.json
+++ b/.agents/skills/typescript-expert/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "typescript-expert",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "TypeScript and JavaScript expert with deep knowledge of type-level programming, performance optimiza",
   "author": {
     "name": "Ship Shit Dev",

--- a/.agents/skills/typescript-expert/references/full-guide.md
+++ b/.agents/skills/typescript-expert/references/full-guide.md
@@ -1,0 +1,94 @@
+# TypeScript Expert — Full Guide
+
+Extended examples and command sequences for the typescript-expert skill. See `SKILL.md` for workflow steps, decision tables, short inline patterns, and pointers to the other reference files in this skill.
+
+## Migration Playbook
+
+Incremental JavaScript → TypeScript migration:
+
+```bash
+# 1. Enable allowJs and checkJs (merge into existing tsconfig.json):
+# Add to existing tsconfig.json:
+# {
+#   "compilerOptions": {
+#     "allowJs": true,
+#     "checkJs": true
+#   }
+# }
+
+# 2. Rename files gradually (.js → .ts)
+# 3. Add types file by file
+# 4. Enable strict mode features one by one
+
+# Automated helpers (if installed/needed)
+command -v ts-migrate >/dev/null 2>&1 && bunx ts-migrate migrate . --sources 'src/**/*.js'
+command -v typesync >/dev/null 2>&1 && bunx typesync  # Install missing @types packages
+```
+
+## Monorepo TypeScript Configuration
+
+```json
+// Root tsconfig.json
+{
+  "references": [
+    { "path": "./packages/core" },
+    { "path": "./packages/ui" },
+    { "path": "./apps/web" }
+  ],
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true
+  }
+}
+```
+
+## Vitest Type Testing
+
+```typescript
+// in avatar.test-d.ts
+import { expectTypeOf } from 'vitest'
+import type { Avatar } from './avatar'
+
+test('Avatar props are correctly typed', () => {
+  expectTypeOf<Avatar>().toHaveProperty('size')
+  expectTypeOf<Avatar['size']>().toEqualTypeOf<'sm' | 'md' | 'lg'>()
+})
+```
+
+## CLI Debugging Tools
+
+```bash
+# Debug TypeScript files directly (if tools installed)
+command -v tsx >/dev/null 2>&1 && bunx tsx --inspect src/file.ts
+command -v ts-node >/dev/null 2>&1 && bunx ts-node --inspect-brk src/file.ts
+
+# Trace module resolution issues
+bunx tsc --traceResolution > resolution.log 2>&1
+grep "Module resolution" resolution.log
+
+# Debug type checking performance (use --incremental false for clean trace)
+bunx tsc --generateTrace trace --incremental false
+# Analyze trace (if installed)
+command -v @typescript/analyze-trace >/dev/null 2>&1 && bunx @typescript/analyze-trace trace
+
+# Memory usage analysis
+node --max-old-space-size=8192 node_modules/typescript/lib/tsc.js
+```
+
+## Custom Error Classes
+
+```typescript
+// Proper error class with stack preservation
+class DomainError extends Error {
+  constructor(
+    message: string,
+    public code: string,
+    public statusCode: number
+  ) {
+    super(message);
+    this.name = 'DomainError';
+    Error.captureStackTrace(this, this.constructor);
+  }
+}
+```

--- a/.agents/skills/typescript-refactor/SKILL.md
+++ b/.agents/skills/typescript-refactor/SKILL.md
@@ -8,11 +8,9 @@ metadata:
 
 # TypeScript Refactor Best Practices
 
-Comprehensive TypeScript refactoring and modernization guide designed for AI agents and LLMs. Contains 43 rules across 8 categories, prioritized by impact to guide automated refactoring, code review, and code generation.
+43 rules across 8 categories for TypeScript refactoring and modernization, prioritized by impact to guide automated refactoring, code review, and code generation.
 
 ## When to Apply
-
-Reference these guidelines when:
 
 - Refactoring TypeScript code for type safety and maintainability
 - Designing type architectures (discriminated unions, branded types, generics)


### PR DESCRIPTION
## Summary
Syncs tracked `.agents/skills/` with the latest shipshitdev/skills master (model-agnosticism audit: platform decoupling, long examples moved to `references/`, version bumps).

## Changes
- 34 shared skills updated to current library content
- Project-local skills (claude-code-guide, github-label-sync, remotion, writing-prds) untouched

## Verification
- Content-hash comparison against library master: 0 stale shared skills after this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)