### PR TITLE
refactor(pipeline): unify execute-phase checkpoint capture (#328 audit)

### DIFF
--- a/packages/git/src/checkpoint.test.ts
+++ b/packages/git/src/checkpoint.test.ts
@@ -10,6 +10,8 @@ import {
   deleteThreadCheckpointRefs,
   listCheckpointRefs,
   parseCheckpointTurn,
+  resolveCurrentBranch,
+  resolveHeadCommit,
   restoreCheckpoint,
 } from './checkpoint';
 
@@ -89,6 +91,33 @@ describe('checkpoint refs', () => {
     expect(second.turn).toBe(1);
     const refs = await listCheckpointRefs(repo, 'thread-1');
     expect(refs.map((ref) => ref.turn)).toEqual([0, 1]);
+  });
+
+  it('returns the worktree HEAD sha and branch so callers need no extra rev-parse', async () => {
+    const repo = makeRepo();
+    const headSha = git(repo, ['rev-parse', 'HEAD']);
+    const branch = git(repo, ['rev-parse', '--abbrev-ref', 'HEAD']);
+    writeFileSync(path.join(repo, 'fresh.txt'), 'untracked\n');
+
+    const captured = await captureCheckpoint(repo, 'thread-1');
+
+    // headSha is the worktree HEAD the checkpoint parents onto — NOT the
+    // checkpoint commit sha — so it is the correct diff base to persist.
+    expect(captured.headSha).toBe(headSha);
+    expect(captured.commitSha).not.toBe(headSha);
+    expect(git(repo, ['rev-parse', `${captured.refName}^`])).toBe(captured.headSha);
+    expect(captured.branch).toBe(branch);
+
+    // The standalone async resolvers agree with the captured metadata.
+    expect(await resolveHeadCommit(repo)).toBe(headSha);
+    expect(await resolveCurrentBranch(repo)).toBe(branch);
+  });
+
+  it('resolvers return null on a non-repo path instead of throwing', async () => {
+    const notRepo = mkdtempSync(path.join(os.tmpdir(), 'shipcode-notrepo-'));
+    tempDirs.push(notRepo);
+    expect(await resolveHeadCommit(notRepo)).toBeNull();
+    expect(await resolveCurrentBranch(notRepo)).toBeNull();
   });
 
   it('restores the captured filesystem state and removes post-checkpoint files', async () => {

--- a/packages/git/src/checkpoint.ts
+++ b/packages/git/src/checkpoint.ts
@@ -29,6 +29,15 @@ export interface CheckpointRef {
   turn: number;
   /** SHA of the checkpoint commit the ref points at (not the worktree HEAD). */
   commitSha: string;
+  /**
+   * Worktree HEAD commit the checkpoint parents onto (the base for restore/
+   * resume diffs), or `null` on an unborn HEAD. This is the sha callers should
+   * persist as the checkpoint's `commitSha` DB column — reuse it instead of a
+   * second `rev-parse HEAD` subprocess.
+   */
+  headSha: string | null;
+  /** Abbreviated current branch (`HEAD` when detached), or `null` if unresolved. */
+  branch: string | null;
 }
 
 async function runGit(cwd: string, args: string[], env?: Record<string, string>): Promise<string> {
@@ -39,6 +48,28 @@ async function runGit(cwd: string, args: string[], env?: Record<string, string>)
     ...(env ? { env: { ...process.env, ...env } } : {}),
   });
   return stdout.trim();
+}
+
+/**
+ * Async worktree HEAD commit resolver (peeled to a commit), `null` on failure
+ * or an unborn HEAD. Shared by capture and by callers that need the base sha
+ * when a full capture failed — never use synchronous git on hot pipeline paths.
+ */
+export async function resolveHeadCommit(cwd: string): Promise<string | null> {
+  try {
+    return await runGit(cwd, ['rev-parse', '--verify', 'HEAD^{commit}']);
+  } catch {
+    return null;
+  }
+}
+
+/** Async current-branch resolver (`HEAD` when detached), `null` on failure. */
+export async function resolveCurrentBranch(cwd: string): Promise<string | null> {
+  try {
+    return await runGit(cwd, ['rev-parse', '--abbrev-ref', 'HEAD']);
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -79,7 +110,9 @@ export async function listCheckpointRefs(
     const [refName, commitSha] = line.trim().split(' ');
     const turn = refName ? parseCheckpointTurn(refName) : null;
     if (refName && commitSha && turn !== null) {
-      refs.push({ refName, turn, commitSha });
+      // headSha/branch are capture-time worktree metadata not recoverable from
+      // a read-back ref; list consumers only use refName/turn.
+      refs.push({ refName, turn, commitSha, headSha: null, branch: null });
     }
   }
   return refs.sort((a, b) => a.turn - b.turn);
@@ -103,12 +136,9 @@ export async function captureCheckpoint(
   );
   const indexEnv = { GIT_INDEX_FILE: tempIndex };
 
-  let headSha: string | null = null;
-  try {
-    headSha = await runGit(worktreePath, ['rev-parse', '--verify', 'HEAD^{commit}']);
-  } catch {
-    headSha = null; // Unborn HEAD — capture still works, but has no parent.
-  }
+  // Unborn HEAD → null: capture still works, but the checkpoint has no parent.
+  const headSha = await resolveHeadCommit(worktreePath);
+  const branch = await resolveCurrentBranch(worktreePath);
 
   try {
     if (headSha) {
@@ -140,7 +170,7 @@ export async function captureCheckpoint(
       },
     );
     await runGit(worktreePath, ['update-ref', refName, commitSha]);
-    return { refName, turn, commitSha };
+    return { refName, turn, commitSha, headSha, branch };
   } finally {
     rmSync(tempIndex, { force: true });
   }

--- a/packages/git/src/index.ts
+++ b/packages/git/src/index.ts
@@ -1,21 +1,23 @@
-export type {
-  BranchSnapshot,
-  CleanupAnalysisInput,
-  PullRequestSnapshot,
-} from './cleanup-analyzer';
-export { analyzeCleanup } from './cleanup-analyzer';
 export type { CheckpointRef } from './checkpoint';
 export {
-  captureCheckpoint,
   CHECKPOINT_REF_ROOT,
+  captureCheckpoint,
   checkpointRefName,
   checkpointRefPrefix,
   deleteAllCheckpointRefs,
   deleteThreadCheckpointRefs,
   listCheckpointRefs,
   parseCheckpointTurn,
+  resolveCurrentBranch,
+  resolveHeadCommit,
   restoreCheckpoint,
 } from './checkpoint';
+export type {
+  BranchSnapshot,
+  CleanupAnalysisInput,
+  PullRequestSnapshot,
+} from './cleanup-analyzer';
+export { analyzeCleanup } from './cleanup-analyzer';
 export { GitService } from './git-service';
 export { WorktreeManager } from './worktree';
 export type { WorktreeArtifact, WorktreeArtifactCleanupResult } from './worktree-artifacts';

--- a/packages/pipeline/src/pipeline.github-issue.smoke.test.ts
+++ b/packages/pipeline/src/pipeline.github-issue.smoke.test.ts
@@ -29,7 +29,19 @@ vi.mock('@shipcode/git', () => {
     listBranches = vi.fn().mockResolvedValue([]);
     getDefaultBranch = vi.fn().mockResolvedValue('main');
   }
-  return { WorktreeManager, GitService };
+  return {
+    WorktreeManager,
+    GitService,
+    captureCheckpoint: vi.fn().mockResolvedValue({
+      refName: 'refs/shipcode/checkpoints/t1/turn/0',
+      turn: 0,
+      commitSha: 'snapshot-sha',
+      headSha: 'head-sha',
+      branch: 'main',
+    }),
+    resolveHeadCommit: vi.fn().mockResolvedValue('head-sha'),
+    resolveCurrentBranch: vi.fn().mockResolvedValue('main'),
+  };
 });
 
 const { mockExecSync } = vi.hoisted(() => ({ mockExecSync: vi.fn() }));

--- a/packages/pipeline/src/pipeline.test.ts
+++ b/packages/pipeline/src/pipeline.test.ts
@@ -7,6 +7,7 @@ import {
   createCodexCliProvider,
   createProviderRegistry,
 } from '@shipcode/agents';
+import { captureCheckpoint, resolveHeadCommit } from '@shipcode/git';
 import type { TaskGraphAssessment, TaskGraphWithNodes } from '@shipcode/shared';
 import {
   DEFAULT_SETTINGS,
@@ -51,7 +52,11 @@ vi.mock('@shipcode/git', () => {
       refName: 'refs/shipcode/checkpoints/t1/turn/0',
       turn: 0,
       commitSha: 'snapshot-sha',
+      headSha: 'head-sha',
+      branch: 'main',
     }),
+    resolveHeadCommit: vi.fn().mockResolvedValue('head-sha'),
+    resolveCurrentBranch: vi.fn().mockResolvedValue('main'),
   };
 });
 
