### PR TITLE
fix(ci): notarize + staple DMGs in the macOS publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -250,6 +250,25 @@ jobs:
           APPLE_API_ISSUER: ${{ vars.APPLE_API_ISSUER_ID }}
           APPLE_TEAM_ID: ${{ vars.APPLE_TEAM_ID }}
 
+      # electron-builder notarizes + staples the .app, but the DMG container it
+      # then packs never gets its own ticket — Gatekeeper still accepts the app
+      # inside, but the DMG can't be validated offline and `stapler validate`
+      # fails. Submit each DMG for its own notarization and staple it, so the
+      # artifact users (and the Homebrew cask) download is self-contained.
+      - name: Notarize and staple DMGs
+        run: |
+          set -e
+          for dmg in apps/desktop/out/*.dmg; do
+            echo "Notarizing $dmg"
+            xcrun notarytool submit "$dmg" \
+              --key "${{ steps.asc.outputs.key_path }}" \
+              --key-id "${{ vars.APPLE_API_KEY_ID }}" \
+              --issuer "${{ vars.APPLE_API_ISSUER_ID }}" \
+              --team-id "${{ vars.APPLE_TEAM_ID }}" \
+              --wait --timeout 30m
+            xcrun stapler staple "$dmg"
+          done
+
       - name: Verify Developer ID signature + stapled notarization
         run: |
           set -e
@@ -258,6 +277,8 @@ jobs:
           echo "Verifying $APP"
           codesign --verify --deep --strict --verbose=2 "$APP"
           codesign -dvvv "$APP" 2>&1 | grep -i 'Authority=Developer ID Application'
+          echo "Stapler validate $APP"
+          xcrun stapler validate "$APP"
           for dmg in apps/desktop/out/*.dmg; do
             echo "Stapler validate $dmg"
             xcrun stapler validate "$dmg"


### PR DESCRIPTION
Attempt 3 proved the pipeline end-to-end except the last inch: the .app signs, notarizes, and verifies clean, but electron-builder never notarizes the DMG container, so the verify gate's `stapler validate <dmg>` fails (exit 65, 'does not have a ticket stapled to it').

Fix: after packaging, submit each DMG via `notarytool --wait` (same API-key creds) and `stapler staple` it. The verify step now validates the app's ticket and the DMGs'. Zips can't be stapled — the stapled app inside covers them.

After merge: dispatch publish.yml (`release_tag=v0.2.0`, macOS + Homebrew only) — fourth and, evidence says, final attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)