### PR TITLE
feat(pipeline): post issue timeline comments

### DIFF
--- a/apps/cli/src/context.test.ts
+++ b/apps/cli/src/context.test.ts
@@ -61,6 +61,7 @@ vi.mock('@shipcode/db', () => ({
   FeatureQaResultQueries: mocks.Query,
   GitHubIssueQueries: mocks.Query,
   getDatabase: mocks.getDatabase,
+  PhaseLogQueries: mocks.Query,
   PipelineRunQueries: mocks.Query,
   PipelineStepQueries: mocks.Query,
   PlanQueries: mocks.Query,
@@ -113,6 +114,7 @@ describe('createCliContext', () => {
       openrouter: { kind: 'openrouter' },
     });
     expect(context.pipelineDeps.projects).toBe(context.projects);
+    expect(context.pipelineDeps.phaseLogs).toBe(context.phaseLogs);
     expect(context.pipelineDeps.emitter).toBe(context.emitter);
     expect(mocks.state.openRouterOptions?.getApiKey()).toBe('openrouter-key');
     expect(mocks.state.openRouterOptions?.getSettings()).toEqual({ telemetryEnabled: true });

--- a/apps/cli/src/context.ts
+++ b/apps/cli/src/context.ts
@@ -17,6 +17,7 @@ import {
   FeatureQaResultQueries,
   GitHubIssueQueries,
   getDatabase,
+  PhaseLogQueries,
   PipelineRunQueries,
   PipelineStepQueries,
   PlanQueries,
@@ -48,6 +49,7 @@ export interface CliContext {
   skills: SkillsQueries;
   checkpoints: CheckpointQueries;
   terminalEvents: TerminalEventQueries;
+  phaseLogs: PhaseLogQueries;
   agentConversations: AgentConversationQueries;
   taskGraphs: TaskGraphQueries;
   ghCli: GhCli;
@@ -78,6 +80,7 @@ export function createCliContext(cwd: string): CliContext {
   const skills = new SkillsQueries(db);
   const checkpoints = new CheckpointQueries(db);
   const terminalEvents = new TerminalEventQueries(db);
+  const phaseLogs = new PhaseLogQueries(db);
   const pipelineRuns = new PipelineRunQueries(db);
   const pipelineSteps = new PipelineStepQueries(db);
   const agentConversations = new AgentConversationQueries(db);
@@ -119,6 +122,7 @@ export function createCliContext(cwd: string): CliContext {
     providers,
     skills,
     taskGraphs,
+    phaseLogs,
     pipelineRuns,
     pipelineSteps,
     agentConversations,
@@ -139,6 +143,7 @@ export function createCliContext(cwd: string): CliContext {
     skills,
     checkpoints,
     terminalEvents,
+    phaseLogs,
     agentConversations,
     taskGraphs,
     ghCli,

--- a/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.test.tsx
@@ -178,6 +178,8 @@ describe('PipelineSettingsSection', () => {
 
     fireEvent.click(screen.getByRole('switch', { name: 'Require approval before execution' }));
     expect(onUpdate).toHaveBeenCalledWith({ requireApproval: true });
+    fireEvent.click(screen.getByRole('switch', { name: 'Post pipeline timeline to GitHub' }));
+    expect(onUpdate).toHaveBeenCalledWith({ postPipelineTimelineEnabled: false });
 
     fireEvent.change(screen.getByLabelText('Max concurrent pipelines'), {
       target: { value: '0' },

--- a/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx
@@ -322,6 +322,19 @@ function pipelineSettingsSection({
               />
             </SettingsRow>
             <SettingsRow
+              label="Post pipeline timeline to GitHub"
+              htmlFor="post-pipeline-timeline-enabled"
+              description="When on, phase transitions update a single timeline comment on the GitHub issue. When off, project status and pipeline labels still sync normally."
+            >
+              <Switch
+                id="post-pipeline-timeline-enabled"
+                checked={settings.postPipelineTimelineEnabled}
+                onCheckedChange={(checked: boolean) =>
+                  onUpdate({ postPipelineTimelineEnabled: checked })
+                }
+              />
+            </SettingsRow>
+            <SettingsRow
               label="Max concurrent pipelines"
               htmlFor="max-concurrent-pipelines"
               description="How many pipelines can run at once. Extras are queued."

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -173,6 +173,10 @@ export {
   measurePhasePromptTelemetry,
   toPersistedPromptTelemetryMaterials,
 } from './prompts/phase-prompt-telemetry';
+export {
+  formatPipelineTimelineComment,
+  PIPELINE_TIMELINE_COMMENT_MARKER,
+} from './prompts/pipeline-timeline-comment';
 export { formatPlanComment, PLAN_COMMENT_MARKER } from './prompts/plan-comment';
 export type {
   PlanPromptContext,

--- a/packages/agents/src/prompts/pipeline-timeline-comment.test.ts
+++ b/packages/agents/src/prompts/pipeline-timeline-comment.test.ts
@@ -1,0 +1,58 @@
+import type { PipelinePhaseLogRecord } from '@shipcode/shared';
+import { describe, expect, it } from 'vitest';
+import {
+  formatPipelineTimelineComment,
+  PIPELINE_TIMELINE_COMMENT_MARKER,
+} from './pipeline-timeline-comment';
+
+function entry(
+  phase: PipelinePhaseLogRecord['phase'],
+  startedAt: string,
+  errorMessage: string | null = null,
+): PipelinePhaseLogRecord {
+  return {
+    id: `${phase}-${startedAt}`,
+    threadId: 'thread-1',
+    runId: 'run-1',
+    phase,
+    startedAt,
+    completedAt: null,
+    durationMs: null,
+    terminalStatus: null,
+    errorMessage,
+    metadata: null,
+  };
+}
+
+describe('formatPipelineTimelineComment', () => {
+  it('renders the marker, ordered phases, timestamps, and current glyph', () => {
+    const body = formatPipelineTimelineComment([
+      entry('planning', '2026-07-12T10:00:00.000Z'),
+      entry('reviewing', '2026-07-12T10:05:00.000Z'),
+      entry('executing', '2026-07-12T10:10:00.000Z'),
+    ]);
+
+    expect(body.split('\n')[0]).toBe(PIPELINE_TIMELINE_COMMENT_MARKER);
+    expect(body).toContain('- ✅ **Planning** — 2026-07-12 10:00 UTC');
+    expect(body).toContain('- ✅ **Reviewing** — 2026-07-12 10:05 UTC');
+    expect(body).toContain('- ▶️ **Executing** — 2026-07-12 10:10 UTC');
+    expect(body.indexOf('Planning')).toBeLessThan(body.indexOf('Reviewing'));
+  });
+
+  it('deduplicates consecutive phases and renders terminal glyphs with clamped errors', () => {
+    const body = formatPipelineTimelineComment([
+      entry('planning', '2026-07-12T10:00:00.000Z'),
+      entry('planning', '2026-07-12T10:01:00.000Z'),
+      entry('paused', '2026-07-12T10:02:00.000Z'),
+      entry('failed', '2026-07-12T10:03:00.000Z', `<failure>${'x'.repeat(400)}\nignored`),
+    ]);
+
+    expect(body.match(/\*\*Planning\*\*/g)).toHaveLength(1);
+    expect(body).toContain('Planning** — 2026-07-12 10:01 UTC');
+    expect(body).toContain('⏸️ **Paused**');
+    expect(body).toContain('❌ **Failed**');
+    expect(body).toContain('<code>&lt;failure&gt;');
+    expect(body).not.toContain('ignored');
+    expect(body).not.toContain('x'.repeat(300));
+  });
+});

--- a/packages/agents/src/prompts/pipeline-timeline-comment.ts
+++ b/packages/agents/src/prompts/pipeline-timeline-comment.ts
@@ -1,0 +1,62 @@
+import type { PipelinePhaseLogRecord } from '@shipcode/shared';
+
+/** Literal first line used to find and update the existing timeline comment. */
+export const PIPELINE_TIMELINE_COMMENT_MARKER = '## ShipCode Pipeline Timeline';
+
+const TERMINAL_PHASES = new Set(['completed', 'failed', 'paused']);
+
+export function formatPipelineTimelineComment(entries: PipelinePhaseLogRecord[]): string {
+  const timeline = dedupeConsecutivePhases(entries);
+  const lines = [PIPELINE_TIMELINE_COMMENT_MARKER, ''];
+
+  for (const [index, entry] of timeline.entries()) {
+    const isCurrent = index === timeline.length - 1 && !TERMINAL_PHASES.has(entry.phase);
+    const detail = entry.phase === 'failed' ? formatError(entry.errorMessage) : '';
+    lines.push(
+      `- ${phaseGlyph(entry.phase, isCurrent)} **${formatPhase(entry.phase)}** — ${formatTimestamp(entry.startedAt)}${detail}`,
+    );
+  }
+
+  lines.push('', '---', '*Updated by ShipCode*');
+  return lines.join('\n');
+}
+
+function dedupeConsecutivePhases(entries: PipelinePhaseLogRecord[]): PipelinePhaseLogRecord[] {
+  const result: PipelinePhaseLogRecord[] = [];
+  for (const entry of entries) {
+    if (result.at(-1)?.phase === entry.phase) {
+      result[result.length - 1] = entry;
+    } else {
+      result.push(entry);
+    }
+  }
+  return result;
+}
+
+function phaseGlyph(phase: PipelinePhaseLogRecord['phase'], isCurrent: boolean): string {
+  if (phase === 'failed') return '❌';
+  if (phase === 'paused') return '⏸️';
+  if (isCurrent) return '▶️';
+  return '✅';
+}
+
+function formatPhase(phase: PipelinePhaseLogRecord['phase']): string {
+  return phase.charAt(0).toUpperCase() + phase.slice(1);
+}
+
+function formatTimestamp(timestamp: string): string {
+  const parsed = new Date(timestamp);
+  if (Number.isNaN(parsed.getTime())) return timestamp;
+  return `${parsed.toISOString().slice(0, 16).replace('T', ' ')} UTC`;
+}
+
+function formatError(error: string | null): string {
+  if (!error) return '';
+  const firstLine = error.split(/\r?\n/, 1)[0]?.trim().slice(0, 280) ?? '';
+  if (!firstLine) return '';
+  const escaped = firstLine
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+  return ` — <code>${escaped}</code>`;
+}

--- a/packages/db/src/queries/settings.test.ts
+++ b/packages/db/src/queries/settings.test.ts
@@ -48,6 +48,7 @@ describe('SettingsQueries', () => {
     expect(s.githubPollingEnabled).toBe(false);
     expect(s.githubPollingIntervalMs).toBe(30000);
     expect(s.githubBotUsername).toBe('');
+    expect(s.postPipelineTimelineEnabled).toBe(true);
     expect(s.maxConcurrentCpuTasks).toBe(1);
     expect(s.cpuThrottleThresholdPercent).toBe(85);
     expect(s.shellCommandTimeoutMs).toBe(600_000);
@@ -57,6 +58,11 @@ describe('SettingsQueries', () => {
     expect(s.projectOpenTarget).toBe('cursor');
     expect(s.terminalOpenTarget).toBe('terminal');
     expect(s.updateTrack).toBe('master');
+  });
+
+  it('round-trips the pipeline timeline comment setting', () => {
+    settings.set({ postPipelineTimelineEnabled: false });
+    expect(settings.get().postPipelineTimelineEnabled).toBe(false);
   });
 
   it('normalizes legacy afk run modes to programmatic', () => {

--- a/packages/db/src/queries/settings.ts
+++ b/packages/db/src/queries/settings.ts
@@ -318,6 +318,10 @@ export class SettingsQueries {
         stored.postPlanCommentsEnabled,
         DEFAULT_SETTINGS.postPlanCommentsEnabled,
       ),
+      postPipelineTimelineEnabled: parseBool(
+        stored.postPipelineTimelineEnabled,
+        DEFAULT_SETTINGS.postPipelineTimelineEnabled,
+      ),
       plannerReasoningEffort: isReasoningEffort(stored.plannerReasoningEffort)
         ? (stored.plannerReasoningEffort as AppSettings['plannerReasoningEffort'])
         : DEFAULT_SETTINGS.plannerReasoningEffort,

--- a/packages/pipeline/src/pipeline/runtime.test.ts
+++ b/packages/pipeline/src/pipeline/runtime.test.ts
@@ -1,7 +1,12 @@
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { type AgentProvider, GhCli, PLAN_COMMENT_MARKER } from '@shipcode/agents';
+import {
+  type AgentProvider,
+  GhCli,
+  PIPELINE_TIMELINE_COMMENT_MARKER,
+  PLAN_COMMENT_MARKER,
+} from '@shipcode/agents';
 import { DEFAULT_SETTINGS } from '@shipcode/shared';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PipelineContext, PipelineDeps } from '../types';
@@ -1923,6 +1928,95 @@ describe('createPipelineRuntime', () => {
 
     expect(phaseLogs.transition).toHaveBeenCalledWith('thread-1', 'executing', null);
     expect(deps.threads.updateStatus).toHaveBeenCalledWith('thread-1', 'executing');
+    expect(deps.emitter.emit).toHaveBeenCalledWith({
+      type: 'pipeline:phase',
+      threadId: 'thread-1',
+      phase: 'executing',
+    });
+  });
+
+  it('upserts the ordered pipeline timeline after a phase transition', async () => {
+    const { deps } = makeDeps();
+    deps.projects.getById = vi.fn(() => ({ path: '/repo' })) as never;
+    deps.phaseLogs = {
+      transition: vi.fn(),
+      listByThread: vi.fn(() => [
+        {
+          id: 'phase-1',
+          threadId: 'thread-1',
+          runId: null,
+          phase: 'planning',
+          startedAt: '2026-07-12T10:00:00.000Z',
+          completedAt: '2026-07-12T10:05:00.000Z',
+          durationMs: 300_000,
+          terminalStatus: 'executing',
+          errorMessage: null,
+          metadata: null,
+        },
+        {
+          id: 'phase-2',
+          threadId: 'thread-1',
+          runId: null,
+          phase: 'executing',
+          startedAt: '2026-07-12T10:05:00.000Z',
+          completedAt: null,
+          durationMs: null,
+          terminalStatus: null,
+          errorMessage: null,
+          metadata: null,
+        },
+      ]),
+    } as never;
+    const runtime = createPipelineRuntime(deps, {} as never);
+
+    runtime.emitPhase('thread-1', 'executing');
+    await vi.waitFor(() => expect(mockGhCli.upsertIssueCommentByMarker).toHaveBeenCalled());
+
+    expect(mockGhCli.upsertIssueCommentByMarker).toHaveBeenCalledWith(
+      42,
+      PIPELINE_TIMELINE_COMMENT_MARKER,
+      expect.stringContaining('▶️ **Executing**'),
+    );
+  });
+
+  it('suppresses pipeline timeline writes when the setting is off', async () => {
+    const { deps } = makeDeps();
+    deps.settings.get = vi.fn(() => ({
+      ...DEFAULT_SETTINGS,
+      postPipelineTimelineEnabled: false,
+    })) as never;
+    deps.phaseLogs = {
+      transition: vi.fn(),
+      listByThread: vi.fn(() => []),
+    } as never;
+    const runtime = createPipelineRuntime(deps, {} as never);
+
+    runtime.emitPhase('thread-1', 'executing');
+    await Promise.resolve();
+
+    expect(mockGhCli.upsertIssueCommentByMarker).not.toHaveBeenCalled();
+  });
+
+  it('swallows pipeline timeline writer failures', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const { deps } = makeDeps();
+    deps.projects.getById = vi.fn(() => ({ path: '/repo' })) as never;
+    deps.phaseLogs = {
+      transition: vi.fn(),
+      listByThread: vi.fn(() => {
+        throw new Error('phase history offline');
+      }),
+    } as never;
+    const runtime = createPipelineRuntime(deps, {} as never);
+
+    runtime.emitPhase('thread-1', 'executing');
+    await vi.waitFor(() =>
+      expect(warn).toHaveBeenCalledWith(
+        '[pipeline] Failed to post pipeline timeline comment:',
+        expect.any(Error),
+      ),
+    );
+
     expect(deps.emitter.emit).toHaveBeenCalledWith({
       type: 'pipeline:phase',
       threadId: 'thread-1',

--- a/packages/pipeline/src/pipeline/runtime.ts
+++ b/packages/pipeline/src/pipeline/runtime.ts
@@ -1,10 +1,12 @@
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import {
+  formatPipelineTimelineComment,
   formatPlanComment,
   GhCli,
   isPoolExhausted,
   measurePhasePromptTelemetry,
+  PIPELINE_TIMELINE_COMMENT_MARKER,
   PLAN_COMMENT_MARKER,
   type PromptMaterial,
   type ProviderPhase,
@@ -807,19 +809,49 @@ export function createPipelineRuntime(
     error?: string,
   ) {
     const runId = syncRunForPhase(threadId, phase, error);
+    let phaseLogged = false;
     try {
       if (runId) {
         deps.phaseLogs?.transition(threadId, phase, error ?? null, runId);
       } else {
         deps.phaseLogs?.transition(threadId, phase, error ?? null);
       }
+      phaseLogged = Boolean(deps.phaseLogs);
     } catch (logError) {
       console.error(`[pipeline] phase log transition failed for thread ${threadId}:`, logError);
     }
     // Route through the shared service's serializer — collapses rapid phase
     // transitions into the latest desired state per issue.
     syncThreadAndIssuePhase(deps.threads, deps.githubIssues, threadId, phase, error, ghSync.deps);
+    if (phaseLogged) void postPipelineTimelineComment(threadId);
     deps.emitter.emit({ type: 'pipeline:phase', threadId, phase, ...(runId ? { runId } : {}) });
+  }
+
+  async function postPipelineTimelineComment(threadId: string): Promise<void> {
+    try {
+      if (!deps.settings.get().postPipelineTimelineEnabled) return;
+
+      const activeContext = _contextHelpers.activePipelines?.get(threadId);
+      const thread = activeContext ? null : deps.threads.getById(threadId);
+      const issueNumber = activeContext?.githubIssueNumber ?? thread?.githubIssueNumber ?? null;
+      if (!isRealGithubIssueNumber(issueNumber)) return;
+
+      const projectPath =
+        activeContext?.projectPath ?? deps.projects.getById(thread?.projectId ?? '')?.path;
+      if (!projectPath) return;
+
+      const entries = deps.phaseLogs?.listByThread(threadId) ?? [];
+      if (entries.length === 0) return;
+
+      const ghCli = new GhCli(projectPath);
+      await ghCli.upsertIssueCommentByMarker(
+        issueNumber,
+        PIPELINE_TIMELINE_COMMENT_MARKER,
+        formatPipelineTimelineComment(entries),
+      );
+    } catch (error) {
+      console.warn('[pipeline] Failed to post pipeline timeline comment:', error);
+    }
   }
 
   async function postPlanComment(

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -109,6 +109,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   pipelineSpeedProfile: 'smart_fast',
   requireApproval: false,
   postPlanCommentsEnabled: true,
+  postPipelineTimelineEnabled: true,
   plannerReasoningEffort: 'low',
   reviewerReasoningEffort: 'high',
   executorReasoningEffort: 'medium',

--- a/packages/shared/src/types/settings.ts
+++ b/packages/shared/src/types/settings.ts
@@ -97,6 +97,9 @@ export interface AppSettings {
   // whenever a plan is approved (autonomous or manual). When false, plan comments
   // are suppressed; task-graph and review comments are unaffected.
   postPlanCommentsEnabled: boolean;
+  // When true (default), phase transitions are mirrored to a single timeline
+  // comment on the GitHub issue. This does not affect project or label sync.
+  postPipelineTimelineEnabled: boolean;
   // Per-phase reasoning effort. Applied as:
   //   Claude: mapped to a supported thinking-token budget
   //   Codex:  mapped to supported low|medium|high levels


### PR DESCRIPTION
## Summary

- render durable pipeline phase history as a single marker-upserted GitHub issue timeline
- post timeline updates fire-and-forget from the shared phase transition choke point in desktop and CLI runs
- add a default-on live setting and desktop toggle without affecting project status or pipeline label sync
- clamp and HTML-escape failed-phase errors before including them in comments

## Impact

Reviewers can follow planning, review, execution, verification, shipping, pause, and failure transitions directly from the issue. Consecutive duplicate phases are collapsed, while timestamps and terminal/current glyphs remain visible.

## Verification

- `bunx biome check --assist-enabled=false <13 changed files>`
- focused tests: formatter 2/2, settings 38/38, runtime 79/79, renderer 7/7
- focused coverage: formatter 91.42% statements / 80% branches; runtime 88.64% statements / 80.76% branches
- `bun run --cwd apps/cli build`
- `bun run verify:affected` (desktop 1,528; agents 1,095 + 1 skipped; DB 531; pipeline 570 + 7 skipped; shared 431; CLI 103 tests passed)
- `git diff --check`

No required checks were skipped and there are no known blockers.

Closes #331


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to post pipeline timelines to a single GitHub issue comment.
  * Pipeline timeline comments now show phase progress, timestamps, and failure details.
  * Added the “Post pipeline timeline to GitHub” setting, enabled by default and persisted across sessions.

* **Bug Fixes**
  * Timeline comment update failures no longer interrupt pipeline phase transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->