### PR TITLE
fix(git): reconcile default branch fallback

### DIFF
--- a/packages/git/src/default-branch.test.ts
+++ b/packages/git/src/default-branch.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveDefaultBranch } from './default-branch';
+
+describe('resolveDefaultBranch', () => {
+  it.each([
+    {
+      name: 'origin HEAD before every local branch',
+      originHead: 'origin/develop\n',
+      branches: { all: ['main', 'master', 'feature/test'], current: 'feature/test' },
+      expected: 'develop',
+    },
+    {
+      name: 'main before master and the current branch',
+      originHead: null,
+      branches: { all: ['main', 'master', 'feature/test'], current: 'feature/test' },
+      expected: 'main',
+    },
+    {
+      name: 'master before the current branch',
+      originHead: null,
+      branches: { all: ['master', 'feature/test'], current: 'feature/test' },
+      expected: 'master',
+    },
+    {
+      name: 'the current branch when no conventional default exists',
+      originHead: null,
+      branches: { all: ['feature/test'], current: 'feature/test' },
+      expected: 'feature/test',
+    },
+    {
+      name: 'main when no branch can be detected',
+      originHead: null,
+      branches: { all: [], current: '' },
+      expected: 'main',
+    },
+  ])('$name', async ({ originHead, branches, expected }) => {
+    const git = {
+      raw: originHead
+        ? vi.fn().mockResolvedValue(originHead)
+        : vi.fn().mockRejectedValue(new Error('origin/HEAD missing')),
+      branchLocal: vi.fn().mockResolvedValue(branches),
+    };
+
+    await expect(resolveDefaultBranch(git)).resolves.toBe(expected);
+  });
+});

--- a/packages/git/src/default-branch.ts
+++ b/packages/git/src/default-branch.ts
@@ -1,0 +1,16 @@
+import type { SimpleGit } from 'simple-git';
+
+type DefaultBranchGit = Pick<SimpleGit, 'branchLocal' | 'raw'>;
+
+/** Resolve the repository default without mistaking a worktree branch for trunk. */
+export async function resolveDefaultBranch(git: DefaultBranchGit): Promise<string> {
+  try {
+    const result = await git.raw(['symbolic-ref', 'refs/remotes/origin/HEAD', '--short']);
+    return result.trim().replace('origin/', '');
+  } catch {
+    const branches = await git.branchLocal();
+    if (branches.all.includes('main')) return 'main';
+    if (branches.all.includes('master')) return 'master';
+    return branches.current || 'main';
+  }
+}

--- a/packages/git/src/git-service.ts
+++ b/packages/git/src/git-service.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import type { GitState } from '@shipcode/shared';
 import { normalizeBranches } from '@shipcode/shared';
 import { type SimpleGit, type StatusResult, simpleGit } from 'simple-git';
+import { resolveDefaultBranch } from './default-branch';
 
 function isUnavailableGitRepositoryError(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
@@ -100,16 +101,7 @@ export class GitService {
   }
 
   async getDefaultBranch(): Promise<string> {
-    try {
-      const result = await this.git.raw(['symbolic-ref', 'refs/remotes/origin/HEAD', '--short']);
-      return result.trim().replace('origin/', '');
-    } catch {
-      // Fallback: check if main or master exists
-      const branches = await this.git.branchLocal();
-      if (branches.all.includes('main')) return 'main';
-      if (branches.all.includes('master')) return 'master';
-      return branches.current ?? 'main';
-    }
+    return resolveDefaultBranch(this.git);
   }
 
   async getRemoteUrl(): Promise<string | null> {

--- a/packages/git/src/worktree.test.ts
+++ b/packages/git/src/worktree.test.ts
@@ -482,7 +482,7 @@ branch refs/heads/feature/not-ours
       all: ['main', 'master'],
     });
     await manager.merge('ship/42-fix-openrouter');
-    expect(gitMock.checkout).toHaveBeenCalledWith('release');
+    expect(gitMock.checkout).toHaveBeenCalledWith('main');
     expect(gitMock.merge).toHaveBeenCalledWith(['ship/42-fix-openrouter', '--no-ff']);
 
     gitMock.raw.mockRejectedValueOnce(new Error('origin head unavailable'));

--- a/packages/git/src/worktree.ts
+++ b/packages/git/src/worktree.ts
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { formatIssueBranch as formatIssueBranchShared, slugifyIssueTitle } from '@shipcode/shared';
 import { resolveWorktreeParent } from '@shipcode/shared/worktree-path';
 import { type SimpleGit, simpleGit } from 'simple-git';
+import { resolveDefaultBranch } from './default-branch';
 import {
   listWorktreeArtifacts,
   pruneWorktreeArtifacts,
@@ -323,16 +324,6 @@ export class WorktreeManager {
   }
 
   private async getDefaultBranch(): Promise<string> {
-    try {
-      const result = await this.git.raw(['symbolic-ref', 'refs/remotes/origin/HEAD', '--short']);
-      return result.trim().replace('origin/', '');
-    } catch {
-      const branches = await this.git.branchLocal();
-      // Check current branch first, then common defaults
-      if (branches.current) return branches.current;
-      if (branches.all.includes('main')) return 'main';
-      if (branches.all.includes('master')) return 'master';
-      return 'main';
-    }
+    return resolveDefaultBranch(this.git);
   }
 }


### PR DESCRIPTION
## Summary

- extract one canonical default-branch resolver for `GitService` and `WorktreeManager`
- enforce `origin/HEAD` → `main` → `master` → current branch → `main`
- prevent feature/worktree branches from winning when a conventional trunk exists
- cover the complete fallback order with a table-driven test

## Why

`GitService` and `WorktreeManager` implemented different fallback orders. Inside a feature worktree, `WorktreeManager` could choose the current branch as the merge target even when `main` or `master` existed.

## Verification

- `bunx biome check packages/git/src/default-branch.ts packages/git/src/default-branch.test.ts packages/git/src/git-service.ts packages/git/src/worktree.ts packages/git/src/worktree.test.ts --assist-enabled=false --files-ignore-unknown=true`
- `bun run --cwd packages/git test` — 97 tests passed
- `bun run --cwd packages/git typecheck`
- `bun run --cwd packages/git build`
- `bun run --cwd packages/git coverage` — 98.45% statements, 97.26% branches
- `bun run verify:affected`
- `git diff --check`

Closes #309