@@ -2105,26 +2110,23 @@ Custom prompt`,
       expect(pipeline.getContext('t1')).toBeUndefined();
     });
 
-    it('fails execution when checkpoint creation throws', async () => {
-      mockExecSync.mockImplementation((cmd: string) => {
-        if (cmd === 'git rev-parse --abbrev-ref HEAD') {
-          throw new Error('rev-parse offline');
-        }
-        return '';
-      });
+    it('continues execution when checkpoint capture fails entirely', async () => {
+      // Failure policy: checkpoint capture is best-effort and must never fail
+      // the execute phase. Ref capture throws AND HEAD is unresolvable → the
+      // row is skipped, but the executor still runs.
+      vi.mocked(captureCheckpoint).mockRejectedValueOnce(new Error('capture offline'));
+      vi.mocked(resolveHeadCommit)
+        .mockResolvedValueOnce(null) // dedupe probe
+        .mockResolvedValueOnce(null); // commitSha fallback after capture failure
       const pipeline = createPipeline(mock.deps);
       pipeline.initializeContext('t1', { projectPath: '/proj', worktreePath: '/worktree' });
 
       await pipeline.startExecution('t1', JSON.parse(PLAN_JSON));
       await flush();
 
-      expect(mock.deps.threads.recordFailure).toHaveBeenCalledWith(
-        't1',
-        expect.any(String),
-        'Checkpoint creation failed: rev-parse offline',
-      );
-      expect(mock.deps.processManager.spawn).not.toHaveBeenCalled();
-      expect(pipeline.getContext('t1')).toBeUndefined();
+      expect(mock.deps.checkpoints.create).not.toHaveBeenCalled();
+      expect(mock.deps.threads.recordFailure).not.toHaveBeenCalled();
+      expect(mock.deps.processManager.spawn).toHaveBeenCalledTimes(1);
     });
 
     it('skips duplicate checkpoint creation for the same execute attempt', async () => {
@@ -2136,7 +2138,9 @@ Custom prompt`,
         reason: 'before_execute',
         label: 'Before execute attempt 1',
         branch: 'feat/test-branch',
