### PR TITLE
test(pipeline): restore overall coverage above the 95% floor

### DIFF
--- a/packages/pipeline/src/pipeline/execution-checkpoint.test.ts
+++ b/packages/pipeline/src/pipeline/execution-checkpoint.test.ts
@@ -62,6 +62,8 @@ describe('captureExecutionCheckpoint', () => {
     mockCapture.mockReset();
     mockResolveHead.mockReset();
     mockResolveBranch.mockReset();
+    mockDeleteRefs.mockReset();
+    mockDeleteRefs.mockResolvedValue(0);
   });
 
   it('reuses the captured HEAD sha/branch on success and spawns no extra resolver call', async () => {
@@ -175,6 +177,66 @@ describe('captureExecutionCheckpoint', () => {
 
     expect(mockCapture).toHaveBeenCalledTimes(1);
     expect(create).toHaveBeenCalledTimes(1);
+  });
+
+  it('prunes refs and rows older than the retention window once the turn exceeds it', async () => {
+    // Retention window is 25 turns; a captured turn of 30 leaves turns < 6 stale.
+    mockCapture.mockResolvedValue({
+      refName: 'refs/shipcode/checkpoints/t/turn/30',
+      turn: 30,
+      commitSha: 'ck',
+      headSha: 'head-sha',
+      branch: 'main',
+    });
+    const { deps, deleteOlderThan } = makeDeps();
+
+    await captureExecutionCheckpoint(CWD, 'thread-1', meta(), deps);
+
+    const minKeptTurn = 30 - 25 + 1; // 6
+    expect(mockDeleteRefs).toHaveBeenCalledWith(CWD, 'thread-1', { olderThanTurn: minKeptTurn });
+    expect(deleteOlderThan).toHaveBeenCalledWith('thread-1', minKeptTurn);
+  });
+
+  it('does not prune when the captured turn is within the retention window', async () => {
+    mockCapture.mockResolvedValue({
+      refName: 'refs/shipcode/checkpoints/t/turn/3',
+      turn: 3, // minKeptTurn = 3 - 25 + 1 = -21 → nothing to prune
+      commitSha: 'ck',
+      headSha: 'head-sha',
+      branch: 'main',
+    });
+    const { deps, deleteOlderThan } = makeDeps();
+
+    await captureExecutionCheckpoint(CWD, 'thread-1', meta(), deps);
+
+    expect(mockDeleteRefs).not.toHaveBeenCalled();
+    expect(deleteOlderThan).not.toHaveBeenCalled();
+  });
+
+  it('swallows a prune failure — checkpoint GC never fails the phase', async () => {
+    mockCapture.mockResolvedValue({
+      refName: 'refs/shipcode/checkpoints/t/turn/40',
+      turn: 40,
+      commitSha: 'ck',
+      headSha: 'head-sha',
+      branch: 'main',
+    });
+    mockDeleteRefs.mockRejectedValue(new Error('ref GC exploded'));
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const { deps, create, deleteOlderThan } = makeDeps();
+
+    await expect(
+      captureExecutionCheckpoint(CWD, 'thread-1', meta(), deps),
+    ).resolves.toBeUndefined();
+
+    // The row was still written; only the best-effort GC failed and was logged.
+    expect(create).toHaveBeenCalledTimes(1);
+    expect(deleteOlderThan).not.toHaveBeenCalled(); // ref delete threw before the row prune
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('checkpoint GC failed for thread thread-1'),
+      expect.any(Error),
+    );
+    errorSpy.mockRestore();
   });
 
   it('performs no synchronous git on the capture path', () => {

--- a/packages/pipeline/src/pipeline/execution-phase-utils.test.ts
+++ b/packages/pipeline/src/pipeline/execution-phase-utils.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PipelineContext } from '../types';
-import { probeWorktreeChanges } from './execution-phase-utils';
+import { probeWorktreeChanges, resolveWorktreeDiffBase } from './execution-phase-utils';
 
 const { mockExecFileSync } = vi.hoisted(() => ({
   mockExecFileSync: vi.fn(),
@@ -94,5 +94,44 @@ describe('probeWorktreeChanges', () => {
     // Error is clamped to the first line — full stack never reaches renderer logs.
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('git unavailable'));
     expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('full stack'));
+  });
+});
+
+describe('resolveWorktreeDiffBase', () => {
+  beforeEach(() => {
+    mockExecFileSync.mockReset();
+  });
+
+  it('returns the verified fork-point SHA when it resolves', () => {
+    mockExecFileSync.mockImplementation((_command: string, args: string[]) => {
+      if (args[0] === 'rev-parse' && args[1] === '--verify') return 'base\n';
+      return '';
+    });
+
+    expect(resolveWorktreeDiffBase(makeContext({ forkPointSha: 'base' }))).toBe('base');
+  });
+
+  it('falls back to the branch merge-base when the fork point is missing', () => {
+    // No fork point → skip verify; the first merge-base candidate resolves.
+    mockExecFileSync.mockImplementation((_command: string, args: string[]) => {
+      if (args[0] === 'merge-base') return 'merge-base-sha\n';
+      throw new Error('unexpected');
+    });
+
+    expect(
+      resolveWorktreeDiffBase(makeContext({ forkPointSha: undefined, baseBranch: 'main' })),
+    ).toBe('merge-base-sha');
+  });
+
+  it('returns null when no fork point, base branch, or HEAD~1 is resolvable', () => {
+    // Every git probe throws and there is no base branch, so the final HEAD~1
+    // fallback also fails — the diff base is genuinely unknown.
+    mockExecFileSync.mockImplementation(() => {
+      throw new Error('fatal: ambiguous argument');
+    });
+
+    expect(
+      resolveWorktreeDiffBase(makeContext({ forkPointSha: undefined, baseBranch: undefined })),
+    ).toBeNull();
   });
 });

--- a/packages/pipeline/src/pipeline/review-findings.test.ts
+++ b/packages/pipeline/src/pipeline/review-findings.test.ts
@@ -1,3 +1,4 @@
+import type { ReviewFindingRecord } from '@shipcode/shared';
 import { describe, expect, it } from 'vitest';
 import {
   buildPullRequestFeedbackFindingInputs,
@@ -271,5 +272,80 @@ describe('review finding helpers', () => {
     expect(comment.startsWith(REVIEW_FINDINGS_PR_COMMENT_MARKER)).toBe(true);
     expect(comment).toContain('1 open ShipCode review finding remains');
     expect(comment).toContain('**blocker / ci**: CI failed');
+  });
+
+  it('returns an empty prompt when there are no open findings', () => {
+    const resolved: ReviewFindingRecord = {
+      id: 'finding-1',
+      projectId: 'project-1',
+      threadId: 'thread-1',
+      planId: 'plan-1',
+      reviewId: null,
+      verificationId: null,
+      runId: null,
+      phase: 'verify',
+      source: 'verification',
+      severity: 'blocker',
+      status: 'fixed',
+      title: 'Build failed',
+      description: 'Typecheck failed',
+      suggestion: 'Fix types',
+      filePath: 'src/app.ts',
+      fingerprint: 'abc',
+      sourceModel: 'claude',
+      commitSha: null,
+      prNumber: null,
+      worktreePath: null,
+      branch: null,
+      metadata: null,
+      resolvedByRunId: null,
+      resolvedAt: null,
+      createdAt: '2026-05-31T00:00:00.000Z',
+      updatedAt: '2026-05-31T00:00:00.000Z',
+    };
+
+    // A non-open finding is not actionable, so the executor prompt block collapses
+    // to the empty string rather than emitting an empty <open_review_findings> tag.
+    expect(formatOpenFindingsForPrompt([resolved])).toBe('');
+    expect(formatOpenFindingsForPrompt([])).toBe('');
+  });
+
+  it('lists resolved findings and reports zero open in the PR comment', () => {
+    const comment = formatReviewFindingsPrComment([
+      {
+        id: 'finding-1',
+        projectId: 'project-1',
+        threadId: 'thread-1',
+        planId: 'plan-1',
+        reviewId: null,
+        verificationId: null,
+        runId: null,
+        phase: 'verify',
+        source: 'verification',
+        severity: 'blocker',
+        status: 'fixed',
+        title: 'Flaky test fixed',
+        description: 'Stabilized',
+        suggestion: null,
+        filePath: null,
+        fingerprint: 'abc',
+        sourceModel: null,
+        commitSha: null,
+        prNumber: 12,
+        worktreePath: null,
+        branch: null,
+        metadata: null,
+        resolvedByRunId: null,
+        resolvedAt: '2026-05-31T00:00:00.000Z',
+        createdAt: '2026-05-31T00:00:00.000Z',
+        updatedAt: '2026-05-31T00:00:00.000Z',
+      },
+    ]);
+
+    expect(comment).toContain('No open ShipCode review findings.');
+    expect(comment).toContain('### Recently Resolved');
+    expect(comment).toContain('**fixed**: Flaky test fixed');
+    // No open findings → no "### Open" section.
+    expect(comment).not.toContain('### Open');
   });
 });

