### PR TITLE
feat(ci): cask-only publish dispatch (no macOS rebuild)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -293,8 +293,21 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  # Runs after a macOS build, OR standalone from the existing release assets
+  # when dispatched with build_macos=false + update_homebrew=true — a cheap
+  # cask re-sync (recompute SHAs, bump the tap) with no 35-min rebuild. The
+  # `always()` guard lets the job proceed when build-desktop-macos is *skipped*
+  # (cask-only dispatch) while still blocking on a build that actually failed.
   update-homebrew-cask:
-    if: ${{ (github.event_name == 'release' && vars.HOMEBREW_PUBLISH_ENABLED == 'true') || (inputs.build_macos && inputs.update_homebrew) }}
+    if: >-
+      ${{ always()
+          && needs.validate-release.result == 'success'
+          && needs.build-desktop-macos.result != 'failure'
+          && needs.build-desktop-macos.result != 'cancelled'
+          && (
+            (github.event_name == 'release' && vars.HOMEBREW_PUBLISH_ENABLED == 'true')
+            || inputs.update_homebrew
+          ) }}
     needs:
       - validate-release
       - build-desktop-macos


### PR DESCRIPTION
Dispatching `publish.yml` with `build_macos=false` + `update_homebrew=true` now runs the Homebrew cask job standalone — recompute SHAs from the existing release DMGs and bump the tap in ~30s, instead of a 35-min rebuild (which also churns the DMG SHAs and transiently breaks the cask).

The cask job already downloads artifacts via `gh release download`, so it never depended on build outputs — only the `needs` skip propagation forced a rebuild. An `always()` guard lets it proceed when `build-desktop-macos` is *skipped* (cask-only), while still blocking on a real build failure/cancellation, with `validate-release` required.

Motivating case: cheaply verify the `TAP_GITHUB_TOKEN` org grant and re-sync the v0.2.0 cask.

🤖 Generated with [Claude Code](https://claude.com/claude-code)