-        commitSha: 'abc123',
+        // Dedupe compares the latest row's commitSha against the worktree's
+        // resolved HEAD ('head-sha' from the module mock above).
+        commitSha: 'head-sha',
         refName: null,
         createdAt: '',
       });

--- a/packages/pipeline/src/pipeline/execution-checkpoint.test.ts
+++ b/packages/pipeline/src/pipeline/execution-checkpoint.test.ts
@@ -1,0 +1,180 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import type { PipelineCheckpoint } from '@shipcode/shared';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  captureExecutionCheckpoint,
+  type ExecutionCheckpointDeps,
+  type ExecutionCheckpointMeta,
+} from './execution-checkpoint';
+
+const { mockCapture, mockResolveHead, mockResolveBranch } = vi.hoisted(() => ({
+  mockCapture: vi.fn(),
+  mockResolveHead: vi.fn(),
+  mockResolveBranch: vi.fn(),
+}));
+
+// The helper depends only on these three async git primitives — replace the
+// whole module so no real git runs and the failure paths are deterministic.
+vi.mock('@shipcode/git', () => ({
+  captureCheckpoint: mockCapture,
+  resolveHeadCommit: mockResolveHead,
+  resolveCurrentBranch: mockResolveBranch,
+}));
+
+type Created = Parameters<ExecutionCheckpointDeps['checkpoints']['create']>[0];
+
+function makeDeps(latest: PipelineCheckpoint | null = null) {
+  const created: Created[] = [];
+  const getLatest = vi.fn(() => latest);
+  const create = vi.fn((row: Created) => {
+    created.push(row);
+    return { id: 'ck', createdAt: '', ...row } as unknown as PipelineCheckpoint;
+  });
+  return { created, deps: { checkpoints: { getLatest, create } }, getLatest, create };
+}
+
+const CWD = '/tmp/worktree';
+
+function meta(overrides: Partial<ExecutionCheckpointMeta> = {}): ExecutionCheckpointMeta {
+  return {
+    projectId: 'proj-1',
+    phase: 'executing',
+    reason: 'after_execute',
+    label: (turn) => `label turn=${turn}`,
+    ...overrides,
+  };
+}
+
+describe('captureExecutionCheckpoint', () => {
+  beforeEach(() => {
+    mockCapture.mockReset();
+    mockResolveHead.mockReset();
+    mockResolveBranch.mockReset();
+  });
+
+  it('reuses the captured HEAD sha/branch on success and spawns no extra resolver call', async () => {
+    mockCapture.mockResolvedValue({
+      refName: 'refs/shipcode/checkpoints/t/turn/2',
+      turn: 2,
+      commitSha: 'checkpoint-commit',
+      headSha: 'head-sha',
+      branch: 'feat/x',
+    });
+    const { deps, create } = makeDeps();
+
+    await captureExecutionCheckpoint(CWD, 'thread-1', meta(), deps);
+
+    expect(mockCapture).toHaveBeenCalledTimes(1); // single staging per invocation (#3 guard)
+    // Hot path reuses captured metadata — no redundant rev-parse subprocess.
+    expect(mockResolveHead).not.toHaveBeenCalled();
+    expect(mockResolveBranch).not.toHaveBeenCalled();
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(create.mock.calls[0][0]).toMatchObject({
+      threadId: 'thread-1',
+      projectId: 'proj-1',
+      phase: 'executing',
+      reason: 'after_execute',
+      label: 'label turn=2', // label built from the captured turn
+      branch: 'feat/x',
+      commitSha: 'head-sha', // worktree HEAD, NOT the checkpoint commit
+      refName: 'refs/shipcode/checkpoints/t/turn/2',
+    });
+  });
+
+  // The two call sites (pre-execute dedupe=true, post-attempt dedupe=false) must
+  // behave IDENTICALLY on failure — previously they diverged (null-ref row vs no
+  // row). Parametrize the policy assertions over both.
+  for (const dedupe of [false, true]) {
+    describe(`failure policy (dedupe=${dedupe})`, () => {
+      it('writes a metadata-only row (refName=null) when ref capture throws', async () => {
+        mockCapture.mockRejectedValue(new Error('git exploded'));
+        mockResolveHead.mockResolvedValue('fallback-head');
+        mockResolveBranch.mockResolvedValue('main');
+        const { deps, create } = makeDeps();
+
+        await expect(
+          captureExecutionCheckpoint(CWD, 'thread-1', meta({ dedupe }), deps),
+        ).resolves.toBeUndefined(); // never throws → never blocks the phase
+
+        expect(create).toHaveBeenCalledTimes(1);
+        expect(create.mock.calls[0][0]).toMatchObject({
+          commitSha: 'fallback-head',
+          branch: 'main',
+          refName: null, // dense turn sequence preserved despite capture failure
+          label: 'label turn=null',
+        });
+      });
+
+      it('skips the row (never throws) when the worktree HEAD is unresolvable', async () => {
+        mockCapture.mockRejectedValue(new Error('git exploded'));
+        mockResolveHead.mockResolvedValue(null); // unborn / broken HEAD
+        mockResolveBranch.mockResolvedValue(null);
+        const { deps, create } = makeDeps();
+
+        await expect(
+          captureExecutionCheckpoint(CWD, 'thread-1', meta({ dedupe }), deps),
+        ).resolves.toBeUndefined();
+
+        expect(create).not.toHaveBeenCalled(); // commit_sha is NOT NULL → no row
+      });
+    });
+  }
+
+  it('dedupe skips an identical consecutive row without minting a ref', async () => {
+    mockResolveHead.mockResolvedValue('same-head');
+    const { deps, create } = makeDeps({
+      commitSha: 'same-head',
+      phase: 'executing',
+      reason: 'before_execute',
+    } as PipelineCheckpoint);
+
+    await captureExecutionCheckpoint(
+      CWD,
+      'thread-1',
+      meta({ reason: 'before_execute', dedupe: true }),
+      deps,
+    );
+
+    expect(mockCapture).not.toHaveBeenCalled(); // no orphan ref on a skipped row
+    expect(create).not.toHaveBeenCalled();
+  });
+
+  it('dedupe still captures when the latest row differs', async () => {
+    mockResolveHead.mockResolvedValue('new-head');
+    mockCapture.mockResolvedValue({
+      refName: 'refs/shipcode/checkpoints/t/turn/0',
+      turn: 0,
+      commitSha: 'ck',
+      headSha: 'new-head',
+      branch: 'main',
+    });
+    const { deps, create } = makeDeps({
+      commitSha: 'old-head', // different commit → not a duplicate
+      phase: 'executing',
+      reason: 'before_execute',
+    } as PipelineCheckpoint);
+
+    await captureExecutionCheckpoint(
+      CWD,
+      'thread-1',
+      meta({ reason: 'before_execute', dedupe: true }),
+      deps,
+    );
+
+    expect(mockCapture).toHaveBeenCalledTimes(1);
+    expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it('performs no synchronous git on the capture path', () => {
+    // Guards finding #2: sync git subprocesses freeze the Electron main event
+    // loop on the per-attempt hot path. The helper must use only async git.
+    const source = readFileSync(
+      fileURLToPath(new URL('./execution-checkpoint.ts', import.meta.url)),
+      'utf-8',
+    );
+    expect(source).not.toContain('execFileSync');
+    expect(source).not.toContain('execSync');
+    expect(source).not.toContain('child_process');
+  });
+});

--- a/packages/pipeline/src/pipeline/execution-checkpoint.ts
+++ b/packages/pipeline/src/pipeline/execution-checkpoint.ts
@@ -1,0 +1,115 @@
+import {
+  type CheckpointRef,
+  captureCheckpoint,
+  resolveCurrentBranch,
+  resolveHeadCommit,
+} from '@shipcode/git';
+import type { PipelineCheckpoint, PipelineCheckpointPhase } from '@shipcode/shared';
+
+/** Narrowed checkpoint-DB surface the capture helper needs. */
+export interface ExecutionCheckpointDeps {
+  checkpoints: {
+    getLatest(threadId: string): PipelineCheckpoint | null;
+    create(input: {
+      threadId: string;
+      projectId: string | null;
+      phase: PipelineCheckpointPhase;
+      reason: string;
+      label: string;
+      branch: string | null;
+      commitSha: string;
+      refName: string | null;
+    }): PipelineCheckpoint;
+  };
+}
+
+export interface ExecutionCheckpointMeta {
+  projectId: string | null;
+  phase: PipelineCheckpointPhase;
+  reason: string;
+  /**
+   * Row label, built once the checkpoint turn is known. Receives the captured
+   * turn, or `null` when ref capture failed (metadata-only fallback row).
+   */
+  label: (turn: number | null) => string;
+  /**
+   * Pre-execute only: skip writing when the latest row already pins this exact
+   * (commitSha, phase, reason). Post-attempt passes `false` — every attempt is
+   * a distinct checkpoint.
+   */
+  dedupe?: boolean;
+}
+
+/**
+ * Single capture-and-persist path for execute-phase checkpoints (issue #212),
+ * shared by the pre-execute and post-attempt call sites so both behave
+ * identically.
+ *
+ * ONE FAILURE POLICY (documented, identical at both sites): checkpoint capture
+ * is best-effort and MUST NEVER fail the execute phase.
+ *   - Ref capture throws  → still write a metadata-only row (`refName: null`)
+ *     so the checkpoint turn sequence stays dense regardless of which site ran
+ *     (the pre-execute and post-attempt sites previously diverged here — one
+ *     wrote a null-ref row, the other wrote nothing).
+ *   - Worktree HEAD unresolvable → skip the row (the `commit_sha` column is NOT
+ *     NULL) and log; the executor still runs.
+ *
+ * All git work is async (`execFile`), so the Electron main event loop is never
+ * blocked — this runs after every execute attempt (× task-graph nodes ×
+ * retries). On the hot success path the helper reuses the HEAD sha and branch
+ * `captureCheckpoint` already computed, so it spawns no redundant `rev-parse`
+ * subprocess; the async fallbacks fire only when ref capture failed.
+ */
+export async function captureExecutionCheckpoint(
+  cwd: string,
+  threadId: string,
+  meta: ExecutionCheckpointMeta,
+  deps: ExecutionCheckpointDeps,
+): Promise<void> {
+  // Pre-execute dedupe runs before capture so an identical consecutive entry
+  // never mints an orphan ref. This path executes once per execute entry (cold),
+  // so the extra async HEAD resolve is negligible.
+  if (meta.dedupe) {
+    const headForDedupe = await resolveHeadCommit(cwd);
+    const latest = deps.checkpoints.getLatest(threadId);
+    if (
+      headForDedupe &&
+      latest &&
+      latest.commitSha === headForDedupe &&
+      latest.phase === meta.phase &&
+      latest.reason === meta.reason
+    ) {
+      return;
+    }
+  }
+
+  let captured: CheckpointRef | null = null;
+  try {
+    captured = await captureCheckpoint(cwd, threadId);
+  } catch (captureError) {
+    console.error(`[pipeline] checkpoint ref capture failed for thread ${threadId}:`, captureError);
+  }
+
+  // Reuse the HEAD sha captureCheckpoint already resolved; only re-derive when
+  // capture failed. The post-attempt hot path never hits the fallback.
+  const commitSha = captured?.headSha ?? (await resolveHeadCommit(cwd));
+  if (!commitSha) {
+    console.error(
+      `[pipeline] checkpoint row skipped for thread ${threadId}: could not resolve worktree HEAD`,
+    );
+    return;
+  }
+
+  const branch = captured?.branch ?? (await resolveCurrentBranch(cwd));
+
+  deps.checkpoints.create({
+    threadId,
+    projectId: meta.projectId,
+    phase: meta.phase,
+    reason: meta.reason,
+    label: meta.label(captured?.turn ?? null),
+    branch,
+    commitSha,
+    refName: captured?.refName ?? null,
+  });
+}

--- a/packages/pipeline/src/pipeline/execution-phases.ts
+++ b/packages/pipeline/src/pipeline/execution-phases.ts
@@ -16,7 +16,7 @@ import {
   shellExecEnv,
   summarizePromptMaterials,
 } from '@shipcode/agents';
-import { captureCheckpoint, WorktreeManager } from '@shipcode/git';
+import { WorktreeManager } from '@shipcode/git';
 import {
   buildTaskNodePlan,
   EXECUTION_PHASES,
@@ -36,6 +36,7 @@ import { computeRetryDelayMs } from '../retry-scheduler';
 import type { ExecutePhaseCarry, PipelineContext, VerifyPhaseCarry } from '../types';
 import { renderWorkflowPromptTemplate } from '../workflow-prompt';
 import { buildPhasePayload, resetPhaseState } from './context';
+import { captureExecutionCheckpoint } from './execution-checkpoint';
 import {
   buildContinuationPrompt,
   buildTestFailureFingerprint,
@@ -749,58 +750,30 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
       return { next: 'failed' };
     }
 
-    try {
-      const cwd = context.worktreePath ?? context.projectPath;
-      const branch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
-        cwd,
-        encoding: 'utf-8',
-      }).trim();
-      const commitSha = execFileSync('git', ['rev-parse', 'HEAD'], {
-        cwd,
-        encoding: 'utf-8',
-      }).trim();
-      const latest = deps.checkpoints.getLatest(threadId);
-      const retryOrdinal =
-        1 + context.reviewRound + context.testRetries + context.verificationRetries;
-      const reason = retryOrdinal > 1 ? 'before_retry' : 'before_execute';
-      const label =
-        retryOrdinal > 1 ? `Before execute retry ${retryOrdinal}` : 'Before execute attempt 1';
-
-      if (
-        !latest ||
-        latest.commitSha !== commitSha ||
-        latest.phase !== PIPELINE_PHASE.executing ||
-        latest.reason !== reason
-      ) {
-        // Hidden checkpoint ref (#212): snapshot the full worktree state so
-        // restore/resume can recover uncommitted work. Ref capture failure
-        // must never block execution — fall back to a metadata-only row.
-        let refName: string | null = null;
-        try {
-          refName = (await captureCheckpoint(cwd, threadId)).refName;
-        } catch (captureError) {
-          console.error(
-            `[pipeline] checkpoint ref capture failed for thread ${threadId}:`,
-            captureError,
-          );
-        }
-        deps.checkpoints.create({
-          threadId,
-          projectId: context.projectId,
-          phase: PIPELINE_PHASE.executing,
-          reason,
-          label,
-          branch,
-          commitSha,
-          refName,
-        });
-      }
-    } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
-      emitPhase(threadId, 'failed', `Checkpoint creation failed: ${message}`);
-      activePipelines.delete(threadId);
-      return { next: 'failed' };
-    }
+    const preExecuteRetryOrdinal =
+      1 + context.reviewRound + context.testRetries + context.verificationRetries;
+    const preExecuteReason = preExecuteRetryOrdinal > 1 ? 'before_retry' : 'before_execute';
+    const preExecuteLabel =
+      preExecuteRetryOrdinal > 1
+        ? `Before execute retry ${preExecuteRetryOrdinal}`
+        : 'Before execute attempt 1';
+    // Snapshot the pre-execute worktree state (#212) so restore/resume can
+    // recover uncommitted work. `dedupe` skips a redundant row when the latest
+    // checkpoint already pins this commit/phase/reason. Capture is best-effort
+    // and async — it MUST NEVER block execution (see captureExecutionCheckpoint
+    // for the single failure policy shared with the post-attempt site below).
+    await captureExecutionCheckpoint(
+      context.worktreePath ?? context.projectPath,
+      threadId,
+      {
+        projectId: context.projectId,
+        phase: PIPELINE_PHASE.executing,
+        reason: preExecuteReason,
+        label: () => preExecuteLabel,
+        dedupe: true,
+      },
+      deps,
+    );
 
     const skill = skillCallSite(context);
     const latestPlanRecord = deps.plans.getLatest(threadId);
