### PR TITLE
fix(pipeline): preserve verification retry evidence

### DIFF
--- a/packages/pipeline/src/pipeline/execution-phases.test.ts
+++ b/packages/pipeline/src/pipeline/execution-phases.test.ts
@@ -883,6 +883,8 @@ describe('execution phase handlers', () => {
   it('feeds structured verification failures back into the next execution prompt', async () => {
     const context = makeContext({ repoPromptMaterials: null, worktreePath: process.cwd() });
     const harness = makeExecutionHarness(context);
+    const testOutput = `test-start-${'t'.repeat(9000)}-test-end`;
+    const runtimeQaOutput = `runtime-start-${'r'.repeat(9000)}-runtime-end`;
     (
       harness.deps as never as { verifications: { getLatest: ReturnType<typeof vi.fn> } }
     ).verifications.getLatest.mockReturnValue({
@@ -892,8 +894,8 @@ describe('execution phase handlers', () => {
         summary: ' Needs   polish ',
         criteriaResults: [{ criterion: ' AC ', passed: false, evidence: ' Missing   proof ' }],
         issues: [{ severity: 'major', description: ' Bad   file ', filePath: 'src/a.ts' }],
-        testOutput: 'PASS unit suite\ncoverage threshold missed',
-        runtimeQaOutput: 'GET /health 500\nserver smoke failed',
+        testOutput,
+        runtimeQaOutput,
       },
     });
 
@@ -904,8 +906,18 @@ describe('execution phase handlers', () => {
     expect(prompt).toContain('<previous_verification_failure>');
     expect(prompt).toContain('- AC: Missing proof');
     expect(prompt).toContain('- [major] src/a.ts: Bad file');
-    expect(prompt).toContain('Prior test output:\nPASS unit suite\ncoverage threshold missed');
-    expect(prompt).toContain('Prior runtime QA output:\nGET /health 500\nserver smoke failed');
+    const persistedTestOutput = prompt.match(
+      /Prior test output:\n([\s\S]*?)\n\nPrior runtime QA output:/,
+    )?.[1];
+    const persistedRuntimeQaOutput = prompt.match(
+      /Prior runtime QA output:\n([\s\S]*?)\n<\/previous_verification_failure>/,
+    )?.[1];
+    expect(persistedTestOutput).toContain('test-start-');
+    expect(persistedTestOutput).toContain('-test-end');
+    expect(persistedTestOutput?.length).toBeLessThanOrEqual(8192);
+    expect(persistedRuntimeQaOutput).toContain('runtime-start-');
+    expect(persistedRuntimeQaOutput).toContain('-runtime-end');
+    expect(persistedRuntimeQaOutput?.length).toBeLessThanOrEqual(8192);
   });
 
   it('loads repo prompt material content when execution context is initialized lazily', async () => {

--- a/packages/pipeline/src/pipeline/execution-phases.test.ts
+++ b/packages/pipeline/src/pipeline/execution-phases.test.ts
@@ -892,6 +892,8 @@ describe('execution phase handlers', () => {
         summary: ' Needs   polish ',
         criteriaResults: [{ criterion: ' AC ', passed: false, evidence: ' Missing   proof ' }],
         issues: [{ severity: 'major', description: ' Bad   file ', filePath: 'src/a.ts' }],
+        testOutput: 'PASS unit suite\ncoverage threshold missed',
+        runtimeQaOutput: 'GET /health 500\nserver smoke failed',
       },
     });
 
@@ -902,6 +904,8 @@ describe('execution phase handlers', () => {
     expect(prompt).toContain('<previous_verification_failure>');
     expect(prompt).toContain('- AC: Missing proof');
     expect(prompt).toContain('- [major] src/a.ts: Bad file');
+    expect(prompt).toContain('Prior test output:\nPASS unit suite\ncoverage threshold missed');
+    expect(prompt).toContain('Prior runtime QA output:\nGET /health 500\nserver smoke failed');
   });
 
   it('loads repo prompt material content when execution context is initialized lazily', async () => {
@@ -1936,6 +1940,45 @@ describe('execution phase handlers', () => {
       andThen: { next: 'execute', plan },
     });
     expect(harness.runtime.runProviderPhase).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists test and runtime QA output with a failed verification retry', async () => {
+    const context = makeContext({ verificationRetries: 0 });
+    const harness = makeExecutionHarness(context);
+    harness.deps.plans.getLatest.mockReturnValue({
+      id: 'plan-record-1',
+      status: 'approved',
+      structured: plan,
+    });
+    vi.mocked(harness.runtime.runProviderPhase).mockResolvedValue({
+      rawOutput: verificationFailed,
+      exitCode: 0,
+    });
+    mockExecFileSync.mockImplementation((_command: string, args: string[]) => {
+      if (args[0] === 'status') return '';
+      if (args[0] === 'rev-parse') return 'head-sha\n';
+      if (args[0] === 'diff') return 'diff --git a/src/a.ts b/src/a.ts\n';
+      return '';
+    });
+
+    await harness.handlers.startVerification('thread-1', {
+      testOutput: 'PASS unit suite',
+      runtimeQaOutput: 'runtime smoke ok',
+    });
+
+    expect(
+      (harness.deps as never as { verifications: { create: ReturnType<typeof vi.fn> } })
+        .verifications.create,
+    ).toHaveBeenCalledWith(
+      'thread-1',
+      'plan-record-1',
+      expect.any(String),
+      expect.objectContaining({
+        result: 'failed',
+        testOutput: 'PASS unit suite',
+        runtimeQaOutput: 'runtime smoke ok',
+      }),
+    );
   });
 
   it('publishes the durable findings summary to a linked PR during shipping', async () => {

--- a/packages/pipeline/src/pipeline/execution-phases.ts
+++ b/packages/pipeline/src/pipeline/execution-phases.ts
@@ -27,6 +27,7 @@ import {
   MAX_TEST_RETRIES,
   MAX_VERIFICATION_RETRIES,
   PIPELINE_PHASE,
+  clampTextBlock,
   parseUnifiedDiff,
   type ShipCodePlan,
   type TaskNodeRecord,
@@ -304,6 +305,14 @@ export function createExecutionPhaseHandlers({ deps, contextHelpers, runtime }: 
 
     if (issues) {
       lines.push('', 'Issues:', issues);
+    }
+
+    if (structured.testOutput) {
+      lines.push('', 'Prior test output:', clampTextBlock(structured.testOutput, 8192));
+    }
+
+    if (structured.runtimeQaOutput) {
+      lines.push('', 'Prior runtime QA output:', clampTextBlock(structured.runtimeQaOutput, 8192));
     }
 
     lines.push('</previous_verification_failure>');
@@ -1603,11 +1612,16 @@ Pass criteria: ALL acceptance criteria passed with no blocker-severity issues.`;
         return { next: 'failed' };
       }
 
+      const persistedVerification = {
+        ...result.data,
+        ...(testOutput ? { testOutput } : {}),
+        ...(runtimeQaOutput ? { runtimeQaOutput } : {}),
+      };
       const verificationRecord = deps.verifications.create(
         threadId,
         latestPlan.id,
         result.raw,
-        result.data,
+        persistedVerification,
       );
       if (context.projectId && deps.reviewFindings) {
         if (result.data.result === 'passed') {

--- a/packages/shared/src/types/verification.ts
+++ b/packages/shared/src/types/verification.ts
@@ -7,6 +7,10 @@ export interface VerificationResult {
   summary: string;
   criteriaResults: CriteriaCheck[];
   issues: VerificationIssue[];
+  /** Pipeline test evidence supplied to the verifier for this attempt. */
+  testOutput?: string;
+  /** Runtime-QA evidence supplied to the verifier for this attempt. */
+  runtimeQaOutput?: string;
 }
 
 export interface CriteriaCheck {


### PR DESCRIPTION
## Summary

- persist the exact test and runtime-QA evidence supplied to each parsed verification
- replay bounded evidence excerpts alongside structured verifier findings on automatic and desktop-resumed execute retries
- add regression coverage for persistence, retry-prompt reconstruction, and the 8 KiB evidence boundaries

## Why

Verification retries rebuilt execution feedback from the persisted structured verifier result. The preceding test and runtime-QA output reached the verifier through typed carry, but was not persisted, so it disappeared before the next execute attempt.

## Verification

Passed locally:

- `bunx @biomejs/biome@2.4.16 check --write --assist-enabled=false --files-ignore-unknown=true packages/shared/src/types/verification.ts packages/pipeline/src/pipeline/execution-phases.ts packages/pipeline/src/pipeline/execution-phases.test.ts`
- `bun run lint`
- `git diff --check`
- correctness/security diff review: approved with no findings

Passed in PR CI on the final head:

- affected tests
- affected typecheck
- affected build, including desktop app code
- lint and design-system validation
- web smoke
- trust and secret scans
- Socket security checks
- React Doctor (no React files changed)

Skipped by affected-scope CI:

- coverage
- desktop E2E
- separate web lint/typecheck lane

## Risk

Low. Evidence is stored in the existing structured verification JSON, so no schema migration is required. Retry prompts clamp test and runtime-QA excerpts to 8 KiB each. Parsed verification events and review-finding generation retain their existing payloads.

Closes #320