--- a/packages/pipeline/src/pipeline/runtime.test.ts
+++ b/packages/pipeline/src/pipeline/runtime.test.ts
@@ -355,6 +355,12 @@ describe('createPipelineRuntime', () => {
       ).toBe('pnpm install');
     });
 
+    it('returns null when pnpm output does not match a known signature', () => {
+      expect(
+        buildFrozenInstallFallback('pnpm install --frozen-lockfile', 'ENOSPC: no space left'),
+      ).toBeNull();
+    });
+
     it('strips --frozen-lockfile from yarn install on YN0028', () => {
       expect(
         buildFrozenInstallFallback(
@@ -364,6 +370,12 @@ describe('createPipelineRuntime', () => {
       ).toBe('yarn install');
     });
 
+    it('returns null when yarn output does not match a known signature', () => {
+      expect(
+        buildFrozenInstallFallback('yarn install --frozen-lockfile', 'network timeout'),
+      ).toBeNull();
+    });
+
     it('rewrites npm ci → npm install on EUSAGE', () => {
       expect(
         buildFrozenInstallFallback(
@@ -371,6 +383,10 @@ describe('createPipelineRuntime', () => {
           'EUSAGE The `npm ci` command can only install with an existing package-lock.json',
         ),
       ).toBe('npm install');
+    });
+
+    it('returns null when npm ci output does not match a known signature', () => {
+      expect(buildFrozenInstallFallback('npm ci', 'ETIMEDOUT registry request failed')).toBeNull();
     });
 
     it('returns null for unrelated commands', () => {

--- a/packages/pipeline/src/workflow-loader.test.ts
+++ b/packages/pipeline/src/workflow-loader.test.ts
@@ -6,10 +6,14 @@ import {
   _internals,
   DEFAULT_MAX_CONCURRENT_AGENTS,
   DEFAULT_MAX_TURNS,
+  DEFAULT_WORKFLOW_POLICY,
   formatUnknownError,
   loadWorkflowPolicy,
+  loadWorkflowPolicyUncached,
   parseWorkflowPolicy,
+  peekWorkflowPolicyCache,
   resolveWorkflowPath,
+  setWorkflowPolicyCache,
 } from './workflow-loader';
 
 const tempDirs: string[] = [];
@@ -397,5 +401,45 @@ body`,
         ).continuationPromptTemplate,
       ).toBeNull();
     });
+  });
+});
+
+// The watcher-facing cache seams (loadWorkflowPolicyUncached / peekWorkflowPolicyCache
+// / setWorkflowPolicyCache) let the workflow watcher compute a candidate policy and
+// commit or revert it without waiting out the TTL. Exercise them directly.
+describe('workflow policy cache seams', () => {
+  afterEach(() => {
+    _internals.policyCache.clear();
+    vi.useRealTimers();
+
+    for (const dir of tempDirs.splice(0)) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('loadWorkflowPolicyUncached resolves without touching the cache', () => {
+    const repo = tempRepo();
+
+    const policy = loadWorkflowPolicyUncached(repo);
+
+    expect(policy.path).toBeNull();
+    // Uncached load must NOT seed the cache — that is the whole point of the seam.
+    expect(_internals.policyCache.has(repo)).toBe(false);
+  });
+
+  it('peekWorkflowPolicyCache returns null when nothing is cached', () => {
+    const repo = tempRepo();
+
+    expect(peekWorkflowPolicyCache(repo)).toBeNull();
+  });
+
+  it('setWorkflowPolicyCache overwrites the entry and peek reads it back', () => {
+    const repo = tempRepo();
+    const policy = { ...DEFAULT_WORKFLOW_POLICY, path: '/repo/WORKFLOW.md' };
+
+    setWorkflowPolicyCache(repo, policy, 1_000);
+
+    expect(peekWorkflowPolicyCache(repo)).toBe(policy);
+    expect(_internals.policyCache.get(repo)?.expiresAt).toBe(1_000 + _internals.policyCacheTtlMs);
   });
 });

--- a/packages/pipeline/src/workflow-watcher.test.ts
+++ b/packages/pipeline/src/workflow-watcher.test.ts
@@ -1,5 +1,7 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { DEFAULT_WORKFLOW_POLICY, type WorkflowPolicy } from './workflow-loader';
 import {
   createWorkflowWatcher,
@@ -325,6 +327,63 @@ describe('createWorkflowWatcher', () => {
     root.change?.();
     timers.flush();
     expect(shipcodeAttaches).toBe(2);
+  });
+
+  it('ignores watch events fired after close()', () => {
+    const watch = fakeWatch();
+    const timers = fakeTimers();
+    const loadUncached = vi.fn(() => validPolicy());
+
+    const watcher = createWorkflowWatcher({
+      repoPath: REPO,
+      onReload: vi.fn(),
+      watchFactory: watch.factory,
+      pathExists: () => true,
+      loadUncached,
+      peekCache: vi.fn(() => null),
+      setCache: vi.fn(),
+      setTimeoutFn: timers.setTimeoutFn,
+      clearTimeoutFn: timers.clearTimeoutFn,
+    });
+
+    watcher.close();
+    // A late fs event (the underlying watch had already queued it) must be a
+    // no-op: onChange returns early because the watcher is closed.
+    watch.trigger();
+
+    expect(timers.pendingCount()).toBe(0);
+    timers.flush();
+    expect(loadUncached).not.toHaveBeenCalled();
+  });
+
+  describe('default fs.watch factory', () => {
+    const tempDirs: string[] = [];
+
+    afterEach(() => {
+      for (const dir of tempDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+    });
+
+    it('watches a real directory and returns null for a missing one', () => {
+      const repo = mkdtempSync(path.join(os.tmpdir(), 'shipcode-watcher-'));
+      tempDirs.push(repo);
+      const timers = fakeTimers();
+
+      // No injected watchFactory → exercises the real fs.watch-backed default:
+      // the repo root exists (watch attaches) while `.shipcode` is absent (the
+      // factory's try/catch returns null instead of crashing).
+      const watcher = createWorkflowWatcher({
+        repoPath: repo,
+        onReload: vi.fn(),
+        loadUncached: vi.fn(() => validPolicy()),
+        peekCache: vi.fn(() => null),
+        setCache: vi.fn(),
+        setTimeoutFn: timers.setTimeoutFn,
+        clearTimeoutFn: timers.clearTimeoutFn,
+      });
+
+      // Tearing down a real watcher must not throw.
+      expect(() => watcher.close()).not.toThrow();
+    });
   });
 
   it('close() is idempotent', () => {


### PR DESCRIPTION
## Why

The advisory **Coverage** job on `master` (`.github/workflows/ci.yml`, `COVERAGE_MIN=95` / `COVERAGE_BRANCH_MIN=90`) started failing after the 22-PR audit batch merged on 2026-07-11:

> `Coverage threshold failed: statements 94.96% < 95.00%`

Only overall **statements** dipped below its floor (lines 95.80%, functions 95.29%, branches 90.74% all passed). Every new miss lands in `packages/pipeline` — the weakest package (93.77% statements) after the batch.

## What

Targeted unit tests for the untested branches in pipeline's least-covered files. **No source changes** — tests only:

| File | Paths now covered |
|------|-------------------|
| `execution-checkpoint` | retention-window GC (prune refs+rows once the captured turn exceeds `CHECKPOINT_HISTORY_LIMIT`), the within-window no-prune path, and the best-effort catch that must never fail the phase |
| `execution-phase-utils` | `resolveWorktreeDiffBase` fork-point → merge-base → `HEAD~1` fallback chain, incl. the null-when-nothing-resolves tail |
| `review-findings` | empty executor prompt when nothing is open; the "Recently Resolved" / "No open findings" PR-comment branches |
| `runtime` (`buildFrozenInstallFallback`) | pnpm / yarn / npm-ci null paths when the failure output doesn't match a lockfile-drift signature |
| `workflow-loader` | watcher-facing cache seams: `loadWorkflowPolicyUncached`, `peekWorkflowPolicyCache`, `setWorkflowPolicyCache` |
| `workflow-watcher` | the real `fs.watch` default factory (present dir attaches, missing dir returns null) and the post-`close()` change guard |

## Result

Local `bun run coverage` (COVERAGE_MIN=95 / COVERAGE_BRANCH_MIN=90):

```
lines:      95.89% (21648/22577)
statements: 95.05% (23966/25215)   ← was 94.96%
functions:  95.38% (5593/5864)
branches:   90.79% (18835/20745)
Coverage threshold passed at lines/statements/functions 95.00%, branches 90.00%.
```

All 567 pipeline tests pass (7 skipped); typecheck and biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded coverage for checkpoint cleanup and retention behavior, including graceful handling of cleanup failures.
  * Added validation for Git change-base resolution across fallback scenarios.
  * Improved coverage for review findings formatting, including resolved-only results.
  * Added checks for package installation fallback handling and workflow policy caching.
  * Verified workflow watchers ignore events after shutdown and operate when optional directories are absent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->