### PR TITLE
fix(models): preflight CLI model servability

### DIFF
--- a/apps/desktop/src/main/ipc/helpers.test.ts
+++ b/apps/desktop/src/main/ipc/helpers.test.ts
@@ -371,9 +371,7 @@ describe('phase model helpers', () => {
         executorReasoningEffort: 'high',
         verifierReasoningEffort: 'high',
       }),
-    ).rejects.toThrow(
-      'Reviewer: Codex CLI codex-cli 1.0.3 cannot confirm it serves gpt-5.2',
-    );
+    ).rejects.toThrow('Reviewer: Codex CLI codex-cli 1.0.3 cannot confirm it serves gpt-5.2');
   });
 
   it('validates PRD rewrite CLI model selections', async () => {

--- a/apps/desktop/src/main/ipc/helpers.test.ts
+++ b/apps/desktop/src/main/ipc/helpers.test.ts
@@ -20,6 +20,7 @@ import type { Queries } from './types';
 
 const {
   checkCliModelCapabilitiesMock,
+  checkSystemHealthMock,
   ghCliGetPullRequestFeedbackMock,
   ghCliSetIssueLabelPresenceMock,
   ghCliInstances,
@@ -28,6 +29,7 @@ const {
   streamParserFeedMock,
 } = vi.hoisted(() => ({
   checkCliModelCapabilitiesMock: vi.fn(),
+  checkSystemHealthMock: vi.fn(),
   ghCliGetPullRequestFeedbackMock: vi.fn(),
   ghCliSetIssueLabelPresenceMock: vi.fn(async () => undefined),
   ghCliInstances: [] as Array<{
@@ -56,6 +58,7 @@ vi.mock('@shipcode/agents', () => {
   };
   return {
     checkCliModelCapabilities: checkCliModelCapabilitiesMock,
+    checkSystemHealth: checkSystemHealthMock,
     DEFAULT_SKILLS: {
       'plan-generation': defaultSkill,
       'adversarial-review': defaultSkill,
@@ -261,6 +264,13 @@ describe('phase model helpers', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     checkCliModelCapabilitiesMock.mockResolvedValue(makeCapabilities());
+    checkSystemHealthMock.mockResolvedValue({
+      claude: { version: '1.2.3' },
+      codex: { version: 'codex-cli 1.0.3' },
+      gemini: { version: '2.0.0' },
+      cursor: { version: '3.0.0' },
+      grok: { version: '4.0.0' },
+    });
   });
 
   it('resolves project and issue phase model providers, model ids, and reasoning effort', () => {
@@ -331,7 +341,39 @@ describe('phase model helpers', () => {
         executorReasoningEffort: 'high',
         verifierReasoningEffort: 'high',
       }),
-    ).rejects.toThrow('Planner: missing-claude-model is not reported');
+    ).rejects.toThrow(
+      'Planner: Claude CLI 1.2.3 cannot serve missing-claude-model. missing-claude-model is not reported',
+    );
+  });
+
+  it('fails closed when Codex cannot return its authoritative model catalog', async () => {
+    checkCliModelCapabilitiesMock.mockResolvedValueOnce({
+      ...makeCapabilities(),
+      codex: {
+        ...makeCapabilities().codex,
+        source: 'fallback',
+        error: 'Codex model catalog unavailable: unknown command debug models',
+      },
+    });
+
+    await expect(
+      assertCliPhaseModelsSupported({
+        plannerModel: 'claude',
+        reviewerModel: 'codex',
+        executorModel: 'codex',
+        verifierModel: 'codex',
+        plannerModelId: 'claude-sonnet-4-5',
+        reviewerModelId: 'gpt-5.2',
+        executorModelId: 'gpt-5.2',
+        verifierModelId: 'gpt-5.2',
+        plannerReasoningEffort: 'medium',
+        reviewerReasoningEffort: 'high',
+        executorReasoningEffort: 'high',
+        verifierReasoningEffort: 'high',
+      }),
+    ).rejects.toThrow(
+      'Reviewer: Codex CLI codex-cli 1.0.3 cannot confirm it serves gpt-5.2',
+    );
   });
 
   it('validates PRD rewrite CLI model selections', async () => {

--- a/apps/desktop/src/main/ipc/helpers.ts
+++ b/apps/desktop/src/main/ipc/helpers.ts
@@ -149,7 +149,7 @@ function assertCliSelectionSupported(
   // Codex publishes an authoritative local catalog. Falling back to ShipCode's
   // curated list when that command is missing or fails must not be treated as
   // proof that a stale CLI can serve a newly curated model.
-  if (provider === 'codex' && providerCapabilities.source !== 'catalog') {
+  if (provider === 'codex' && modelId && providerCapabilities.source !== 'catalog') {
     throw new Error(
       `${label}: ${CLI_PROVIDER_LABELS.codex}${versionLabel} cannot confirm it serves ${modelLabel}. ${providerCapabilities.error ?? 'The installed CLI did not return a model catalog.'}`,
     );

--- a/apps/desktop/src/main/ipc/helpers.ts
+++ b/apps/desktop/src/main/ipc/helpers.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import {
   checkCliModelCapabilities,
+  checkSystemHealth,
   DEFAULT_SKILLS,
   GhCli,
   inspectProjectSetup,
@@ -15,6 +16,8 @@ import {
 import type { ShipCodePlan } from '@shipcode/shared';
 import {
   assessCliSelectionAvailabilityFromCapabilities,
+  CLI_PROVIDER_LABELS,
+  type CliModelCapabilities,
   clampError,
   DEFAULT_SETTINGS,
   type ExecutorModel,
@@ -23,6 +26,7 @@ import {
   ISSUE_PIPELINE_STATUS,
   isPipelineStateLabel,
   type PipelinePhase,
+  type PhaseCliProvider,
   parseGithubProjectUrl,
   pipelineLabelForStatus,
   type ReasoningEffort,
@@ -33,6 +37,7 @@ import {
   resolvePhaseModelId,
   resolvePhaseModelIdForIssue,
   SHIPCODE_CI_BLOCKED_LABEL,
+  type SystemHealth,
 } from '@shipcode/shared';
 import type { BrowserWindow } from 'electron';
 import type { ChatNotificationService } from '../chat-notification-service';
@@ -128,8 +133,46 @@ export function resolveIssuePhaseModels(
 
 type PhaseModels = ReturnType<typeof resolveProjectPhaseModels>;
 
+function assertCliSelectionSupported(
+  capabilities: Record<PhaseCliProvider, CliModelCapabilities>,
+  systemHealth: SystemHealth,
+  label: string,
+  provider: PhaseCliProvider,
+  modelId: string | null,
+  effort: ReasoningEffort,
+): void {
+  const providerCapabilities = capabilities[provider];
+  const installedVersion = systemHealth[provider]?.version;
+  const versionLabel = installedVersion ? ` ${installedVersion}` : '';
+  const modelLabel = modelId ?? 'the configured default model';
+
+  // Codex publishes an authoritative local catalog. Falling back to ShipCode's
+  // curated list when that command is missing or fails must not be treated as
+  // proof that a stale CLI can serve a newly curated model.
+  if (provider === 'codex' && providerCapabilities.source !== 'catalog') {
+    throw new Error(
+      `${label}: ${CLI_PROVIDER_LABELS.codex}${versionLabel} cannot confirm it serves ${modelLabel}. ${providerCapabilities.error ?? 'The installed CLI did not return a model catalog.'}`,
+    );
+  }
+
+  const selection = assessCliSelectionAvailabilityFromCapabilities(
+    capabilities,
+    provider,
+    modelId,
+    effort,
+  );
+  if (!selection.available) {
+    throw new Error(
+      `${label}: ${CLI_PROVIDER_LABELS[provider]}${versionLabel} cannot serve ${modelLabel}. ${selection.message}`,
+    );
+  }
+}
+
 export async function assertCliPhaseModelsSupported(phaseModels: PhaseModels): Promise<void> {
-  const capabilities = await checkCliModelCapabilities();
+  const [capabilities, systemHealth] = await Promise.all([
+    checkCliModelCapabilities(),
+    checkSystemHealth(),
+  ]);
   const phases = [
     {
       label: 'Planner',
@@ -165,13 +208,14 @@ export async function assertCliPhaseModelsSupported(phaseModels: PhaseModels): P
   for (const phase of phases) {
     const cliProvider = phase.provider;
     if (cliProvider === 'openrouter') continue;
-    const selection = assessCliSelectionAvailabilityFromCapabilities(
+    assertCliSelectionSupported(
       capabilities,
+      systemHealth,
+      phase.label,
       cliProvider,
       phase.modelId,
       phase.effort,
     );
-    if (!selection.available) throw new Error(`${phase.label}: ${selection.message}`);
   }
 }
 
@@ -180,16 +224,18 @@ export async function assertPrdRewriteModelSupported(
   modelId: string | null,
   effort: ReasoningEffort,
 ): Promise<void> {
-  const capabilities = await checkCliModelCapabilities();
-  const selection = assessCliSelectionAvailabilityFromCapabilities(
+  const [capabilities, systemHealth] = await Promise.all([
+    checkCliModelCapabilities(),
+    checkSystemHealth(),
+  ]);
+  assertCliSelectionSupported(
     capabilities,
+    systemHealth,
+    'PRD rewrite',
     cli,
     modelId,
     effort ?? DEFAULT_SETTINGS.prdRewriteReasoningEffort,
   );
-  if (!selection.available) {
-    throw new Error(selection.message ?? `${cli} model selection is unavailable`);
-  }
 }
 
 export function tryParsePlan(rawOutput: string): ShipCodePlan | null {

--- a/apps/desktop/src/main/ipc/register-automation-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/register-automation-handlers.test.ts
@@ -4,6 +4,29 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { AutomationSchedulerLike } from '../automation-scheduler';
 import { registerAutomationHandlers } from './register-automation-handlers';
 
+const { assertCliPhaseModelsSupportedMock, resolveProjectPhaseModelsMock } = vi.hoisted(() => ({
+  assertCliPhaseModelsSupportedMock: vi.fn(async () => undefined),
+  resolveProjectPhaseModelsMock: vi.fn(() => ({
+    plannerModel: 'claude',
+    reviewerModel: 'claude',
+    executorModel: 'codex',
+    verifierModel: 'codex',
+    plannerModelId: 'claude-sonnet-4-6',
+    reviewerModelId: 'claude-sonnet-4-6',
+    executorModelId: 'gpt-5.5',
+    verifierModelId: 'gpt-5.5',
+    plannerReasoningEffort: 'high',
+    reviewerReasoningEffort: 'high',
+    executorReasoningEffort: 'high',
+    verifierReasoningEffort: 'high',
+  })),
+}));
+
+vi.mock('./helpers', () => ({
+  assertCliPhaseModelsSupported: assertCliPhaseModelsSupportedMock,
+  resolveProjectPhaseModels: resolveProjectPhaseModelsMock,
+}));
+
 vi.mock('../logger.service', () => ({
   default: {
     error: vi.fn(),
@@ -58,6 +81,14 @@ describe('registerAutomationHandlers', () => {
     listByAutomationId: vi.fn(),
   };
 
+  const projects = {
+    getById: vi.fn(),
+  };
+
+  const settings = {
+    get: vi.fn(),
+  };
+
   const automationScheduler: AutomationSchedulerLike = {
     start: vi.fn(),
     stop: vi.fn(),
@@ -75,10 +106,14 @@ describe('registerAutomationHandlers', () => {
   beforeEach(() => {
     handlers.clear();
     vi.clearAllMocks();
+    automations.getById.mockReturnValue(makeAutomation());
+    projects.getById.mockImplementation((id: string) => ({ id, name: id }));
+    settings.get.mockReturnValue({});
+    assertCliPhaseModelsSupportedMock.mockResolvedValue(undefined);
     registerAutomationHandlers(
       {
         ipcMain,
-        queries: { automations, threads },
+        queries: { automations, threads, projects, settings },
       } as never,
       automationScheduler,
     );
@@ -205,5 +240,87 @@ describe('registerAutomationHandlers', () => {
     ).rejects.toThrow();
     expect(automations.create).not.toHaveBeenCalled();
     expect(automations.update).not.toHaveBeenCalled();
+  });
+
+  it('validates normalized model selections before creating or updating automations', async () => {
+    const automation = makeAutomation({
+      executorProvider: 'codex',
+      executorModelId: 'gpt-5.6-sol',
+    });
+    automations.create.mockReturnValue(automation);
+    automations.update.mockReturnValue(automation);
+
+    await getHandler('automations:create')(null, {
+      projectId: 'project-1',
+      targets: ['project-1', 'project-2'],
+      name: 'Frontier run',
+      prompt: 'Run it',
+      cronExpr: '0 0 * * *',
+      executorProvider: 'codex',
+      executorModelId: 'sol',
+    });
+
+    expect(projects.getById).toHaveBeenCalledTimes(2);
+    expect(assertCliPhaseModelsSupportedMock).toHaveBeenCalledTimes(2);
+    expect(assertCliPhaseModelsSupportedMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({ executorModel: 'codex', executorModelId: 'gpt-5.6-sol' }),
+    );
+    expect(automations.create).toHaveBeenCalledWith(
+      expect.objectContaining({ executorModelId: 'gpt-5.6-sol' }),
+    );
+
+    await getHandler('automations:update')(null, {
+      id: 'auto-1',
+      executorReasoningEffort: 'xhigh',
+    });
+
+    expect(assertCliPhaseModelsSupportedMock).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        executorModel: 'codex',
+        executorModelId: 'gpt-5.5',
+        executorReasoningEffort: 'xhigh',
+      }),
+    );
+    expect(automations.update).toHaveBeenCalled();
+  });
+
+  it('does not persist an automation when model preflight fails', async () => {
+    assertCliPhaseModelsSupportedMock.mockRejectedValueOnce(
+      new Error('Executor: Codex CLI 1.0.3 cannot serve gpt-5.6-sol'),
+    );
+
+    await expect(
+      getHandler('automations:create')(null, {
+        projectId: 'project-1',
+        name: 'Broken run',
+        prompt: 'Run it',
+        cronExpr: '0 0 * * *',
+        executorProvider: 'codex',
+        executorModelId: 'gpt-5.6-sol',
+      }),
+    ).rejects.toThrow('Executor: Codex CLI 1.0.3 cannot serve gpt-5.6-sol');
+
+    expect(automations.create).not.toHaveBeenCalled();
+    expect(automationScheduler.schedule).not.toHaveBeenCalled();
+  });
+
+  it('preflights a disabled automation before enabling it', async () => {
+    automations.getById.mockReturnValue(
+      makeAutomation({
+        enabled: false,
+        executorProvider: 'codex',
+        executorModelId: 'gpt-5.6-sol',
+      }),
+    );
+    assertCliPhaseModelsSupportedMock.mockRejectedValueOnce(
+      new Error('Executor: Codex CLI cannot serve gpt-5.6-sol'),
+    );
+
+    await expect(
+      getHandler('automations:set-enabled')(null, { id: 'auto-1', enabled: true }),
+    ).rejects.toThrow('Executor: Codex CLI cannot serve gpt-5.6-sol');
+
+    expect(automations.setEnabled).not.toHaveBeenCalled();
+    expect(automationScheduler.schedule).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/main/ipc/register-automation-handlers.ts
+++ b/apps/desktop/src/main/ipc/register-automation-handlers.ts
@@ -1,6 +1,9 @@
 import {
+  type AgentType,
+  type Automation,
   type CreateAutomationInput,
   clampError,
+  type ExecutorModel,
   resolveModelAlias,
   type UpdateAutomationInput,
 } from '@shipcode/shared';
@@ -8,12 +11,63 @@ import { Cron } from 'croner';
 import type { IpcMainInvokeEvent } from 'electron';
 import type { AutomationSchedulerLike } from '../automation-scheduler';
 import log from '../logger.service';
+import { assertCliPhaseModelsSupported, resolveProjectPhaseModels } from './helpers';
 import type { IpcHandlerDeps } from './types';
 
 function validateCron(expr: string): void {
   // `paused: true` makes croner validate the expression without scheduling it.
   // Throws on invalid input — caller wraps in try/catch + clampError.
   new Cron(expr, { paused: true });
+}
+
+type AutomationModelSelection = {
+  targets: string[];
+  executorProvider: AgentType | null;
+  executorModelId: string | null;
+  executorReasoningEffort: Automation['executorReasoningEffort'];
+};
+
+function resolveAutomationExecutorProvider(
+  provider: AgentType | null,
+  fallback: ExecutorModel,
+): ExecutorModel {
+  if (provider === null) return fallback;
+  switch (provider) {
+    case 'claude':
+    case 'codex':
+    case 'gemini':
+    case 'cursor':
+    case 'grok':
+    case 'openrouter':
+      return provider;
+    case 'gh':
+    case 'shell':
+      throw new Error(`${provider} cannot be used as an automation executor`);
+  }
+}
+
+async function assertAutomationModelsSupported(
+  selection: AutomationModelSelection,
+  queries: IpcHandlerDeps['queries'],
+): Promise<void> {
+  const settings = queries.settings.get();
+
+  for (const projectId of selection.targets) {
+    const project = queries.projects.getById(projectId);
+    if (!project) throw new Error(`Automation target project ${projectId} not found`);
+
+    const phaseModels = resolveProjectPhaseModels(settings, project);
+    await assertCliPhaseModelsSupported({
+      ...phaseModels,
+      executorModel: resolveAutomationExecutorProvider(
+        selection.executorProvider,
+        phaseModels.executorModel,
+      ),
+      executorModelId: selection.executorModelId ?? phaseModels.executorModelId,
+      executorReasoningEffort:
+        selection.executorReasoningEffort ?? phaseModels.executorReasoningEffort,
+    });
+  }
 }
 
 export function registerAutomationHandlers(
@@ -54,6 +108,15 @@ export function registerAutomationHandlers(
       input.executorModelId == null
         ? input
         : { ...input, executorModelId: resolveModelAlias(input.executorModelId) };
+    await assertAutomationModelsSupported(
+      {
+        targets: normalized.targets ?? [normalized.projectId],
+        executorProvider: normalized.executorProvider ?? null,
+        executorModelId: normalized.executorModelId ?? null,
+        executorReasoningEffort: normalized.executorReasoningEffort ?? null,
+      },
+      queries,
+    );
     const automation = queries.automations.create(normalized);
     automationScheduler.schedule(automation);
     return automation;
@@ -68,6 +131,26 @@ export function registerAutomationHandlers(
         patch.executorModelId == null
           ? patch
           : { ...patch, executorModelId: resolveModelAlias(patch.executorModelId) };
+      const existing = queries.automations.getById(id);
+      if (!existing) throw new Error(`Automation ${id} not found`);
+      await assertAutomationModelsSupported(
+        {
+          targets: normalized.targets ?? existing.targets,
+          executorProvider:
+            normalized.executorProvider === undefined
+              ? existing.executorProvider
+              : normalized.executorProvider,
+          executorModelId:
+            normalized.executorModelId === undefined
+              ? existing.executorModelId
+              : normalized.executorModelId,
+          executorReasoningEffort:
+            normalized.executorReasoningEffort === undefined
+              ? existing.executorReasoningEffort
+              : normalized.executorReasoningEffort,
+        },
+        queries,
+      );
       const automation = queries.automations.update(id, normalized);
       automationScheduler.schedule(automation);
       return automation;
@@ -83,6 +166,19 @@ export function registerAutomationHandlers(
   handleAutomation(
     'automations:set-enabled',
     async (_e, { id, enabled }: { id: string; enabled: boolean }) => {
+      if (enabled) {
+        const existing = queries.automations.getById(id);
+        if (!existing) throw new Error(`Automation ${id} not found`);
+        await assertAutomationModelsSupported(
+          {
+            targets: existing.targets,
+            executorProvider: existing.executorProvider,
+            executorModelId: existing.executorModelId,
+            executorReasoningEffort: existing.executorReasoningEffort,
+          },
+          queries,
+        );
+      }
       const automation = queries.automations.setEnabled(id, enabled);
       if (enabled) {
         automationScheduler.schedule(automation);


### PR DESCRIPTION
## Summary

- fail closed when an explicit Codex model is selected but the installed CLI cannot return its authoritative local model catalog
- include the installed CLI version and selected model in launch and PRD rewrite preflight errors
- validate automation create, update, and enable operations across every target before persisting or scheduling
- preserve CLI-selected defaults and alias normalization so only explicit model selections require catalog confirmation

## Verification

Passed locally:

- `bunx @biomejs/biome@2.4.16 check apps/desktop/src/main/ipc/helpers.ts apps/desktop/src/main/ipc/helpers.test.ts apps/desktop/src/main/ipc/register-automation-handlers.ts apps/desktop/src/main/ipc/register-automation-handlers.test.ts --assist-enabled=false --files-ignore-unknown=true`
- `git diff --check`
- QA diff review: no correctness, security, regression, dead-code, or unrelated-change findings

Passed in PR CI:

- affected tests
- typecheck
- build
- lint
- design-system validation
- web smoke
- trust and secret scans
- Socket security checks
- React Doctor (no React files changed)
- CodeRabbit review

Skipped by affected-scope CI:

- coverage
- desktop E2E
- separate web lint/typecheck lane

## Risk

Low-to-moderate. Explicit Codex selections now fail closed when the installed CLI cannot expose its catalog; transient catalog failures will block saves and launches with an actionable error instead of allowing a scheduled failure. CLI-selected defaults remain valid without catalog confirmation.

Closes #360
