### PR TITLE
fix(agents): detect Grok auth via credential file, not nonexistent `grok auth status`

### DIFF
--- a/packages/agents/src/health-check.test.ts
+++ b/packages/agents/src/health-check.test.ts
@@ -63,6 +63,7 @@ import {
   checkGeminiAuth,
   checkGeminiModelCapabilities,
   checkGhAuth,
+  checkGrokAuth,
   checkIntegrationStatus,
   checkOpenRouterAuth,
   checkOpenRouterHealth,
@@ -419,6 +420,53 @@ describe('checkCodexAuth', () => {
     mockAccess.mockRejectedValue(new Error('ENOENT'));
     const result = await checkCodexAuth();
     expect(result).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkGrokAuth
+//
+// Contract pinned against the real Grok Build CLI: there is NO `grok auth
+// status` subcommand (the surface is `grok login` / `grok logout`), so auth is
+// detected via env var (`XAI_API_KEY`) or the credential file `~/.grok/auth.json`
+// written by `grok login`. Probing a nonexistent subcommand exits non-zero and
+// would fail closed even for a logged-in user.
+// ---------------------------------------------------------------------------
+describe('checkGrokAuth', () => {
+  it('returns true when XAI_API_KEY is set', async () => {
+    execRouted({ 'printenv XAI_API_KEY': { stdout: 'xai-key\n' } });
+    mockAccess.mockRejectedValue(new Error('ENOENT'));
+    const result = await checkGrokAuth();
+    expect(result).toBe(true);
+  });
+
+  it('returns true when env var is unset but ~/.grok/auth.json exists', async () => {
+    execRouted({ 'printenv XAI_API_KEY': { stdout: '' } });
+    mockAccess.mockResolvedValue(undefined);
+    const result = await checkGrokAuth();
+    expect(result).toBe(true);
+  });
+
+  it('returns false when both env var and credential file are absent', async () => {
+    execRouted({ 'printenv XAI_API_KEY': { stdout: '' } });
+    mockAccess.mockRejectedValue(new Error('ENOENT'));
+    const result = await checkGrokAuth();
+    expect(result).toBe(false);
+  });
+
+  it('checks the ~/.grok/auth.json credential path (homedir mocked)', async () => {
+    execRouted({ 'printenv XAI_API_KEY': { stdout: '' } });
+    mockAccess.mockResolvedValue(undefined);
+    await checkGrokAuth();
+    expect(mockAccess).toHaveBeenCalledWith('/mock/home/.grok/auth.json');
+  });
+
+  it('never probes the nonexistent `grok auth status` subcommand', async () => {
+    execRouted({ 'printenv XAI_API_KEY': { stdout: '' } });
+    mockAccess.mockRejectedValue(new Error('ENOENT'));
+    await checkGrokAuth();
+    const invokedGrokAuth = mockExec.mock.calls.some(([cmd]) => String(cmd).includes('grok auth'));
+    expect(invokedGrokAuth).toBe(false);
   });
 });
 

--- a/packages/agents/src/health-check.ts
+++ b/packages/agents/src/health-check.ts
@@ -689,15 +689,14 @@ export async function checkGrokAuth(): Promise<boolean> {
     return true;
   }
 
-  // Otherwise rely on the CLI's own stored credentials. The exact status
-  // subcommand should be confirmed against the installed Grok Build CLI; this
-  // probe fails closed (reports unauthenticated) if the command differs.
-  try {
-    await execAsync('grok auth status', { timeout: 10_000, env: shellExecEnv() });
-    return true;
-  } catch {
-    return false;
-  }
+  // Otherwise rely on the CLI's own stored credentials. Grok Build has no
+  // `grok auth status` subcommand — its command surface is `grok login` /
+  // `grok logout`, which read/write `~/.grok/auth.json` (mode 0600). Probing a
+  // nonexistent subcommand exits non-zero and would fail closed even when the
+  // user is logged in, so we check for the credential file directly, mirroring
+  // `checkCodexAuth`'s `~/.codex/auth.json` check.
+  const grokAuthPath = join(homedir(), '.grok', 'auth.json');
+  return fileExists(grokAuthPath);
 }
 
 export type OpenRouterAuthStatus =


### PR DESCRIPTION
## Summary

Audit-gap fix from the 2026-07-10 14-day commit audit — **adversarially verified against the installed Grok Build CLI before fixing.**

`checkGrokAuth()` (shipped in #327 with the Grok Build executor) probed a `grok auth status` subcommand. **That subcommand does not exist.** The real CLI surface is `grok login` / `grok logout`:

```
$ grok auth status
error: unrecognized subcommand 'status'
$ echo $?   # → 2
```

Because the probe exits non-zero, `execAsync` rejected and `checkGrokAuth` **failed closed** — every user logged in via `grok login` (without `XAI_API_KEY` set) appeared **unauthenticated** in system health and model-capability gating, silently blocking the newly shipped executor. No test covered the real contract.

## Root cause + fix

Verified on the installed CLI that `grok login` stores credentials at `~/.grok/auth.json` (mode `0600`) — an exact structural mirror of codex's `~/.codex/auth.json`. The fix replaces the broken subcommand probe with a credential-file check, mirroring `checkCodexAuth()`:

```ts
if (await readEnvVar('XAI_API_KEY')) return true;      // headless fallback (unchanged)
const grokAuthPath = join(homedir(), '.grok', 'auth.json');
return fileExists(grokAuthPath);                        // was: execAsync('grok auth status')
```

Deterministic and offline — no network call, no reliance on a nonexistent command, no silent fail-closed.

## Tests

New `checkGrokAuth` suite pinning the contract (mirrors the `checkCodexAuth` tests):
- returns `true` when `XAI_API_KEY` is set
- returns `true` when env var absent but `~/.grok/auth.json` exists
- returns `false` when both absent
- asserts the exact `~/.grok/auth.json` path is probed
- **regression guard**: asserts we never invoke the nonexistent `grok auth` subcommand

## Verification

- `vitest run src/health-check.test.ts` → **109 passed** (5 new)
- `tsc --noEmit` clean · `biome check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)