### PR TITLE
ci: read-only TAP_GITHUB_TOKEN write-permission probe

### DIFF
--- a/.github/workflows/check-tap-token.yml
+++ b/.github/workflows/check-tap-token.yml
@@ -1,0 +1,35 @@
+name: Check Tap Token
+
+# Read-only diagnostic: reports whether TAP_GITHUB_TOKEN can WRITE to the
+# Homebrew tap, without mutating the tap or rebuilding anything. GitHub's REST
+# repo endpoint returns .permissions.push for the *authenticated* token, so this
+# is a definitive, side-effect-free test of the publish cask-push credential.
+on:
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report tap write permission
+        env:
+          GH_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
+        run: |
+          if [ -z "$GH_TOKEN" ]; then
+            echo "::error::TAP_GITHUB_TOKEN is empty/unset"; exit 1
+          fi
+          echo "Token identity:"
+          gh api user --jq '"  login: \(.login), type: \(.type)"' || echo "  (gh api user failed — token may be fine-grained; that's fine)"
+          echo "Permissions on shipshitdev/homebrew-tap:"
+          PERMS=$(gh api repos/shipshitdev/homebrew-tap --jq '.permissions' 2>&1) || {
+            echo "::error::cannot read repo with this token: $PERMS"; exit 1;
+          }
+          echo "  $PERMS"
+          PUSH=$(gh api repos/shipshitdev/homebrew-tap --jq '.permissions.push')
+          echo "push=$PUSH"
+          if [ "$PUSH" = "true" ]; then
+            echo "::notice::TAP_GITHUB_TOKEN CAN write to the tap — publish cask job will succeed."
+          else
+            echo "::error::TAP_GITHUB_TOKEN CANNOT write (push=$PUSH). Fix token resource-owner/scope."
+            exit 1
+          fi

--- a/.github/workflows/check-tap-token.yml
+++ b/.github/workflows/check-tap-token.yml
@@ -21,11 +21,13 @@ jobs:
           echo "Token identity:"
           gh api user --jq '"  login: \(.login), type: \(.type)"' || echo "  (gh api user failed — token may be fine-grained; that's fine)"
           echo "Permissions on shipshitdev/homebrew-tap:"
+          # Single request; parse .push from the response so set -e can't abort
+          # before the diagnostic and we don't hit the API twice.
           PERMS=$(gh api repos/shipshitdev/homebrew-tap --jq '.permissions' 2>&1) || {
             echo "::error::cannot read repo with this token: $PERMS"; exit 1;
           }
           echo "  $PERMS"
-          PUSH=$(gh api repos/shipshitdev/homebrew-tap --jq '.permissions.push')
+          PUSH=$(printf '%s' "$PERMS" | jq -r '.push // false')
           echo "push=$PUSH"
           if [ "$PUSH" = "true" ]; then
             echo "::notice::TAP_GITHUB_TOKEN CAN write to the tap — publish cask job will succeed."


### PR DESCRIPTION
Read-only diagnostic workflow. Dispatch it to see whether `TAP_GITHUB_TOKEN` can write to `shipshitdev/homebrew-tap` (`.permissions.push`) — no tap mutation, no rebuild, ~15s. Lets us verify the credential before a real publish, and re-verify on every rotation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a manually triggered validation workflow for the publishing access token.
  * Reports whether the configured token has the required repository permissions.
  * Provides clear success or failure feedback before publishing begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->