### PR TITLE
fix(health): preserve deprecated OpenRouter status

### DIFF
--- a/apps/desktop/src/renderer/components/settings-panel/IntegrationsSettingsSection.callbacks.test.tsx
+++ b/apps/desktop/src/renderer/components/settings-panel/IntegrationsSettingsSection.callbacks.test.tsx
@@ -207,6 +207,33 @@ afterEach(() => {
 });
 
 describe('IntegrationsSettingsSection callback coverage', () => {
+  it('shows deprecated OpenRouter models as a distinct warning with replacement guidance', () => {
+    render(
+      <IntegrationsSettingsSection
+        integrationStatus={{
+          ...status,
+          openrouter: {
+            ...status.openrouter,
+            authStatus: 'model_deprecated',
+            message: "OpenRouter model 'retired/model' is not available",
+          },
+        }}
+        integrationsFetching={false}
+        settings={DEFAULT_SETTINGS}
+        onUpdate={vi.fn()}
+        onRefetch={vi.fn()}
+        onTestChat={vi.fn(async (provider: 'discord' | 'telegram') => `${provider} ok`)}
+      />,
+    );
+
+    expect(screen.getByText('Model deprecated')).toHaveClass('text-amber-300');
+    expect(
+      screen.getByText(
+        'Model deprecated — select a replacement in Settings → Pipeline → Models.',
+      ),
+    ).toBeInTheDocument();
+  });
+
   it('renders all integration status variants and forwards opener select changes', () => {
     const onUpdate = vi.fn();
 

--- a/apps/desktop/src/renderer/components/settings-panel/IntegrationsSettingsSection.callbacks.test.tsx
+++ b/apps/desktop/src/renderer/components/settings-panel/IntegrationsSettingsSection.callbacks.test.tsx
@@ -228,9 +228,7 @@ describe('IntegrationsSettingsSection callback coverage', () => {
 
     expect(screen.getByText('Model deprecated')).toHaveClass('text-amber-300');
     expect(
-      screen.getByText(
-        'Model deprecated — select a replacement in Settings → Pipeline → Models.',
-      ),
+      screen.getByText('Model deprecated — select a replacement in Settings → Pipeline → Models.'),
     ).toBeInTheDocument();
   });
 

--- a/apps/desktop/src/renderer/components/settings-panel/IntegrationsSettingsSection.tsx
+++ b/apps/desktop/src/renderer/components/settings-panel/IntegrationsSettingsSection.tsx
@@ -2,6 +2,8 @@ import type {
   AppSettings,
   DesktopAppHealth,
   IntegrationStatus,
+  OpenRouterAuthStatus,
+  OpenRouterHealth,
   ProjectOpenTarget,
 } from '@shipcode/shared';
 import { SettingsSection } from '@shipcode/ui';
@@ -79,6 +81,56 @@ function StatusPill({
     >
       {children}
     </span>
+  );
+}
+
+function OpenRouterAuthHealthCard({ health }: { health: OpenRouterHealth }) {
+  const presentation = (() => {
+    switch (health.authStatus) {
+      case 'valid':
+        return { label: 'valid', tone: 'success', action: null } as const;
+      case 'model_deprecated':
+        return {
+          label: 'Model deprecated',
+          tone: 'warning',
+          action: 'Model deprecated — select a replacement in Settings → Pipeline → Models.',
+        } as const;
+      case 'missing_key':
+      case 'invalid_key':
+      case 'unreachable':
+        return { label: health.authStatus, tone: 'warning', action: null } as const;
+      default: {
+        const exhaustiveStatus: never = health.authStatus satisfies OpenRouterAuthStatus;
+        return exhaustiveStatus;
+      }
+    }
+  })();
+
+  return (
+    <div className="rounded-md border border-border bg-secondary/40 p-3 text-[12px] text-secondary">
+      <div className="mb-2 flex flex-wrap items-start justify-between gap-2">
+        <span className="text-[13px] font-medium text-primary">OpenRouter</span>
+        <div className="ml-auto flex flex-wrap justify-end gap-2">
+          <StatusPill tone={health.keyPresent ? 'success' : 'warning'}>
+            {health.keyPresent ? 'OPENROUTER_API_KEY detected' : 'OPENROUTER_API_KEY missing'}
+          </StatusPill>
+          <StatusPill tone={presentation.tone}>{presentation.label}</StatusPill>
+        </div>
+      </div>
+      <div className="space-y-1">
+        <div>
+          ShipCode currently reads <code>OPENROUTER_API_KEY</code> from the environment exposed to
+          the desktop app.
+        </div>
+        {health.label ? (
+          <div>
+            Key label: <code>{health.label}</code>
+          </div>
+        ) : null}
+        {presentation.action ? <div className="text-amber-300">{presentation.action}</div> : null}
+        {health.message ? <div className="text-amber-300">{health.message}</div> : null}
+      </div>
+    </div>
   );
 }
 
@@ -370,41 +422,7 @@ function useIntegrationsSettingsSectionView({
 
           <TabsContent value="api-keys" className="mt-0">
             <SettingsSection title="API Keys">
-              <div className="rounded-md border border-border bg-secondary/40 p-3 text-[12px] text-secondary">
-                <div className="mb-2 flex flex-wrap items-start justify-between gap-2">
-                  <span className="text-[13px] font-medium text-primary">OpenRouter</span>
-                  <div className="ml-auto flex flex-wrap justify-end gap-2">
-                    <StatusPill
-                      tone={integrationStatus.openrouter.keyPresent ? 'success' : 'warning'}
-                    >
-                      {integrationStatus.openrouter.keyPresent
-                        ? 'OPENROUTER_API_KEY detected'
-                        : 'OPENROUTER_API_KEY missing'}
-                    </StatusPill>
-                    <StatusPill
-                      tone={
-                        integrationStatus.openrouter.authStatus === 'valid' ? 'success' : 'warning'
-                      }
-                    >
-                      {integrationStatus.openrouter.authStatus}
-                    </StatusPill>
-                  </div>
-                </div>
-                <div className="space-y-1">
-                  <div>
-                    ShipCode currently reads <code>OPENROUTER_API_KEY</code> from the environment
-                    exposed to the desktop app.
-                  </div>
-                  {integrationStatus.openrouter.label ? (
-                    <div>
-                      Key label: <code>{integrationStatus.openrouter.label}</code>
-                    </div>
-                  ) : null}
-                  {integrationStatus.openrouter.message ? (
-                    <div className="text-amber-300">{integrationStatus.openrouter.message}</div>
-                  ) : null}
-                </div>
-              </div>
+              <OpenRouterAuthHealthCard health={integrationStatus.openrouter} />
             </SettingsSection>
 
             <SettingsSection title="Chat Providers">

--- a/packages/agents/src/health-check.ts
+++ b/packages/agents/src/health-check.ts
@@ -14,6 +14,7 @@ import type {
   CliProviderUsageStatus,
   GhAuthStatus,
   IntegrationStatus,
+  OpenRouterAuthStatus,
   OpenRouterHealth,
   OpenRouterModelCheck,
   OpenRouterModelValidation,
@@ -699,7 +700,7 @@ export async function checkGrokAuth(): Promise<boolean> {
   return fileExists(grokAuthPath);
 }
 
-export type OpenRouterAuthStatus =
+export type OpenRouterAuthCheckResult =
   | { ok: true; label?: string }
   | {
       ok: false;
@@ -720,7 +721,7 @@ export type OpenRouterAuthStatus =
 export async function checkOpenRouterAuth(
   apiKey: string | undefined,
   pinnedModel?: string | null,
-): Promise<OpenRouterAuthStatus> {
+): Promise<OpenRouterAuthCheckResult> {
   if (!apiKey) {
     return { ok: false, reason: 'missing_key', message: 'OPENROUTER_API_KEY is not set' };
   }
@@ -796,6 +797,25 @@ export async function checkOpenRouterAuth(
   }
 
   return { ok: true, label };
+}
+
+function openRouterAuthStatusFromFailure(
+  result: Exclude<OpenRouterAuthCheckResult, { ok: true }>,
+): OpenRouterAuthStatus {
+  switch (result.reason) {
+    case 'missing_key':
+      return 'missing_key';
+    case 'invalid_key':
+      return 'invalid_key';
+    case 'unreachable':
+      return 'unreachable';
+    case 'model_deprecated':
+      return 'model_deprecated';
+    default: {
+      const exhaustiveReason: never = result.reason;
+      return exhaustiveReason;
+    }
+  }
 }
 
 async function fetchOpenRouterCatalog(apiKey: string): Promise<Set<string> | null> {
@@ -880,11 +900,10 @@ export async function checkOpenRouterHealth(settings: AppSettings): Promise<Open
 
   const auth = await checkOpenRouterAuth(apiKey);
   if (!auth.ok) {
-    const authStatus = auth.reason === 'invalid_key' ? 'invalid_key' : 'unreachable';
     return {
       enabled: true,
       keyPresent: true,
-      authStatus,
+      authStatus: openRouterAuthStatusFromFailure(auth),
       message: auth.message,
       label: null,
       modelChecks: buildOpenRouterModelChecks(settings, null, auth.message),

--- a/packages/agents/src/index.ts
+++ b/packages/agents/src/index.ts
@@ -62,7 +62,7 @@ export {
   normalizeStatusOption,
   validateProjectStatusField,
 } from './github/project-status';
-export type { CacheOptions, OpenRouterAuthStatus } from './health-check';
+export type { CacheOptions, OpenRouterAuthCheckResult } from './health-check';
 export {
   checkClaudeAuth,
   checkClaudeModelCapabilities,

--- a/packages/shared/src/types/health.ts
+++ b/packages/shared/src/types/health.ts
@@ -117,7 +117,12 @@ export interface SystemHealth {
   gh: CliHealth;
 }
 
-export type OpenRouterAuthStatus = 'missing_key' | 'valid' | 'invalid_key' | 'unreachable';
+export type OpenRouterAuthStatus =
+  | 'missing_key'
+  | 'valid'
+  | 'invalid_key'
+  | 'unreachable'
+  | 'model_deprecated';
 
 export type OpenRouterModelStatus = 'not_configured' | 'valid' | 'invalid' | 'unverified';
 


### PR DESCRIPTION
## Summary

- rename the agents-package auth result to `OpenRouterAuthCheckResult`, removing its collision with the shared status type
- preserve every OpenRouter auth failure through an exhaustive mapper, including `model_deprecated`
- render deprecated models as a distinct warning with replacement guidance in Settings
- add focused renderer coverage for the deprecated-model presentation

## Verification

Passed locally:

- `bunx @biomejs/biome@2.4.16 check packages/shared/src/types/health.ts packages/agents/src/health-check.ts packages/agents/src/index.ts apps/desktop/src/renderer/components/settings-panel/IntegrationsSettingsSection.tsx apps/desktop/src/renderer/components/settings-panel/IntegrationsSettingsSection.callbacks.test.tsx --assist-enabled=false --files-ignore-unknown=true`
- `git diff --check`

Passed in PR CI:

- affected tests
- typecheck
- build
- lint
- design-system validation
- web smoke
- React Doctor (97/100, 0 errors)
- trust and secret scans
- Socket security checks
- CodeRabbit review

Not run locally under the repository MacBook verification constraint. Coverage, desktop E2E, and the separate web lint/typecheck job were skipped by affected-scope CI.

## Risk

Low. The change is limited to the OpenRouter health contract and settings presentation. Existing auth states retain their previous tone and labels.

Closes #306
