### PR TITLE
fix(desktop): drop 'Developer ID Application:' prefix from signing identity

### DIFF
--- a/apps/desktop/electron-builder.signed.yml
+++ b/apps/desktop/electron-builder.signed.yml
@@ -27,7 +27,9 @@ mac:
     - zip
   category: public.app-category.developer-tools
   # Real Developer ID signing (auto-discovered from keychain by this identity).
-  identity: "Developer ID Application: Vincent Tellier (C76R5DRH64)"
+  # electron-builder 26.x: no "Developer ID Application:" prefix — the
+  # certificate type is chosen automatically from the identity name.
+  identity: "Vincent Tellier (C76R5DRH64)"
   hardenedRuntime: true
   gatekeeperAssess: false
   entitlements: resources/entitlements.mac.plist


### PR DESCRIPTION
electron-builder 26.x rejects the prefixed identity at packaging time (`⨯ Please remove prefix "Developer ID Application:" from the specified name`). Follow-up to #368; failed the v0.2.0 macOS re-run's arm64 job at Package/sign/notarize.

After merge: dispatch publish.yml again (`release_tag=v0.2.0`, macOS + Homebrew only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)