### PR TITLE
chore: harmonize PR issue linking

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Summary
+
+<!-- What changed and what outcome does it produce? -->
+
+## Related issue
+
+<!-- Use `Closes #123` only when this PR fully resolves the issue. Use `Refs #123` otherwise. A closing keyword takes effect when the PR merges into the repository's default branch. -->
+
+## Verification
+
+<!-- List the commands and manual checks run, with results and any blockers. -->
+
+## Screenshots
+
+<!-- Required for visible changes; otherwise write "Not applicable". -->
+
+## Checklist
+
+- [ ] I reviewed the final diff for unrelated changes.
+- [ ] I ran the relevant repository checks or documented why they could not run.
+- [ ] I did not include secrets, credentials, personal data, or generated build output.


### PR DESCRIPTION
## Summary

- add the shared Related issue contract to the repository PR template
- use `Closes #123` only for fully resolved issues and `Refs #123` otherwise
- document that the closing keyword takes effect when the PR merges into the default branch

## Verification

- `git diff --check`
- documentation-only GitHub PR-template change

## Impact

Fully resolving PRs can consistently close their linked issue on merge. The GitHub Project Item closed workflow remains responsible for moving the closed issue to Done.