### PR TITLE
chore: prepare 0.2.0 release

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipshitdev/shipcode",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "Autonomous AI coding pipeline. GitHub issues in, pull requests out.",
   "type": "module",
   "repository": {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -71,5 +71,5 @@
     "test": "vitest run",
     "typecheck": "tsc --noEmit"
   },
-  "version": "0.1.4"
+  "version": "0.2.0"
 }

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -20,5 +20,5 @@
     "coverage": "vitest run --coverage",
     "start": "next start"
   },
-  "version": "0.1.4"
+  "version": "0.2.0"
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/web",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev -p 3000",

--- a/bun.lock
+++ b/bun.lock
@@ -18,7 +18,7 @@
     },
     "apps/cli": {
       "name": "@shipshitdev/shipcode",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "bin": {
         "shipcode": "dist/index.js",
       },
@@ -42,7 +42,7 @@
     },
     "apps/desktop": {
       "name": "@shipcode/desktop",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.55",
         "@fontsource/dm-sans": "5.2.8",
@@ -94,7 +94,7 @@
     },
     "apps/docs": {
       "name": "@shipcode/docs",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "dependencies": {
         "@shipcode/ui": "workspace:*",
         "next": "16.2.7",
@@ -110,7 +110,7 @@
     },
     "apps/web": {
       "name": "@shipcode/web",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "dependencies": {
         "@shipcode/shared": "workspace:*",
         "@shipcode/ui": "workspace:*",
@@ -146,7 +146,7 @@
     },
     "packages/agents": {
       "name": "@shipcode/agents",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "dependencies": {
         "@anthropic-ai/sandbox-runtime": "0.0.55",
         "@shipcode/shared": "workspace:*",
@@ -160,7 +160,7 @@
     },
     "packages/db": {
       "name": "@shipcode/db",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "dependencies": {
         "@shipcode/shared": "workspace:*",
         "nanoid": "5.1.11",
@@ -171,7 +171,7 @@
     },
     "packages/git": {
       "name": "@shipcode/git",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "dependencies": {
         "@shipcode/shared": "workspace:*",
         "simple-git": "3.36.0",
@@ -182,7 +182,7 @@
     },
     "packages/pipeline": {
       "name": "@shipcode/pipeline",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "dependencies": {
         "@shipcode/agents": "workspace:*",
         "@shipcode/db": "workspace:*",
@@ -199,7 +199,7 @@
     },
     "packages/shared": {
       "name": "@shipcode/shared",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "dependencies": {
         "zod": "4.4.3",
       },
@@ -209,7 +209,7 @@
     },
     "packages/ui": {
       "name": "@shipcode/ui",
-      "version": "0.1.4",
+      "version": "0.2.0",
       "dependencies": {
         "@dnd-kit/core": "6.3.1",
         "@radix-ui/react-dropdown-menu": "2.1.16",

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/agents",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/db",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/git/package.json
+++ b/packages/git/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/git",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/pipeline/package.json
+++ b/packages/pipeline/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/pipeline",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/shared",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@shipcode/ui",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "private": true,
   "description": "ShipCode-specific UI components for the ShipCode monorepo.",
   "type": "module",


### PR DESCRIPTION
Bumps all workspace packages `0.1.4` → `0.2.0` and refreshes `bun.lock`. Version-only change; no code touched. Mirrors the v0.1.4 bump (#323): same 10 packages + lockfile; `.deepsec` and `e2e` untouched.

**Merge after #358** (coverage top-up) so the release is cut from a fully green trunk.

## What v0.2.0 ships (since v0.1.4, cut 2026-07-06)

Headline: **signed macOS distribution**, **new model families**, and a **worktree-snapshot checkpoint subsystem**, on top of a 21-PR correctness audit.

### Features
- **Signed + notarized macOS releases** (#341) — Developer ID signing + notarytool, hardened-runtime entitlements, Gatekeeper-passing DMG/zip, Homebrew cask publishing
- **ShipCode-owned checkpoint refs** (#328, #338, #343, #347, #354) — full-worktree snapshots under `refs/shipcode/checkpoints/*`; restore recovers uncommitted work; pre-restore safety snapshot; turn bookkeeping + capture-time GC
- **New executors** — Fable 5 + codex GPT-5.6 family (Sol/Terra/Luna) (#325), Grok Build 4.5 execute-only (#327, #342, #344)
- **Editable automation targets + hardened removeTarget** (#356); per-target multi-repo run bookkeeping (#346)
- **Plan comments always posted to GitHub issues**, settings-gated (#330)

### Fixes / hardening (14-day audit, 21 PRs)
- Project removal no longer destroys multi-repo automations (#353); automation hydration N+1 batched (#345)
- Pipeline: fan-out worktree cleanup on all-fail (#339), worker-pool bound (#348), probe failures don't fail successful runs (#349), human steering scoped to its run (#350)
- DB: `migrateV64` in `createTestDb` + canonical `MIGRATIONS` registry (#336)
- One queued GitHub sync service; deferred status no longer written as Done (#355)

### CI / infra
- `Build` required on master + `react-doctor` naming (#337); AGENTS.md sync gate (#340); coverage back above the 95% floor (#358)

## Release steps after this merges
1. `gh release create v0.2.0` — publish triggers `publish.yml` (validates tag ↔ package versions)
2. Workflow deploys web, builds Linux + **signed/notarized macOS** installers, updates the Homebrew cask, publishes the CLI to npm

🤖 Generated with [Claude Code](https://claude.com/claude-code)