@@ -963,41 +936,33 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
 
       // Post-attempt checkpoint ref (#212): snapshot the attempt's worktree
       // state (including uncommitted executor changes) after every execute /
-      // task-graph-node attempt. Best-effort — never fails the phase.
-      try {
-        const attemptCwd = context.worktreePath ?? context.projectPath;
-        const captured = await captureCheckpoint(attemptCwd, threadId);
-        const attemptCommitSha = execFileSync('git', ['rev-parse', 'HEAD'], {
-          cwd: attemptCwd,
-          encoding: 'utf-8',
-        }).trim();
-        let attemptBranch: string | null = null;
-        try {
-          attemptBranch = execFileSync('git', ['rev-parse', '--abbrev-ref', 'HEAD'], {
-            cwd: attemptCwd,
-            encoding: 'utf-8',
-          }).trim();
-        } catch {
-          attemptBranch = null;
-        }
-        deps.checkpoints.create({
-          threadId,
+      // task-graph-node attempt. Runs on the per-attempt hot path (× task-graph
+      // nodes × retries), so it shares captureExecutionCheckpoint's single
+      // async, best-effort, never-blocks-the-phase policy with the pre-execute
+      // site — no synchronous git that would freeze the Electron main loop.
+      //
+      // Note (#3, fan-out): when execute ran fan-out, the winner's worktree was
+      // already `git add -A`-staged by captureDiff for the judge; captureCheckpoint
+      // then stages the identical tree once more into an isolated temp index. That
+      // double full-tree stage is one extra `git add -A` per fan-out attempt on the
+      // winner only — accepted here rather than reused via a trusted pre-staged
+      // index, whose correctness would hinge on a fragile cross-function invariant
+      // (a stale real index would silently drop uncommitted work from the snapshot).
+      // Fan-out is experimental/opt-in, so the cost is bounded and localized.
+      await captureExecutionCheckpoint(
+        context.worktreePath ?? context.projectPath,
+        threadId,
+        {
           projectId: context.projectId,
           phase: PIPELINE_PHASE.executing,
           reason: 'after_execute',
-          label: activeTaskNode
-            ? `After node ${activeTaskNode.stableKey} attempt (turn ${captured.turn})`
-            : `After execute attempt (turn ${captured.turn})`,
-          branch: attemptBranch,
-          commitSha: attemptCommitSha,
-          refName: captured.refName,
-        });
-      } catch (captureError) {
-        console.error(
-          `[pipeline] post-attempt checkpoint capture failed for thread ${threadId}:`,
-          captureError,
-        );
-      }
+          label: (turn) =>
+            activeTaskNode
+              ? `After node ${activeTaskNode.stableKey} attempt${turn !== null ? ` (turn ${turn})` : ''}`
+              : `After execute attempt${turn !== null ? ` (turn ${turn})` : ''}`,
+        },
+        deps,
+      );
 
       if (response.exitCode === 0) {
         if (activeTaskNode && deps.taskGraphs) {


### PR DESCRIPTION
## Summary

Fixes three related confirmed findings from the 2026-07-10 14-day audit of the execute-phase checkpoint code (PR #328, verified at `c370b369`). One extraction resolves all three.

The pre-execute (`before_execute`) and post-attempt (`after_execute`) checkpoint blocks in [execution-phases.ts](packages/pipeline/src/pipeline/execution-phases.ts) each independently resolved cwd + branch + HEAD, called `captureCheckpoint`, and built a `deps.checkpoints.create()` row — with **different error handling**.

### Findings addressed

1. **DRY (high)** — the two near-identical blocks diverged on failure: pre-execute wrote a metadata-only row (`refName=null`), or *failed the whole phase* if git threw; post-attempt wrote **no row at all**. The checkpoint turn sequence became gapped/inconsistent depending on which site failed.
2. **Optimization (high)** — the post-attempt block ran `execFileSync` git subprocesses **after every execute attempt** (× task-graph nodes × retries), freezing the Electron main event loop (all IPC, other pipelines, cancel buttons) each time, and redundantly re-derived HEAD that `captureCheckpoint` had already computed internally.
3. **Optimization (medium)** — in fan-out mode, `captureDiff()`'s `git add -A` on the winner worktree is followed moments later by `captureCheckpoint` re-staging the identical tree.

### Change

- New `captureExecutionCheckpoint(cwd, threadId, meta, deps)` helper ([execution-checkpoint.ts](packages/pipeline/src/pipeline/execution-checkpoint.ts)) owns cwd resolution, capture, and the DB row, with **one documented failure policy** identical at both sites:
  - ref capture fails → still write a metadata-only row (`refName=null`) — turn sequence stays dense at **both** sites
  - worktree HEAD unresolvable → skip the row (`commit_sha` is `NOT NULL`) and log
  - **never fails the execute phase** (the pre-execute site previously could — contradicting its own "must never block execution" comment)
- `captureCheckpoint` now **returns the `headSha`/`branch` it already resolves**, so the hot success path reuses them — no redundant `rev-parse`. All remaining git on the capture path is **async** (`execFile`); nothing synchronous blocks the main loop.
- Both call sites replaced; `dedupe` flag preserves the pre-execute site's skip-identical-row behavior without minting an orphan ref.

### Finding #3 decision

Documented + bounded at the call site rather than implemented as an index-reuse fast path. Eliminating the second `git add -A` requires *trusting* a pre-staged real index, whose correctness hinges on a fragile cross-function invariant — a stale index would silently drop uncommitted work from the snapshot (data-loss on restore/resume). Fan-out is experimental/opt-in and the extra staging is one `git add -A` on the winner only, so the cost is bounded. Called out here for reviewer visibility.

## Tests (focused)

- `packages/git/src/checkpoint.test.ts` — `captureCheckpoint` returns worktree `headSha` (≠ checkpoint commit) + `branch`; resolvers return `null` on a non-repo path.
- `packages/pipeline/src/pipeline/execution-checkpoint.test.ts` — identical failure policy at both sites (metadata-only row on capture failure; no row when HEAD unresolvable; never throws), success path reuses captured HEAD/branch with no extra resolver call, dedupe skips without minting a ref, and a static guard that the capture path uses no synchronous git.

All green; `@shipcode/git` + `@shipcode/pipeline` typecheck and Biome clean. Existing `execution-phases.test.ts` (46 pass / 2 skip) unaffected.

## Scope

Kept to the capture-block extraction only — untouched: fan-out cleanup/concurrency and checkpoint turn-lifecycle (separate audit chips).