### PR TITLE
fix(desktop): electron-builder 26.x requires boolean mac.notarize

### DIFF
--- a/apps/desktop/electron-builder.signed.yml
+++ b/apps/desktop/electron-builder.signed.yml
@@ -32,9 +32,10 @@ mac:
   gatekeeperAssess: false
   entitlements: resources/entitlements.mac.plist
   entitlementsInherit: resources/entitlements.mac.inherit.plist
-  # electron-builder drives notarytool with the APPLE_API_* env vars.
-  notarize:
-    teamId: C76R5DRH64
+  # electron-builder 26.x: `notarize` is a boolean; notarytool credentials
+  # (APPLE_API_KEY / APPLE_API_KEY_ID / APPLE_API_ISSUER) and APPLE_TEAM_ID
+  # come from the environment (mapped in publish.yml).
+  notarize: true
   # NOTE: no ad-hoc afterPack here — real signing replaces it.
 linux:
   target:


### PR DESCRIPTION
Both macOS jobs of the v0.2.0 publish run failed at config schema validation: `configuration.mac.notarize should be a boolean`. electron-builder 26.x moved notarization credentials fully to env vars (already mapped in publish.yml from the canonical secrets/vars), so the config just needs `notarize: true`.

After merge: re-run publish via workflow_dispatch (`release_tag=v0.2.0`, macOS + Homebrew only) to attach the signed installers to the existing release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)