### PR TITLE
fix(pipeline): handle turn events exhaustively

### DIFF
--- a/apps/cli/src/adapters/cli-emitter.test.ts
+++ b/apps/cli/src/adapters/cli-emitter.test.ts
@@ -37,6 +37,12 @@ describe('createCliEmitter', () => {
       reasons: ['clean plan', 'low risk'],
     } as never);
     emitter.emit({ type: 'pipeline:verification-exhausted', retries: 2 } as never);
+    emitter.emit({ type: 'pipeline:turn-started', turnNumber: 2 } as never);
+    emitter.emit({
+      type: 'pipeline:turn-completed',
+      turnNumber: 2,
+      result: 'max_turns_reached',
+    } as never);
 
     expect(logSpy).toHaveBeenCalledWith('[12:34:56] Phase: planning');
     expect(logSpy).toHaveBeenCalledWith(
@@ -49,6 +55,8 @@ describe('createCliEmitter', () => {
       '[12:34:56] Approval gate: approved after approve (clean plan, low risk)',
     );
     expect(logSpy).toHaveBeenCalledWith('[12:34:56] Verification exhausted after 2 retries');
+    expect(logSpy).toHaveBeenCalledWith('[12:34:56] Turn 2 started');
+    expect(logSpy).toHaveBeenCalledWith('[12:34:56] Turn 2 completed: max_turns_reached');
   });
 
   it('prints model routing with optional requested model, tokens, and cost', () => {

--- a/apps/cli/src/adapters/cli-emitter.ts
+++ b/apps/cli/src/adapters/cli-emitter.ts
@@ -35,6 +35,14 @@ export function createCliEmitter(): PipelineEmitter {
         case 'pipeline:verification-exhausted':
           console.log(`[${timestamp}] Verification exhausted after ${event.retries} retries`);
           break;
+        case 'pipeline:turn-started':
+          console.log(`[${timestamp}] Turn ${event.turnNumber} started`);
+          break;
+        case 'pipeline:turn-completed':
+          console.log(
+            `[${timestamp}] Turn ${event.turnNumber} completed: ${sanitizeCliText(event.result)}`,
+          );
+          break;
         case 'pipeline:model-resolved': {
           // Build tokens and cost as independent segments so cost still
           // renders when a provider reports it without token totals.
@@ -84,6 +92,10 @@ export function createCliEmitter(): PipelineEmitter {
         case 'terminal:event':
         case 'pipeline:output':
           break;
+        default: {
+          const _exhaustive: never = event;
+          throw new Error(`CLI emitter: unknown pipeline event ${JSON.stringify(_exhaustive)}`);
+        }
       }
     },
   };

--- a/apps/desktop/src/main/pipeline-bridge.test.ts
+++ b/apps/desktop/src/main/pipeline-bridge.test.ts
@@ -686,6 +686,13 @@ describe('createElectronEmitter event forwarding and terminal bookkeeping', () =
 
     emitter.emit({ type: 'pipeline:start-context', threadId: 'thread-1', source: 'test' } as never);
     emitter.emit({ type: 'pipeline:approval-gate', threadId: 'thread-1' } as never);
+    emitter.emit({ type: 'pipeline:turn-started', threadId: 'thread-1', turnNumber: 2 } as never);
+    emitter.emit({
+      type: 'pipeline:turn-completed',
+      threadId: 'thread-1',
+      turnNumber: 2,
+      result: 'success',
+    } as never);
     emitter.emit({ type: 'skill:fallback', threadId: 'thread-1', skill: 'missing' } as never);
     emitter.emit({ type: 'workflow:warning', threadId: 'thread-1', message: 'warn' } as never);
 
@@ -696,6 +703,14 @@ describe('createElectronEmitter event forwarding and terminal bookkeeping', () =
     expect(mainWindow.webContents.send).toHaveBeenCalledWith(
       'pipeline:approval-gate',
       expect.objectContaining({ type: 'pipeline:approval-gate' }),
+    );
+    expect(logEvent).toHaveBeenCalledWith(
+      'pipeline:turn-started',
+      expect.objectContaining({ turnNumber: 2 }),
+    );
+    expect(logEvent).toHaveBeenCalledWith(
+      'pipeline:turn-completed',
+      expect.objectContaining({ turnNumber: 2, result: 'success' }),
     );
     expect(mainWindow.webContents.send).toHaveBeenCalledWith(
       'skill:fallback',

--- a/apps/desktop/src/main/pipeline-bridge.ts
+++ b/apps/desktop/src/main/pipeline-bridge.ts
@@ -222,6 +222,12 @@ export function createElectronEmitter(
       case 'pipeline:verification-exhausted':
         logEvent('pipeline:verification-exhausted', event);
         return;
+      case 'pipeline:turn-started':
+        logEvent('pipeline:turn-started', event);
+        return;
+      case 'pipeline:turn-completed':
+        logEvent('pipeline:turn-completed', event);
+        return;
       case 'pipeline:model-resolved':
         logEvent('pipeline:model-resolved', event);
         return;
@@ -261,6 +267,12 @@ export function createElectronEmitter(
           kind: event.event.kind,
         });
         return;
+      case 'pipeline:output':
+        return;
+      default: {
+        const _exhaustive: never = event;
+        throw new Error(`Pipeline bridge: unknown pipeline event ${JSON.stringify(_exhaustive)}`);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

- log `pipeline:turn-started` and `pipeline:turn-completed` in the CLI and desktop event adapters
- add `never`-typed default guards so future `PipelineEvent` variants fail exhaustiveness checks instead of silently disappearing
- explicitly preserve raw pipeline output as intentionally unlogged in the desktop event log
- add focused regression coverage for both turn-event paths

## Verification

Passed locally:

- `bunx @biomejs/biome@2.4.16 check --write --assist-enabled=false --files-ignore-unknown=true apps/cli/src/adapters/cli-emitter.ts apps/cli/src/adapters/cli-emitter.test.ts apps/desktop/src/main/pipeline-bridge.ts apps/desktop/src/main/pipeline-bridge.test.ts`
- `git diff --check`
- structured correctness, security, regression, dead-code, and scope review: approved with no findings

Not run locally under the repository MacBook verification constraint:

- `bun run --cwd apps/cli test`
- `bun run --cwd apps/cli coverage`
- `bun run --cwd apps/cli typecheck`
- `bun run --cwd apps/cli build`
- `bun run --cwd apps/desktop test`
- `bun run --cwd apps/desktop coverage`
- `bun run --cwd apps/desktop typecheck`
- `bun run --cwd apps/desktop build`

PR CI is the verification authority for tests, typechecks, builds, and coverage.

Passed in PR CI on the final head:

- affected tests
- affected typecheck
- affected build
- lint and design-system validation
- web smoke
- trust, secret, and Socket security scans
- React checks
- CodeRabbit review

Skipped by affected-scope CI:

- coverage
- desktop E2E
- separate web lint/typecheck lane

## Risk

Low. The change adds observability for events that were already emitted and forwarded, plus compile-time exhaustiveness guards. It does not alter pipeline state or control flow.

Closes #290
