### PR TITLE
docs(sessions): 2026-07-11 — roadmap audit, milestone restructure

### DIFF
--- a/.agents/SESSIONS/2026-07-11.md
+++ b/.agents/SESSIONS/2026-07-11.md
@@ -1,0 +1,76 @@
+# 2026-07-11
+
+## Session 1 — Roadmap audit, milestone restructure, v0.1.5 release prep
+
+### System flow
+
+```text
+audit (gh milestones + issues + project board + repo greps + docs)
+  → gap analysis: frontier-model orchestration (Fable 5 / GPT-5.6 / Grok)
+  → user interview (AskUserQuestion) → 4 needs-decision issues resolved
+  → 6 new issues filed (#359–#364)
+  → milestone restructure: Week 5 = P0 dogfood sprint, Weeks 6–8 seeded,
+    Weeks 1–4 closed, 31 issues → Backlog/Deferred
+  → priority:P0/P1/P2 labels created + applied (43 issues)
+  → release prep: version bump 0.1.4 → 0.1.5 (10 packages, lockstep)
+    → PR #365 (release/v0.1.5)
+```
+
+### Affected components
+
+- GitHub board only (issues, milestones, labels) + 10 `package.json` version fields.
+  No product code changed.
+
+### What was done
+
+- [x] Audited roadmap/issues/milestones/project board + repo state before release.
+- [x] Filed 6 gap issues for frontier-model orchestration:
+  - **#359** (P0) flip `PINNED_MODEL_DEFAULTS` to Fable 5 / GPT-5.6 (+ Luna triage lanes)
+  - **#360** (P0) preflight model-servability check (CLI version vs selected model — the codex 1.0.3 / gpt-5.6-sol failure from 2026-07-10)
+  - **#361** (P1) Grok 4.5 E2E verification once EU access lands
+  - **#362** (P1) docs model-catalog page (docs have zero mention of Fable/5.6/Grok)
+  - **#363** (P2) OpenRouter entries for Fable 5 / 5.6 family
+  - **#364** (P2) default `fan_out_judge_model` → Fable 5
+- [x] Created `priority:P0/P1/P2` labels; applied across all scheduled issues.
+- [x] Milestone restructure:
+  - **Week 5 (Jul 13–19) = P0 dogfood sprint** (10): #331, #332, #359, #360, #309 (P0); #306, #274, #320, #361, #362 (P1)
+  - **Week 6** (10): #312 routing parity, #91 dual-plan (pulled up), #18, #81, #363, #364, #318, #319, #251, #82
+  - **Week 7** (8): #194, #211, #66, #83, #84, #85 + existing #125, #93
+  - **Week 8** (15): Wave 1 refactors #280–#294 as ShipCode-automation dogfood fodder
+  - **Backlog/Deferred** (31): #311, EC2/daemon/issue-source items, audit follow-ups #275–#279, wave-2/3
+  - Closed empty past milestones Weeks 1–4; rewrote milestone descriptions.
+- [x] Release prep: bumped all 10 workspace packages 0.1.4 → 0.1.5 on `release/v0.1.5`, opened **PR #365**.
+
+### Key decisions (user-interviewed, recorded as issue comments, `needs-decision` removed)
+
+- **#309**: canonical `getDefaultBranch` fallback = **main → master → current** (git-service.ts order); a feature branch must never masquerade as default. Align worktree.ts.
+- **#306**: desktop shows distinct **"Model deprecated — select a replacement"** status (not collapsed to unreachable); rename agents type to `OpenRouterAuthCheckResult`.
+- **#311**: CLI retry parity **deferred — desktop-first**. Backlog; revisit if CLI/headless becomes primary.
+- **#312**: **build CLI model-routing parity** (code, not doc-only). Week 6.
+- **Priority doctrine (user)**: everything required to use ShipCode as the daily driver = P0; everything else is a post-first-release feature.
+- **#360 before #359**: flipping defaults without the servability preflight breaks stale-CLI machines.
+
+### Release readiness findings
+
+- `publish.yml` is release-published-triggered; validates tag matches `apps/cli` + `apps/desktop` versions; builds **Developer ID signed + notarized** DMGs (arm64 + x64) with secret validation, plus Linux installers, Homebrew cask, npm CLI. Signing is real in CI (local `build:installer:mac` remains ad-hoc-signed; `:signed` variant needs APPLE_* env).
+- v0.1.4 assets confirmed: dmg/zip both arches + AppImage/deb.
+- Remaining human steps: merge PR #365 → publish GitHub release `v0.1.5`.
+- Known pre-existing flakes (not regressions): automation-modal timeout under load; `index.test.ts` `loadFile`.
+- **Machine TODO still open**: upgrade fleet Codex CLIs (1.0.3 can't serve 5.6 family).
+
+### Mistakes and fixes
+
+- None material. Note: repo session dir is `.agents/SESSIONS/` (uppercase), skill default says `sessions/` — repo convention wins.
+
+### Next steps
+
+- Merge #365, publish release `v0.1.5` (triggers signed DMG build).
+- Start Week 5 P0 sprint: #360 → #359 (in that order), #331, #332, #309.
+- Dogfood: run Wave 1 (#280–#294, Week 8) through ShipCode automations (Terra/Luna execute, Fable review).
+
+### Addendum (post-session)
+
+- The v0.1.5 release prep above was superseded the same day: the 22-PR audit
+  batch merged and the release was cut as **v0.2.0** instead (PR #366).
+  PR #365 (`release/v0.1.5`) closed unmerged; this log is the only survivor
+  of that branch.


### PR DESCRIPTION
Salvages the session log from `release/v0.1.5` (PR #365), which is superseded by the v0.2.0 release (#366). Doc-only; adds an addendum noting the version-bump portion was superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a session log documenting roadmap and milestone updates.
  * Recorded release-readiness findings, follow-up tasks, and decisions from user interviews.
  * Documented newly identified work items and their prioritization.
  * Clarified that the planned v0.1.5 preparation was superseded by the v0.2.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->