### PR TITLE
chore(release): v0.1.5

### DIFF
--- a/.agents/SESSIONS/2026-07-11.md
+++ b/.agents/SESSIONS/2026-07-11.md
@@ -1,0 +1,69 @@
+# 2026-07-11
+
+## Session 1 — Roadmap audit, milestone restructure, v0.1.5 release prep
+
+### System flow
+
+```text
+audit (gh milestones + issues + project board + repo greps + docs)
+  → gap analysis: frontier-model orchestration (Fable 5 / GPT-5.6 / Grok)
+  → user interview (AskUserQuestion) → 4 needs-decision issues resolved
+  → 6 new issues filed (#359–#364)
+  → milestone restructure: Week 5 = P0 dogfood sprint, Weeks 6–8 seeded,
+    Weeks 1–4 closed, 31 issues → Backlog/Deferred
+  → priority:P0/P1/P2 labels created + applied (43 issues)
+  → release prep: version bump 0.1.4 → 0.1.5 (10 packages, lockstep)
+    → PR #365 (release/v0.1.5)
+```
+
+### Affected components
+
+- GitHub board only (issues, milestones, labels) + 10 `package.json` version fields.
+  No product code changed.
+
+### What was done
+
+- [x] Audited roadmap/issues/milestones/project board + repo state before release.
+- [x] Filed 6 gap issues for frontier-model orchestration:
+  - **#359** (P0) flip `PINNED_MODEL_DEFAULTS` to Fable 5 / GPT-5.6 (+ Luna triage lanes)
+  - **#360** (P0) preflight model-servability check (CLI version vs selected model — the codex 1.0.3 / gpt-5.6-sol failure from 2026-07-10)
+  - **#361** (P1) Grok 4.5 E2E verification once EU access lands
+  - **#362** (P1) docs model-catalog page (docs have zero mention of Fable/5.6/Grok)
+  - **#363** (P2) OpenRouter entries for Fable 5 / 5.6 family
+  - **#364** (P2) default `fan_out_judge_model` → Fable 5
+- [x] Created `priority:P0/P1/P2` labels; applied across all scheduled issues.
+- [x] Milestone restructure:
+  - **Week 5 (Jul 13–19) = P0 dogfood sprint** (10): #331, #332, #359, #360, #309 (P0); #306, #274, #320, #361, #362 (P1)
+  - **Week 6** (10): #312 routing parity, #91 dual-plan (pulled up), #18, #81, #363, #364, #318, #319, #251, #82
+  - **Week 7** (8): #194, #211, #66, #83, #84, #85 + existing #125, #93
+  - **Week 8** (15): Wave 1 refactors #280–#294 as ShipCode-automation dogfood fodder
+  - **Backlog/Deferred** (31): #311, EC2/daemon/issue-source items, audit follow-ups #275–#279, wave-2/3
+  - Closed empty past milestones Weeks 1–4; rewrote milestone descriptions.
+- [x] Release prep: bumped all 10 workspace packages 0.1.4 → 0.1.5 on `release/v0.1.5`, opened **PR #365**.
+
+### Key decisions (user-interviewed, recorded as issue comments, `needs-decision` removed)
+
+- **#309**: canonical `getDefaultBranch` fallback = **main → master → current** (git-service.ts order); a feature branch must never masquerade as default. Align worktree.ts.
+- **#306**: desktop shows distinct **"Model deprecated — select a replacement"** status (not collapsed to unreachable); rename agents type to `OpenRouterAuthCheckResult`.
+- **#311**: CLI retry parity **deferred — desktop-first**. Backlog; revisit if CLI/headless becomes primary.
+- **#312**: **build CLI model-routing parity** (code, not doc-only). Week 6.
+- **Priority doctrine (user)**: everything required to use ShipCode as the daily driver = P0; everything else is a post-first-release feature.
+- **#360 before #359**: flipping defaults without the servability preflight breaks stale-CLI machines.
+
+### Release readiness findings
+
+- `publish.yml` is release-published-triggered; validates tag matches `apps/cli` + `apps/desktop` versions; builds **Developer ID signed + notarized** DMGs (arm64 + x64) with secret validation, plus Linux installers, Homebrew cask, npm CLI. Signing is real in CI (local `build:installer:mac` remains ad-hoc-signed; `:signed` variant needs APPLE_* env).
+- v0.1.4 assets confirmed: dmg/zip both arches + AppImage/deb.
+- Remaining human steps: merge PR #365 → publish GitHub release `v0.1.5`.
+- Known pre-existing flakes (not regressions): automation-modal timeout under load; `index.test.ts` `loadFile`.
+- **Machine TODO still open**: upgrade fleet Codex CLIs (1.0.3 can't serve 5.6 family).
+
+### Mistakes and fixes
+
+- None material. Note: repo session dir is `.agents/SESSIONS/` (uppercase), skill default says `sessions/` — repo convention wins.
+
+### Next steps
+
+- Merge #365, publish release `v0.1.5` (triggers signed DMG build).
+- Start Week 5 P0 sprint: #360 → #359 (in that order), #331, #332, #309.
+- Dogfood: run Wave 1 (#280–#294, Week 8) through ShipCode automations (Terra/Luna execute, Fable review).

--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipshitdev/shipcode",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Autonomous AI coding pipeline. GitHub issues in, pull requests out.",
   "type": "module",
   "repository": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -71,5 +71,5 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
-  "version": "0.1.4"
+  "version": "0.1.5"
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -20,5 +20,5 @@
     "coverage": "vitest run --coverage",
     "start": "next start"
   },
-  "version": "0.1.4"
+  "version": "0.1.5"
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/web",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3000",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/agents",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/db",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/git",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/pipeline",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/shared",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/ui",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "private": true,
   "description": "ShipCode-specific UI components for the ShipCode monorepo.",
   "type": "module",


### PR DESCRIPTION
Lockstep version bump 0.1.4 → 0.1.5 across all 10 workspace packages.

Release highlights since v0.1.4 (2026-07-06):
- Fable 5 + GPT-5.6 family (Sol/Terra/Luna) in the model catalog, aliases, effort rules, `fable-combo` preset (#325)
- Grok Build (Grok 4.5) as execute-only CLI executor (#326)
- ShipCode-owned checkpoint refs: capture/restore worktree state per turn (#212, #328, #338, #347, #354)
- Unified GitHub pipeline sync — one queued writer, manual board moves now sync (#333, #334)
- Plan comments always posted + upserted in place, `postPlanCommentsEnabled` toggle
- Automations: per-target run bookkeeping for multi-repo (#346)

After merge: publish GitHub release `v0.1.5` — publish.yml validates the tag against these versions and builds signed+notarized macOS DMGs (arm64 + x64), Linux installers, Homebrew cask, and npm CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)