### PR TITLE
feat(pipeline): post formal PR reviews

### DIFF
--- a/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.test.tsx
+++ b/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.test.tsx
@@ -178,6 +178,8 @@ describe('PipelineSettingsSection', () => {
 
     fireEvent.click(screen.getByRole('switch', { name: 'Require approval before execution' }));
     expect(onUpdate).toHaveBeenCalledWith({ requireApproval: true });
+    fireEvent.click(screen.getByRole('switch', { name: 'Post formal PR reviews to GitHub' }));
+    expect(onUpdate).toHaveBeenCalledWith({ postFormalPrReviewEnabled: false });
 
     fireEvent.change(screen.getByLabelText('Max concurrent pipelines'), {
       target: { value: '0' },

--- a/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings-panel/PipelineSettingsSection.tsx
@@ -322,6 +322,19 @@ function pipelineSettingsSection({
               />
             </SettingsRow>
             <SettingsRow
+              label="Post formal PR reviews to GitHub"
+              htmlFor="post-formal-pr-review-enabled"
+              description="When on, ShipCode publishes findings in GitHub's native review surface. When off, findings remain a regular PR comment."
+            >
+              <Switch
+                id="post-formal-pr-review-enabled"
+                checked={settings.postFormalPrReviewEnabled}
+                onCheckedChange={(checked: boolean) =>
+                  onUpdate({ postFormalPrReviewEnabled: checked })
+                }
+              />
+            </SettingsRow>
+            <SettingsRow
               label="Max concurrent pipelines"
               htmlFor="max-concurrent-pipelines"
               description="How many pipelines can run at once. Extras are queued."

--- a/packages/agents/src/github/gh-cli.test.ts
+++ b/packages/agents/src/github/gh-cli.test.ts
@@ -700,6 +700,59 @@ describe('GhCli', () => {
     });
   });
 
+  describe('submitPrReview', () => {
+    it('downgrades self-reviews to comments and pipes the body through stdin', async () => {
+      success(JSON.stringify({ owner: { login: 'shipshitdev' }, name: 'shipcode' }));
+      success('ShipCodeBot\n');
+      success(JSON.stringify({ user: { login: 'shipcodebot' }, head: { sha: 'head-sha' } }));
+      success(JSON.stringify([[]]));
+      const fake = createFakeProc();
+      mockSpawn.mockReturnValueOnce(fake.proc);
+
+      const promise = gh.submitPrReview(17, 'request-changes', '---\nreview body');
+      await waitForSpawnCall();
+      fake.complete(0);
+
+      await expect(promise).resolves.toEqual({
+        event: 'comment',
+        downgradedForSelfReview: true,
+        skippedDuplicate: false,
+      });
+      expect(mockSpawn).toHaveBeenCalledWith(
+        'gh',
+        ['pr', 'review', '17', '--comment', '--body-file', '-'],
+        ghSpawnOptions,
+      );
+      expect(fake.stdinWrites).toEqual(['---\nreview body']);
+      expect(fake.isStdinEnded()).toBe(true);
+    });
+
+    it('skips an identical review from the same author and head commit', async () => {
+      success(JSON.stringify({ owner: { login: 'shipshitdev' }, name: 'shipcode' }));
+      success('ReviewerBot\n');
+      success(JSON.stringify({ user: { login: 'author' }, head: { sha: 'head-sha' } }));
+      success(
+        JSON.stringify([
+          [
+            {
+              user: { login: 'reviewerbot' },
+              commit_id: 'head-sha',
+              state: 'APPROVED',
+              body: 'looks good',
+            },
+          ],
+        ]),
+      );
+
+      await expect(gh.submitPrReview(17, 'approve', 'looks good')).resolves.toEqual({
+        event: 'approve',
+        downgradedForSelfReview: false,
+        skippedDuplicate: true,
+      });
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+  });
+
   describe('setIssueLabelPresence', () => {
     it('adds the label when missing', async () => {
       success(

--- a/packages/agents/src/github/gh-cli.ts
+++ b/packages/agents/src/github/gh-cli.ts
@@ -21,6 +21,14 @@ import { shellExecEnv } from '../health-check';
 
 const execFileAsync = promisify(execFile);
 
+export type PrReviewEvent = 'approve' | 'request-changes' | 'comment';
+
+export interface SubmitPrReviewResult {
+  event: PrReviewEvent;
+  downgradedForSelfReview: boolean;
+  skippedDuplicate: boolean;
+}
+
 /**
  * Detect whether a `gh project item-add` failure is the "already on the
  * board" case, which we treat as success in addIssueToProject. The exact
@@ -916,6 +924,82 @@ export class GhCli {
       ['pr', 'edit', String(options.prNumber), '--title', options.title, '--body-file', '-'],
       options.body,
     );
+  }
+
+  async submitPrReview(
+    prNumber: number,
+    event: PrReviewEvent,
+    body: string,
+  ): Promise<SubmitPrReviewResult> {
+    const { owner, repo } = await this.getRepoCoordinates();
+    const { stdout: viewerStdout } = await execFileAsync('gh', ['api', 'user', '--jq', '.login'], {
+      cwd: this.cwd,
+      env: this.env,
+    });
+    const { stdout: prStdout } = await execFileAsync(
+      'gh',
+      ['api', `repos/${owner}/${repo}/pulls/${prNumber}`],
+      { cwd: this.cwd, env: this.env },
+    );
+    const pr = JSON.parse(prStdout) as {
+      user?: { login?: string } | null;
+      head?: { sha?: string } | null;
+    };
+    const viewer = viewerStdout.trim();
+    const author = pr.user?.login?.trim() ?? '';
+    const headSha = pr.head?.sha?.trim() ?? '';
+    const downgradedForSelfReview =
+      event !== 'comment' && !!viewer && !!author && viewer.toLowerCase() === author.toLowerCase();
+    const submittedEvent = downgradedForSelfReview ? 'comment' : event;
+
+    if (viewer && headSha) {
+      const { stdout: reviewsStdout } = await execFileAsync(
+        'gh',
+        ['api', '--paginate', '--slurp', `repos/${owner}/${repo}/pulls/${prNumber}/reviews`],
+        { cwd: this.cwd, env: this.env },
+      );
+      const reviews = (
+        JSON.parse(reviewsStdout) as Array<
+          Array<{
+            user?: { login?: string } | null;
+            commit_id?: string;
+            state?: string;
+            body?: string;
+          }>
+        >
+      ).flat();
+      const expectedState =
+        submittedEvent === 'approve'
+          ? 'APPROVED'
+          : submittedEvent === 'request-changes'
+            ? 'CHANGES_REQUESTED'
+            : 'COMMENTED';
+      const duplicate = reviews.some(
+        (review) =>
+          review.user?.login?.toLowerCase() === viewer.toLowerCase() &&
+          review.commit_id === headSha &&
+          review.state?.toUpperCase() === expectedState &&
+          (review.body ?? '') === body,
+      );
+      if (duplicate) {
+        return {
+          event: submittedEvent,
+          downgradedForSelfReview,
+          skippedDuplicate: true,
+        };
+      }
+    }
+
+    await this.spawnWithStdin(
+      'gh',
+      ['pr', 'review', String(prNumber), `--${submittedEvent}`, '--body-file', '-'],
+      body,
+    );
+    return {
+      event: submittedEvent,
+      downgradedForSelfReview,
+      skippedDuplicate: false,
+    };
   }
 
   async setIssueLabelPresence(issueNumber: number, label: string, present: boolean): Promise<void> {

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -32,6 +32,7 @@ export {
   readContextFile,
 } from './context-generator';
 export { loadRepoContext, loadStructuredRepoContext } from './context-loader';
+export type { PrReviewEvent, SubmitPrReviewResult } from './github/gh-cli';
 export { GhCli } from './github/gh-cli';
 export type {
   ApplyTriageRulesOnceOptions,

--- a/packages/db/src/queries/settings.test.ts
+++ b/packages/db/src/queries/settings.test.ts
@@ -48,6 +48,7 @@ describe('SettingsQueries', () => {
     expect(s.githubPollingEnabled).toBe(false);
     expect(s.githubPollingIntervalMs).toBe(30000);
     expect(s.githubBotUsername).toBe('');
+    expect(s.postFormalPrReviewEnabled).toBe(true);
     expect(s.maxConcurrentCpuTasks).toBe(1);
     expect(s.cpuThrottleThresholdPercent).toBe(85);
     expect(s.shellCommandTimeoutMs).toBe(600_000);
@@ -57,6 +58,12 @@ describe('SettingsQueries', () => {
     expect(s.projectOpenTarget).toBe('cursor');
     expect(s.terminalOpenTarget).toBe('terminal');
     expect(s.updateTrack).toBe('master');
+  });
+
+  it('persists the formal PR review toggle', () => {
+    settings.set({ postFormalPrReviewEnabled: false });
+
+    expect(settings.get().postFormalPrReviewEnabled).toBe(false);
   });
 
   it('normalizes legacy afk run modes to programmatic', () => {

--- a/packages/db/src/queries/settings.ts
+++ b/packages/db/src/queries/settings.ts
@@ -318,6 +318,10 @@ export class SettingsQueries {
         stored.postPlanCommentsEnabled,
         DEFAULT_SETTINGS.postPlanCommentsEnabled,
       ),
+      postFormalPrReviewEnabled: parseBool(
+        stored.postFormalPrReviewEnabled,
+        DEFAULT_SETTINGS.postFormalPrReviewEnabled,
+      ),
       plannerReasoningEffort: isReasoningEffort(stored.plannerReasoningEffort)
         ? (stored.plannerReasoningEffort as AppSettings['plannerReasoningEffort'])
         : DEFAULT_SETTINGS.plannerReasoningEffort,

--- a/packages/pipeline/src/pipeline/execution-phases.test.ts
+++ b/packages/pipeline/src/pipeline/execution-phases.test.ts
@@ -13,6 +13,7 @@ import {
   extractTestFailureSummary,
   normalizeFeatureQaResults,
   probeWorktreeChanges,
+  resolveFormalPrReviewEvent,
   resolveWorktreeDiffBase,
 } from './execution-phases';
 import type { PipelineContextHelpers, PipelineRuntime } from './shared';
@@ -34,12 +35,18 @@ type ExecutionHarnessDeps = {
 
 const {
   mockExecFileSync,
+  mockGhSubmitPrReview,
   mockGhUpsertIssueCommentByMarker,
   mockServerLifecycleStart,
   mockServerLifecycleStop,
   mockShellExecEnv,
 } = vi.hoisted(() => ({
   mockExecFileSync: vi.fn(),
+  mockGhSubmitPrReview: vi.fn(async () => ({
+    event: 'approve',
+    downgradedForSelfReview: false,
+    skippedDuplicate: false,
+  })),
   mockGhUpsertIssueCommentByMarker: vi.fn(async () => undefined),
   mockServerLifecycleStart: vi.fn(),
   mockServerLifecycleStop: vi.fn(),
@@ -80,6 +87,7 @@ vi.mock('@shipcode/agents', async (importOriginal) => {
     ...actual,
     GhCli: vi.fn(function GhCli() {
       return {
+        submitPrReview: mockGhSubmitPrReview,
         upsertIssueCommentByMarker: mockGhUpsertIssueCommentByMarker,
       };
     }),
@@ -214,6 +222,7 @@ function makeExecutionHarness(context = makeContext()) {
       get: vi.fn(() => ({
         maxConcurrentExecutions: 1,
         maxConcurrentCpuTasks: 1,
+        postFormalPrReviewEnabled: true,
       })),
     },
     emitter: { emit },
@@ -377,6 +386,15 @@ describe('extractExecutionErrorSnippet', () => {
 describe('execution phase helpers', () => {
   beforeEach(() => {
     mockExecFileSync.mockReset();
+  });
+
+  it.each([
+    ['approve', [], 'approve'],
+    ['approve', [{ status: 'open', severity: 'major' }], 'request-changes'],
+    ['approve', [{ status: 'open', severity: 'critical' }], 'request-changes'],
+    ['request_changes', [], 'request-changes'],
+  ] as const)('maps %s with findings to %s', (decision, findings, expected) => {
+    expect(resolveFormalPrReviewEvent(decision, [...findings])).toBe(expected);
   });
 
   it('builds default and custom continuation prompts', () => {
@@ -573,6 +591,12 @@ describe('execution phase handlers', () => {
   beforeEach(() => {
     vi.useRealTimers();
     mockExecFileSync.mockReset();
+    mockGhSubmitPrReview.mockReset();
+    mockGhSubmitPrReview.mockResolvedValue({
+      event: 'approve',
+      downgradedForSelfReview: false,
+      skippedDuplicate: false,
+    });
     mockGhUpsertIssueCommentByMarker.mockReset();
     mockGhUpsertIssueCommentByMarker.mockResolvedValue(undefined);
     mockServerLifecycleStart.mockReset();
@@ -1997,10 +2021,45 @@ describe('execution phase handlers', () => {
 
     await harness.handlers.startShipping('thread-1');
 
+    expect(mockGhSubmitPrReview).toHaveBeenCalledWith(
+      17,
+      'request-changes',
+      expect.stringContaining('CI failed'),
+    );
+    expect(mockGhUpsertIssueCommentByMarker).not.toHaveBeenCalled();
+  });
+
+  it('keeps comment-only review findings when formal reviews are disabled', async () => {
+    const context = makeContext({ baseBranch: 'develop' });
+    const harness = makeExecutionHarness(context);
+    vi.mocked(harness.deps.settings.get).mockReturnValue({
+      maxConcurrentExecutions: 1,
+      maxConcurrentCpuTasks: 1,
+      postFormalPrReviewEnabled: false,
+    });
+    (harness.deps as never as { reviewFindings: unknown }).reviewFindings = {
+      listByThread: vi.fn(() => []),
+    };
+    (
+      harness.deps as never as { threads: { setGithubPr: ReturnType<typeof vi.fn> } }
+    ).threads.setGithubPr = vi.fn();
+    mockExecFileSync.mockImplementation((_command: string, args: string[]) => {
+      if (args[0] === 'rev-parse' && args[1] === '--abbrev-ref') return 'shipcode/issue-42\n';
+      if (args[0] === 'pr' && args[1] === 'list') {
+        return JSON.stringify([
+          { number: 17, url: 'https://github.com/acme/repo/pull/17', isDraft: true },
+        ]);
+      }
+      return '';
+    });
+
+    await harness.handlers.startShipping('thread-1');
+
+    expect(mockGhSubmitPrReview).not.toHaveBeenCalled();
     expect(mockGhUpsertIssueCommentByMarker).toHaveBeenCalledWith(
       17,
       '<!-- shipcode:review-findings -->',
-      expect.stringContaining('CI failed'),
+      expect.stringContaining('No open ShipCode review findings.'),
     );
   });
 

--- a/packages/pipeline/src/pipeline/execution-phases.ts
+++ b/packages/pipeline/src/pipeline/execution-phases.ts
@@ -65,6 +65,7 @@ export {
   probeWorktreeChanges,
   resolveWorktreeDiffBase,
 } from './execution-phase-utils';
+export { resolveFormalPrReviewEvent } from './execution-shipping-phases';
 
 import { extractQaFlowResults } from './qa-result-parser';
 import { buildVerificationFindingInputs, formatOpenFindingsForPrompt } from './review-findings';

--- a/packages/pipeline/src/pipeline/execution-shipping-phases.ts
+++ b/packages/pipeline/src/pipeline/execution-shipping-phases.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from 'node:child_process';
-import { buildPRBody, GhCli } from '@shipcode/agents';
+import { buildPRBody, GhCli, type PrReviewEvent } from '@shipcode/agents';
 import {
   clampError,
   type GitHubPrCheckSummary,
@@ -15,6 +15,18 @@ import {
 } from './review-findings';
 import type { PhaseOutcome, PipelineHelperEnv } from './shared';
 
+export function resolveFormalPrReviewEvent(
+  decision: 'approve' | 'request_changes' | 'reject' | null,
+  findings: Array<{ status: string; severity: string }>,
+): PrReviewEvent {
+  if (decision === 'request_changes' || decision === 'reject') return 'request-changes';
+  const hasOpenSevereFinding = findings.some(
+    (finding) =>
+      finding.status === 'open' && ['critical', 'major', 'blocker'].includes(finding.severity),
+  );
+  return hasOpenSevereFinding ? 'request-changes' : 'approve';
+}
+
 export function createShippingPhaseHandlers({ deps, contextHelpers, runtime }: PipelineHelperEnv) {
   const { activePipelines } = contextHelpers;
   const { emitPhase, formatStabilizationFeedback } = runtime;
@@ -22,17 +34,28 @@ export function createShippingPhaseHandlers({ deps, contextHelpers, runtime }: P
   async function publishReviewFindingsComment(
     context: NonNullable<ReturnType<typeof activePipelines.get>>,
     prNumber: number,
+    decision: 'approve' | 'request_changes' | 'reject' | null,
   ): Promise<void> {
     if (!deps.reviewFindings) return;
 
     const findings = deps.reviewFindings.listByThread(context.threadId, { includeClosed: true });
     try {
       const ghCli = new GhCli(context.worktreePath ?? context.projectPath);
-      await ghCli.upsertIssueCommentByMarker(
-        prNumber,
-        REVIEW_FINDINGS_PR_COMMENT_MARKER,
-        formatReviewFindingsPrComment(findings),
-      );
+      const body = formatReviewFindingsPrComment(findings);
+      if (deps.settings.get().postFormalPrReviewEnabled) {
+        const result = await ghCli.submitPrReview(
+          prNumber,
+          resolveFormalPrReviewEvent(decision, findings),
+          body,
+        );
+        if (result.downgradedForSelfReview) {
+          console.info(
+            `[pipeline] Submitted PR #${prNumber} review as a comment because ShipCode authored the PR.`,
+          );
+        }
+      } else {
+        await ghCli.upsertIssueCommentByMarker(prNumber, REVIEW_FINDINGS_PR_COMMENT_MARKER, body);
+      }
     } catch (error) {
       console.warn(
         `[pipeline] Failed to publish review findings to PR #${prNumber}: ${clampError(error)}`,
@@ -252,7 +275,7 @@ export function createShippingPhaseHandlers({ deps, contextHelpers, runtime }: P
           }
         }
 
-        await publishReviewFindingsComment(context, prNumber);
+        await publishReviewFindingsComment(context, prNumber, reviews[0]?.decision ?? null);
 
         if (created) {
           try {

--- a/packages/shared/src/constants.ts
+++ b/packages/shared/src/constants.ts
@@ -109,6 +109,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
   pipelineSpeedProfile: 'smart_fast',
   requireApproval: false,
   postPlanCommentsEnabled: true,
+  postFormalPrReviewEnabled: true,
   plannerReasoningEffort: 'low',
   reviewerReasoningEffort: 'high',
   executorReasoningEffort: 'medium',

--- a/packages/shared/src/types/settings.ts
+++ b/packages/shared/src/types/settings.ts
@@ -97,6 +97,9 @@ export interface AppSettings {
   // whenever a plan is approved (autonomous or manual). When false, plan comments
   // are suppressed; task-graph and review comments are unaffected.
   postPlanCommentsEnabled: boolean;
+  // When true (default), ShipCode submits review findings through GitHub's
+  // native PR review surface. When false, it keeps the comment-only behavior.
+  postFormalPrReviewEnabled: boolean;
   // Per-phase reasoning effort. Applied as:
   //   Claude: mapped to a supported thinking-token budget
   //   Codex:  mapped to supported low|medium|high levels


### PR DESCRIPTION
## Summary

- submit ShipCode findings through GitHub's native PR review surface by default
- map clean reviews to approval and open critical, major, or blocker findings to requested changes
- downgrade approve/request-changes to a comment when the authenticated ShipCode identity authored the PR
- skip identical reviews already submitted for the same head commit
- add a persisted, default-on desktop setting; disabling it preserves comment-only behavior

## Impact

GitHub's Reviews panel and `reviewDecision` can now reflect ShipCode's verdict when a distinct reviewer identity is used. Because ShipCode commonly authors its own PRs, those runs safely fall back to a native comment review instead of failing shipping.

Review bodies are piped through stdin, never argv. Publishing remains best-effort and cannot fail the shipping phase.

## Verification

- focused tests: agents 83; pipeline 51 passed + 2 skipped; DB 38; desktop renderer 7
- focused coverage: `gh-cli.ts` 99.48% statements, 93.75% branches, 100% functions and lines; settings query 89.25% statements / 91.15% branches; shipping phases 55.08% statements / 48.64% branches
- `bun run verify:affected`: all affected builds and typechecks passed; desktop 1,528; agents 1,095 + 1 skipped; DB 531; pipeline 572 + 7 skipped; shared 431 tests passed
- `git diff --check`

No required checks were skipped and there are no known blockers.

Closes #332


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Pipeline setting to enable or disable formal GitHub pull request reviews.
  * Review findings can now be posted as GitHub approvals, change requests, or comments based on results.
  * Duplicate reviews are skipped, and self-authored pull requests receive comment-only reviews.

* **Bug Fixes**
  * Settings now correctly persist and restore the formal review preference.

* **Tests**
  * Added coverage for review event selection, duplicate detection, self-review handling, and disabled formal reviews.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->