### PR TITLE
fix(shared): bound truncation output

### DIFF
--- a/apps/cli/src/commands/logs.test.ts
+++ b/apps/cli/src/commands/logs.test.ts
@@ -181,7 +181,7 @@ describe('logsCommand', () => {
     expect(writeSpy).toHaveBeenCalledWith('plain stdout\n');
     expect(writeSpy).toHaveBeenCalledWith('[12:00:05] started\n');
     expect(writeSpy).toHaveBeenCalledWith('{"type":"event"}\n');
-    expect(logSpy).toHaveBeenCalledWith(`[12:00:02] Thinking: ${'x'.repeat(120)}...`);
+    expect(logSpy).toHaveBeenCalledWith(`[12:00:02] Thinking: ${'x'.repeat(117)}...`);
     expect(logSpy).toHaveBeenCalledWith('[12:00:03] Tool: bun test — running tests');
     expect(logSpy).toHaveBeenCalledWith('[12:00:04] Tool done: bun test (exit 1)');
     expect(logSpy).toHaveBeenCalledWith('[12:00:07] Error: command failed');

--- a/apps/cli/src/commands/logs.ts
+++ b/apps/cli/src/commands/logs.ts
@@ -1,3 +1,4 @@
+import { truncate } from '@shipcode/shared';
 import { sanitizeCliText } from '../adapters/cli-emitter';
 import { createCliContext } from '../context';
 import { requireOnboarding } from './guard';
@@ -34,7 +35,7 @@ export async function logsCommand(issueNumber: string) {
         process.stdout.write(sanitizeCliText(data.content));
         break;
       case 'thinking':
-        console.log(`[${time}] Thinking: ${sanitizeCliText(data.content).slice(0, 120)}...`);
+        console.log(`[${time}] Thinking: ${truncate(sanitizeCliText(data.content), 120, '...')}`);
         break;
       case 'tool_start':
         console.log(

--- a/apps/desktop/src/main/git-workflows.ts
+++ b/apps/desktop/src/main/git-workflows.ts
@@ -8,7 +8,7 @@ import type {
   ExecutorModel,
   Project,
 } from '@shipcode/shared';
-import { stripAnsi } from '@shipcode/shared';
+import { stripAnsi, truncate } from '@shipcode/shared';
 import log from './logger.service';
 
 interface ActiveWorktreeOwner {
@@ -23,7 +23,7 @@ function summarizeCommitFailure(value: string): string {
       return trimmed ? [trimmed] : [];
     });
   const summary = lines.slice(0, 8).join('\n');
-  return summary.length > 800 ? `${summary.slice(0, 797)}...` : summary;
+  return truncate(summary, 800, '...');
 }
 
 function isLikelyHookFailure(message: string): boolean {

--- a/apps/desktop/src/main/telemetry.test.ts
+++ b/apps/desktop/src/main/telemetry.test.ts
@@ -188,7 +188,7 @@ describe('telemetry', () => {
         extra: {
           terminalOutput: '[redacted]',
           items: expect.arrayContaining([expect.objectContaining({ tokenValue: '[redacted]' })]),
-          longValue: `${'x'.repeat(500)}...`,
+          longValue: `${'x'.repeat(497)}...`,
         },
       }),
     );

--- a/apps/desktop/src/main/telemetry.ts
+++ b/apps/desktop/src/main/telemetry.ts
@@ -1,4 +1,4 @@
-import type { AppSettings, TelemetryStatus } from '@shipcode/shared';
+import { type AppSettings, type TelemetryStatus, truncate } from '@shipcode/shared';
 
 const DISABLED_VALUES = new Set(['0', 'false', 'no', 'off']);
 const DEFAULT_CLOSE_TIMEOUT_MS = 2000;
@@ -109,7 +109,7 @@ function scrubValue(key: string, value: unknown): unknown {
     return '[redacted]';
   }
   if (typeof value === 'string') {
-    return value.length > 500 ? `${value.slice(0, 500)}...` : value;
+    return truncate(value, 500, '...');
   }
   if (!value || typeof value !== 'object' || value instanceof Error) return value;
   if (Array.isArray(value)) return value.slice(0, 20).map((entry) => scrubValue(key, entry));

--- a/apps/desktop/src/renderer/components/issue-detail/RunsTab.tsx
+++ b/apps/desktop/src/renderer/components/issue-detail/RunsTab.tsx
@@ -10,6 +10,7 @@ import {
   formatRelativeTime,
   MODEL_DISPLAY,
   stripAnsi,
+  truncate,
 } from '@shipcode/shared';
 import { PhaseChip } from '@shipcode/ui';
 import { Badge, Button, Skeleton } from '@shipshitdev/ui';
@@ -55,7 +56,7 @@ function summarizeTerminalEvent(record: TerminalEventRecord): string | null {
   if (!rendered) return null;
   const cleaned = stripAnsi(rendered).trim();
   if (!cleaned) return null;
-  return cleaned.length > 220 ? `${cleaned.slice(0, 220)}...` : cleaned;
+  return truncate(cleaned, 220, '...');
 }
 
 function runTotals(entry: PipelineRunTimelineEntry) {

--- a/packages/agents/src/providers/normalizers/claude-normalizer.test.ts
+++ b/packages/agents/src/providers/normalizers/claude-normalizer.test.ts
@@ -76,7 +76,7 @@ describe('ClaudeNormalizer', () => {
       {
         kind: 'tool_start',
         name: 'Bash',
-        summary: `$ ${longCommand.slice(0, 60)}...`,
+        summary: `$ ${longCommand.slice(0, 57)}...`,
         command: longCommand,
       },
       { kind: 'tool_start', name: 'TodoWrite', summary: 'TodoWrite: 3' },

--- a/packages/agents/src/providers/normalizers/claude-normalizer.ts
+++ b/packages/agents/src/providers/normalizers/claude-normalizer.ts
@@ -10,6 +10,7 @@
  * - partial line buffering across PTY chunk boundaries
  */
 
+import { truncate } from '@shipcode/shared';
 import type { TerminalEvent } from '../../terminal-events';
 import { FenceStateMachine } from './fence-suppression';
 import { LineBufferedJsonNormalizer } from './line-buffered-json-normalizer';
@@ -43,7 +44,7 @@ function formatToolCall(name: string, input: Record<string, unknown>): ToolCallR
     case 'Bash': {
       const cmd = String(input.command ?? '');
       return {
-        summary: `$ ${cmd.length > 60 ? `${cmd.slice(0, 60)}...` : cmd}`,
+        summary: `$ ${truncate(cmd, 60, '...')}`,
         command: cmd,
       };
     }

--- a/packages/agents/src/providers/normalizers/codex-normalizer.test.ts
+++ b/packages/agents/src/providers/normalizers/codex-normalizer.test.ts
@@ -65,7 +65,7 @@ describe('CodexNormalizer', () => {
       {
         kind: 'tool_start',
         name: 'Bash',
-        summary: `$ ${longCommand.slice(0, 60)}...`,
+        summary: `$ ${longCommand.slice(0, 57)}...`,
         command: longCommand,
       },
     ]);

--- a/packages/agents/src/providers/normalizers/codex-normalizer.ts
+++ b/packages/agents/src/providers/normalizers/codex-normalizer.ts
@@ -12,6 +12,7 @@
  * - partial line buffering across PTY chunk boundaries
  */
 
+import { truncate } from '@shipcode/shared';
 import type { TerminalEvent } from '../../terminal-events';
 import { stripAnsi, summarizeTerminalText } from '../output-summary';
 import { FenceStateMachine } from './fence-suppression';
@@ -51,7 +52,7 @@ export class CodexNormalizer {
       this.onEvent({
         kind: 'tool_start',
         name: 'Bash',
-        summary: `$ ${cmd.length > 60 ? `${cmd.slice(0, 60)}...` : cmd}`,
+        summary: `$ ${truncate(cmd, 60, '...')}`,
         ...(cmd ? { command: cmd } : {}),
       });
       return;

--- a/packages/agents/src/tools/grep-rg-mock.test.ts
+++ b/packages/agents/src/tools/grep-rg-mock.test.ts
@@ -56,6 +56,7 @@ describe('grepTool rg backend formatting', () => {
     expect(res.ok).toBe(true);
     if (res.ok) {
       expect(res.content).toContain('…');
+      expect(res.content.split('\n')[0]).toHaveLength(500);
       expect(res.content).toContain('[truncated at 200 matches]');
       expect(res.data).toEqual({ matches: 200, truncated: true, backend: 'rg' });
     }

--- a/packages/agents/src/tools/grep.ts
+++ b/packages/agents/src/tools/grep.ts
@@ -7,6 +7,7 @@
 
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
+import { truncate } from '@shipcode/shared';
 import { z } from 'zod';
 import { assertPathInWorktree, PathGuardError } from './path-guard';
 import type { Tool, ToolContext, ToolResult } from './types';
@@ -102,9 +103,7 @@ async function runRipgrep(input: GrepInput, rootAbs: string): Promise<ToolResult
       maxBuffer: 2 * 1024 * 1024,
     });
     const lines = stdout.split('\n').filter(Boolean).slice(0, MAX_MATCHES);
-    const cappedLines = lines.map((line) =>
-      line.length > MAX_LINE_LENGTH ? `${line.slice(0, MAX_LINE_LENGTH)}…` : line,
-    );
+    const cappedLines = lines.map((line) => truncate(line, MAX_LINE_LENGTH));
     const truncated = lines.length >= MAX_MATCHES;
     return {
       ok: true,

--- a/packages/pipeline/src/pipeline/review-findings.ts
+++ b/packages/pipeline/src/pipeline/review-findings.ts
@@ -7,6 +7,7 @@ import type {
   ReviewFindingRecord,
   VerificationResult,
 } from '@shipcode/shared';
+import { truncate } from '@shipcode/shared';
 
 export const REVIEW_FINDINGS_PR_COMMENT_MARKER = '<!-- shipcode:review-findings -->';
 
@@ -15,9 +16,7 @@ function compact(value: string): string {
 }
 
 function truncateCompact(value: string, max = 280): string {
-  const cleaned = compact(value);
-  if (cleaned.length <= max) return cleaned;
-  return `${cleaned.slice(0, max - 1)}…`;
+  return truncate(compact(value), max);
 }
 
 function fingerprint(parts: Array<string | number | null | undefined>): string {

--- a/packages/shared/src/errors.ts
+++ b/packages/shared/src/errors.ts
@@ -1,3 +1,5 @@
+import { truncate } from './truncate';
+
 /**
  * Clamp an error-like value to a single-line string bounded in length so
  * multi-KB stderr, stack traces, or echoed prompts never leak into the
@@ -13,8 +15,7 @@ export function clampError(raw: unknown, max = 280): string {
   else message = 'Unknown error';
 
   const firstLine = message.split('\n')[0];
-  if (firstLine.length <= max) return firstLine;
-  return `${firstLine.slice(0, max - 1)}…`;
+  return truncate(firstLine, max);
 }
 
 /**

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -36,6 +36,7 @@ export * from './staleness';
 export * from './task-graph';
 export * from './tokens';
 export * from './triage-rules';
+export * from './truncate';
 export * from './types';
 export * from './unified-diff';
 // worktree-path uses node:path — import directly from '@shipcode/shared/worktree-path'

--- a/packages/shared/src/truncate.test.ts
+++ b/packages/shared/src/truncate.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { truncate } from './truncate';
+
+describe('truncate', () => {
+  it.each([
+    { value: 'short', maxLength: 5, suffix: undefined, expected: 'short' },
+    { value: 'exact', maxLength: 5, suffix: undefined, expected: 'exact' },
+    { value: 'overlong', maxLength: 5, suffix: undefined, expected: 'over…' },
+    { value: 'overlong', maxLength: 6, suffix: '...', expected: 'ove...' },
+    { value: 'overlong', maxLength: 2, suffix: '...', expected: '..' },
+    { value: 'overlong', maxLength: 0, suffix: undefined, expected: '' },
+  ])('truncates $value to at most $maxLength characters', (testCase) => {
+    const result = truncate(testCase.value, testCase.maxLength, testCase.suffix);
+
+    expect(result).toBe(testCase.expected);
+    expect(result.length).toBeLessThanOrEqual(testCase.maxLength);
+  });
+
+  it.each([
+    -1,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+  ])('rejects invalid maximum length %s', (maxLength) => {
+    expect(() => truncate('value', maxLength)).toThrow(RangeError);
+  });
+});

--- a/packages/shared/src/truncate.ts
+++ b/packages/shared/src/truncate.ts
@@ -1,0 +1,11 @@
+/**
+ * Truncate a string to a maximum total length, including the suffix.
+ */
+export function truncate(value: string, maxLength: number, suffix = '…'): string {
+  if (!Number.isInteger(maxLength) || maxLength < 0) {
+    throw new RangeError('maxLength must be a non-negative integer');
+  }
+  if (value.length <= maxLength) return value;
+  if (suffix.length >= maxLength) return suffix.slice(0, maxLength);
+  return `${value.slice(0, maxLength - suffix.length)}${suffix}`;
+}


### PR DESCRIPTION
## Summary

- add a shared `truncate(value, maxLength, suffix)` utility with an explicit maximum-total-length contract
- migrate nine equivalent prefix-plus-ellipsis call sites across shared, agents, pipeline, CLI, and desktop
- fix telemetry, provider command summaries, CLI thinking previews, grep results, and run summaries that previously exceeded their configured content bounds
- add focused boundary coverage and update affected expectations

## Verification

Passed locally:

- `bunx @biomejs/biome@2.4.16 check --write --assist-enabled=false --files-ignore-unknown=true <17 changed files>`
- `bun run lint`
- `git diff --check`
- structured correctness, security, regression, dead-code, and scope review: approved with no findings

Passed in PR CI on the final head:

- affected tests
- affected typecheck
- affected build
- lint and design-system validation
- web smoke
- trust and secret scans
- Socket security checks
- React Doctor (100/100, 0 errors)
- CodeRabbit review

Not run locally under the repository MacBook verification constraint. Coverage, desktop E2E, and the separate E2E lint/typecheck lane were skipped by affected-scope CI.

## Risk

Low. The new helper preserves short and exact-length strings, retains each caller's existing ellipsis style, and changes only overlong output to honor the configured maximum. Specialized tail-preserving and explanatory-marker clamps remain unchanged.

Closes #294
