### PR TITLE
chore(ci): rename tap secret to TAP_GITHUB_TOKEN (match macsweep/meterbar)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -300,19 +300,19 @@ jobs:
       - build-desktop-macos
     runs-on: ubuntu-latest
     steps:
-      - name: Verify HOMEBREW_TAP_TOKEN secret
+      - name: Verify TAP_GITHUB_TOKEN secret
         env:
-          TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          TAP_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
         run: |
           if [ -z "$TAP_TOKEN" ]; then
-            echo "::error::HOMEBREW_TAP_TOKEN repository secret not set"
+            echo "::error::TAP_GITHUB_TOKEN repository secret not set"
             exit 1
           fi
       - name: Checkout tap repo
         uses: actions/checkout@v4
         with:
           repository: shipshitdev/homebrew-tap
-          token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          token: ${{ secrets.TAP_GITHUB_TOKEN }}
           ref: master
       - name: Download macOS release artifacts
         run: |

--- a/docs/audits/00-repo-map.md
+++ b/docs/audits/00-repo-map.md
@@ -109,7 +109,7 @@ Pipeline phase model (13 states): `idle, planning, clarifying, reviewing, revisi
 | OpenRouter | `packages/agents/src/providers/openrouter-http.ts` | OpenAI-compatible SSE, native fetch, 429 retry w/ jitter |
 | Sentry | `@sentry/electron` main + renderer (`apps/desktop/src/main/telemetry.ts`, `src/renderer/telemetry.ts`) | DSN only from env (`SHIPCODE_SENTRY_DSN`/`SENTRY_DSN`), user-consent gated (`telemetryEnabled`), no hardcoded DSN in repo |
 | Telegram / Discord | `apps/desktop/src/main/chat-notification-service.ts` | Outbound pipeline-event notifications (bot API / webhooks) |
-| Vercel, Homebrew, npm | publish workflow only | Secrets: `VERCEL_TOKEN`, `HOMEBREW_TAP_TOKEN`, `GITHUB_TOKEN` — the only 3 secrets referenced in all of `.github/` |
+| Vercel, Homebrew, npm | publish workflow only | Secrets: `VERCEL_TOKEN`, `TAP_GITHUB_TOKEN`, `GITHUB_TOKEN` — the only 3 secrets referenced in all of `.github/` |
 
 **Background jobs.** All in-process (no queue infrastructure): `AutomationScheduler` (cron expressions via croner 10), `PipelineScheduler`, `ReconciliationLoop` (`packages/pipeline/src/reconciliation-loop.ts`), `RetryScheduler` with backoff, GitHub issue poller, 30-min update poll, `ResourceMonitor` + CPU-throttle settings. Weekly repo-level crons live in GitHub Actions (see §5).
 


### PR DESCRIPTION
Aligns shipcode's Homebrew tap-push secret name with the convention already used by `VincentShipsIt/macsweep` and `VincentShipsIt/meterbar.app` (`TAP_GITHUB_TOKEN`). The old `HOMEBREW_TAP_TOKEN` value was dead — the v0.2.0 cask job failed auth and the cask was bumped manually.

**After merge, one manual step:** mint a fine-grained PAT (repo `shipshitdev/homebrew-tap`, Contents: Read+Write) and:
```
gh secret set TAP_GITHUB_TOKEN --repo shipshitdev/shipcode
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved release publishing setup by validating the required Homebrew publishing credential before use.
  * Updated repository documentation to reflect the current publishing credential name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->