### PR TITLE
feat(desktop): sign + notarize macOS release builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,7 @@ on:
         type: boolean
         default: true
       build_macos:
-        description: "Build + upload desktop macOS installers (unsigned dmg + zip)"
+        description: "Build + upload desktop macOS installers (signed + notarized dmg + zip)"
         required: false
         type: boolean
         default: true
@@ -204,10 +204,61 @@ jobs:
         run: bun run turbo run build --filter=@shipcode/desktop^...
       - name: Build desktop app
         run: cd apps/desktop && bun run build:code
-      - name: Package macOS installers
-        run: cd apps/desktop && npx electron-builder --mac --${{ matrix.arch }} --publish never
+      # Fail fast with a clear message if any signing/notarization secret is
+      # missing, rather than letting electron-builder emit a cryptic error or
+      # (worse) silently fall back to an unsigned build.
+      - name: Verify signing + notarization secrets
         env:
-          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          APPLE_API_KEY_B64: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+        run: |
+          missing=0
+          for v in CSC_LINK CSC_KEY_PASSWORD APPLE_API_KEY_B64 APPLE_API_KEY_ID APPLE_API_ISSUER APPLE_TEAM_ID; do
+            if [ -z "${!v}" ]; then echo "::error::missing required secret: $v"; missing=1; fi
+          done
+          [ "$missing" = 0 ] || exit 1
+
+      # electron-builder / notarytool wants the API key as a file path. The
+      # secret holds the base64 of the .p8; decode it into the runner temp dir.
+      - name: Write App Store Connect API key
+        id: asc
+        env:
+          APPLE_API_KEY_B64: ${{ secrets.APPLE_API_KEY }}
+        run: |
+          KEY_PATH="$RUNNER_TEMP/asc_api_key.p8"
+          printf '%s' "$APPLE_API_KEY_B64" | base64 --decode > "$KEY_PATH"
+          echo "key_path=$KEY_PATH" >> "$GITHUB_OUTPUT"
+
+      - name: Package, sign, and notarize macOS installers
+        run: cd apps/desktop && npx electron-builder --mac --${{ matrix.arch }} --config electron-builder.signed.yml --publish never
+        env:
+          # electron-builder imports this cert into a disposable keychain and
+          # signs with the Developer ID identity pinned in the signed config.
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          # Notarization via App Store Connect API key (notarytool).
+          APPLE_API_KEY: ${{ steps.asc.outputs.key_path }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+
+      - name: Verify Developer ID signature + stapled notarization
+        run: |
+          set -e
+          APP=$(find apps/desktop/out -maxdepth 3 -name 'ShipCode.app' -type d | head -1)
+          if [ -z "$APP" ]; then echo "::error::ShipCode.app not found in out/"; exit 1; fi
+          echo "Verifying $APP"
+          codesign --verify --deep --strict --verbose=2 "$APP"
+          codesign -dvvv "$APP" 2>&1 | grep -i 'Authority=Developer ID Application'
+          for dmg in apps/desktop/out/*.dmg; do
+            echo "Stapler validate $dmg"
+            xcrun stapler validate "$dmg"
+          done
+
       - name: Upload macOS binaries to release
         run: |
           gh release upload "${{ needs.validate-release.outputs.release_tag }}" \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -204,21 +204,25 @@ jobs:
         run: bun run turbo run build --filter=@shipcode/desktop^...
       - name: Build desktop app
         run: cd apps/desktop && bun run build:code
-      # Fail fast with a clear message if any signing/notarization secret is
+      # Fail fast with a clear message if any signing/notarization credential is
       # missing, rather than letting electron-builder emit a cryptic error or
       # (worse) silently fall back to an unsigned build.
-      - name: Verify signing + notarization secrets
+      #
+      # Naming matches VincentShipsIt/macsweep: sensitive key material lives in
+      # secrets, non-sensitive identifiers (key id / issuer / team) in variables.
+      - name: Verify signing + notarization credentials
         env:
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          APPLE_API_KEY_B64: ${{ secrets.APPLE_API_KEY }}
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          DEVELOPER_ID_P12_BASE64: ${{ secrets.DEVELOPER_ID_P12_BASE64 }}
+          DEVELOPER_ID_P12_PASSWORD: ${{ secrets.DEVELOPER_ID_P12_PASSWORD }}
+          APPLE_API_PRIVATE_KEY_P8_BASE64: ${{ secrets.APPLE_API_PRIVATE_KEY_P8_BASE64 }}
+          APPLE_API_KEY_ID: ${{ vars.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER_ID: ${{ vars.APPLE_API_ISSUER_ID }}
+          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
         run: |
           missing=0
-          for v in CSC_LINK CSC_KEY_PASSWORD APPLE_API_KEY_B64 APPLE_API_KEY_ID APPLE_API_ISSUER APPLE_TEAM_ID; do
-            if [ -z "${!v}" ]; then echo "::error::missing required secret: $v"; missing=1; fi
+          for v in DEVELOPER_ID_P12_BASE64 DEVELOPER_ID_P12_PASSWORD APPLE_API_PRIVATE_KEY_P8_BASE64 \
+                   APPLE_API_KEY_ID APPLE_API_ISSUER_ID APPLE_TEAM_ID; do
+            if [ -z "${!v}" ]; then echo "::error::missing required credential: $v"; missing=1; fi
           done
           [ "$missing" = 0 ] || exit 1
 
@@ -227,24 +231,24 @@ jobs:
       - name: Write App Store Connect API key
         id: asc
         env:
-          APPLE_API_KEY_B64: ${{ secrets.APPLE_API_KEY }}
+          APPLE_API_PRIVATE_KEY_P8_BASE64: ${{ secrets.APPLE_API_PRIVATE_KEY_P8_BASE64 }}
         run: |
           KEY_PATH="$RUNNER_TEMP/asc_api_key.p8"
-          printf '%s' "$APPLE_API_KEY_B64" | base64 --decode > "$KEY_PATH"
+          printf '%s' "$APPLE_API_PRIVATE_KEY_P8_BASE64" | base64 --decode > "$KEY_PATH"
           echo "key_path=$KEY_PATH" >> "$GITHUB_OUTPUT"
 
       - name: Package, sign, and notarize macOS installers
         run: cd apps/desktop && npx electron-builder --mac --${{ matrix.arch }} --config electron-builder.signed.yml --publish never
         env:
-          # electron-builder imports this cert into a disposable keychain and
-          # signs with the Developer ID identity pinned in the signed config.
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+          # electron-builder imports this cert (base64 .p12) into a disposable
+          # keychain and signs with the Developer ID identity in the signed config.
+          CSC_LINK: ${{ secrets.DEVELOPER_ID_P12_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.DEVELOPER_ID_P12_PASSWORD }}
           # Notarization via App Store Connect API key (notarytool).
           APPLE_API_KEY: ${{ steps.asc.outputs.key_path }}
-          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
-          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
-          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_API_KEY_ID: ${{ vars.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ vars.APPLE_API_ISSUER_ID }}
+          APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
 
       - name: Verify Developer ID signature + stapled notarization
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -341,7 +341,7 @@ jobs:
             zap trash: [
               "~/Library/Application Support/ShipCode",
               "~/Library/Logs/ShipCode",
-              "~/Library/Preferences/com.shipcode.app.plist",
+              "~/Library/Preferences/dev.shipshit.shipcode.plist",
             ]
           end
           RUBY

--- a/apps/desktop/electron-builder.signed.yml
+++ b/apps/desktop/electron-builder.signed.yml
@@ -1,0 +1,44 @@
+# Signed + notarized macOS distribution build.
+# Opt-in path: `bun run build:installer:mac:signed`.
+# The base electron-builder.yml stays ad-hoc for local/CI builds with no cert.
+#
+# Requires these env vars (App Store Connect API key — see README/notarization):
+#   APPLE_API_KEY     path to (or base64 of) the .p8 key file
+#   APPLE_API_KEY_ID  the Key ID
+#   APPLE_API_ISSUER  the Issuer ID
+#   APPLE_TEAM_ID     C76R5DRH64
+appId: dev.shipshit.shipcode
+productName: ShipCode
+artifactName: "${productName}-${version}-${arch}.${ext}"
+directories:
+  output: out
+  buildResources: resources
+files:
+  - dist/**/*
+  - package.json
+# The srt sandbox CLI (and its native seccomp helper) must live on the real
+# filesystem so it can be spawned as a subprocess — it cannot run from inside
+# app.asar. resolveSrt() rewrites the resolved path to app.asar.unpacked.
+asarUnpack:
+  - node_modules/@anthropic-ai/sandbox-runtime/**
+mac:
+  target:
+    - dmg
+    - zip
+  category: public.app-category.developer-tools
+  # Real Developer ID signing (auto-discovered from keychain by this identity).
+  identity: "Developer ID Application: Vincent Tellier (C76R5DRH64)"
+  hardenedRuntime: true
+  gatekeeperAssess: false
+  entitlements: resources/entitlements.mac.plist
+  entitlementsInherit: resources/entitlements.mac.inherit.plist
+  # electron-builder drives notarytool with the APPLE_API_* env vars.
+  notarize:
+    teamId: C76R5DRH64
+  # NOTE: no ad-hoc afterPack here — real signing replaces it.
+linux:
+  target:
+    - AppImage
+    - deb
+  category: Development
+  maintainer: shipshit.dev <hello@shipshit.dev>

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -63,6 +63,7 @@
     "build:code": "tsc && vite build",
     "build:installer:linux": "bun run build:code && electron-builder --linux",
     "build:installer:mac": "bun run build:code && electron-builder --mac",
+    "build:installer:mac:signed": "bun run build:code && electron-builder --mac --config electron-builder.signed.yml",
     "clean": "rm -rf dist out",
     "coverage": "vitest run --coverage",
     "dev": "vite",

--- a/apps/desktop/resources/entitlements.mac.inherit.plist
+++ b/apps/desktop/resources/entitlements.mac.inherit.plist
@@ -5,8 +5,6 @@
   <!-- Child processes inherit the parent's entitlements. -->
   <key>com.apple.security.cs.allow-jit</key>
   <true/>
-  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-  <true/>
   <key>com.apple.security.cs.disable-library-validation</key>
   <true/>
   <key>com.apple.security.inherit</key>

--- a/apps/desktop/resources/entitlements.mac.inherit.plist
+++ b/apps/desktop/resources/entitlements.mac.inherit.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- Child processes inherit the parent's entitlements. -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.inherit</key>
+  <true/>
+</dict>
+</plist>

--- a/apps/desktop/resources/entitlements.mac.plist
+++ b/apps/desktop/resources/entitlements.mac.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- V8/Electron JIT -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <!-- Required so the app can spawn third-party CLIs (claude, codex, git) and
+       load the unpacked @anthropic-ai/sandbox-runtime native helper, which are
+       not signed by our Team ID. Without this, hardened runtime rejects them. -->
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
+  <true/>
+</dict>
+</plist>

--- a/apps/desktop/resources/entitlements.mac.plist
+++ b/apps/desktop/resources/entitlements.mac.plist
@@ -5,14 +5,10 @@
   <!-- V8/Electron JIT -->
   <key>com.apple.security.cs.allow-jit</key>
   <true/>
-  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-  <true/>
   <!-- Required so the app can spawn third-party CLIs (claude, codex, git) and
        load the unpacked @anthropic-ai/sandbox-runtime native helper, which are
        not signed by our Team ID. Without this, hardened runtime rejects them. -->
   <key>com.apple.security.cs.disable-library-validation</key>
-  <true/>
-  <key>com.apple.security.cs.allow-dyld-environment-variables</key>
   <true/>
 </dict>
 </plist>


### PR DESCRIPTION
## What

Adds a **Developer ID signing + notarization** path for the macOS Electron build, replacing the previous ad-hoc / unsigned output. Apps built by CI now run on other Macs without Gatekeeper warnings.

## Changes

- **`apps/desktop/electron-builder.signed.yml`** — opt-in build config: Developer ID identity, `hardenedRuntime: true`, entitlements, `notarize`. The base `electron-builder.yml` stays ad-hoc so local/CI builds with no cert keep working unchanged.
- **`apps/desktop/resources/entitlements.mac.plist` + `.inherit.plist`** — hardened-runtime entitlements, including `disable-library-validation` so spawned CLIs (claude/codex/git) and the unpacked `@anthropic-ai/sandbox-runtime` native helper still load under hardened runtime.
- **`apps/desktop/package.json`** — new `build:installer:mac:signed` script for local signed builds.
- **`.github/workflows/publish.yml`** — `build-desktop-macos` now builds with the signed config, imports the cert via `CSC_LINK`, notarizes via App Store Connect API key, and verifies the Developer ID signature + stapled ticket. Preflights secrets and fails fast if any are missing (no silent unsigned fallback).

## Required repo secrets

`CSC_LINK`, `CSC_KEY_PASSWORD`, `APPLE_API_KEY`, `APPLE_API_KEY_ID`, `APPLE_API_ISSUER`, `APPLE_TEAM_ID`

> ⚠️ CI signing stays disabled (job fails fast with a clear message) until these are set.

## Test plan

- [ ] Set the 6 repo secrets
- [ ] Local: `cd apps/desktop && bun run build:installer:mac:signed` → `codesign --verify` + `xcrun stapler validate` pass
- [ ] CI: tag a release → `build-desktop-macos` produces signed + notarized dmg/zip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - macOS installers are now code-signed and notarized for improved security and a smoother installation experience.
  - Added support for producing signed macOS DMG and ZIP packages.

- **Bug Fixes**
  - Updated Homebrew cleanup to remove the app’s current preference files correctly.

- **Build Improvements**
  - macOS packaging now verifies app signatures and notarization before release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->