### PR TITLE
feat(web): /download smart-redirect to the latest release DMG

### DIFF
--- a/apps/web/app/components/CtaBanner.tsx
+++ b/apps/web/app/components/CtaBanner.tsx
@@ -10,9 +10,7 @@ export function CtaBanner() {
         </p>
         <div className="mt-8 flex flex-wrap items-center justify-center gap-4">
           <a
-            href="https://github.com/shipshitdev/shipcode/releases/latest"
-            target="_blank"
-            rel="noopener noreferrer"
+            href="/download"
             className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-[#09090b] shadow-[0_0_24px_rgba(255,255,255,0.08)] transition-transform duration-200 hover:scale-[1.03]"
           >
             Download for Mac

--- a/apps/web/app/components/Hero.tsx
+++ b/apps/web/app/components/Hero.tsx
@@ -28,12 +28,10 @@ export function Hero() {
         >
           <div className="flex flex-wrap items-center justify-center gap-4">
             <a
-              href="https://github.com/shipshitdev/shipcode/releases/latest"
-              target="_blank"
-              rel="noopener noreferrer"
+              href="/download"
               className="inline-flex items-center gap-2 rounded-full bg-white px-6 py-3 text-sm font-semibold text-[#09090b] shadow-[0_0_24px_rgba(255,255,255,0.08)] transition-transform duration-200 hover:scale-[1.03]"
             >
-              Download
+              Download for Mac
             </a>
             <a
               href="https://github.com/shipshitdev/shipcode"
@@ -45,12 +43,20 @@ export function Hero() {
               <span aria-hidden="true">↗</span>
             </a>
           </div>
-          <a
-            href="#pipeline"
-            className="text-sm text-muted transition-colors duration-200 hover:text-secondary"
-          >
-            See the pipeline <span aria-hidden="true">↓</span>
-          </a>
+          <div className="flex flex-col items-center gap-2">
+            <a
+              href="/download?arch=x64"
+              className="text-xs text-muted transition-colors duration-200 hover:text-secondary"
+            >
+              Intel Mac? Download the x64 build
+            </a>
+            <a
+              href="#pipeline"
+              className="text-sm text-muted transition-colors duration-200 hover:text-secondary"
+            >
+              See the pipeline <span aria-hidden="true">↓</span>
+            </a>
+          </div>
         </div>
 
         {/* Product screenshot */}

--- a/apps/web/app/download/route.test.ts
+++ b/apps/web/app/download/route.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { GET } from './route';
+
+const RELEASES_URL = 'https://github.com/shipshitdev/shipcode/releases';
+const DL_PREFIX = 'https://github.com/shipshitdev/shipcode/releases/download/v0.2.0';
+
+function req(opts: { url?: string; ua?: string; platform?: string } = {}): Request {
+  const headers = new Headers();
+  if (opts.ua) headers.set('user-agent', opts.ua);
+  if (opts.platform) headers.set('sec-ch-ua-platform', `"${opts.platform}"`);
+  return new Request(opts.url ?? 'https://shipcode.shipshit.dev/download', { headers });
+}
+
+function mockLatestRelease(assets: Array<{ name: string; browser_download_url: string }>) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async () => new Response(JSON.stringify({ assets }), { status: 200 })),
+  );
+}
+
+const BOTH_DMGS = [
+  { name: 'ShipCode-0.2.0-arm64.dmg', browser_download_url: `${DL_PREFIX}/ShipCode-0.2.0-arm64.dmg` },
+  { name: 'ShipCode-0.2.0-x64.dmg', browser_download_url: `${DL_PREFIX}/ShipCode-0.2.0-x64.dmg` },
+  { name: 'ShipCode-0.2.0-arm64.zip', browser_download_url: `${DL_PREFIX}/ShipCode-0.2.0-arm64.zip` },
+];
+
+const MAC_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120 Safari/537.36';
+const WIN_UA = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120 Safari/537.36';
+
+describe('GET /download', () => {
+  beforeEach(() => mockLatestRelease(BOTH_DMGS));
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('redirects non-Mac clients to the releases page (no API call needed)', async () => {
+    const res = await GET(req({ ua: WIN_UA }));
+    expect(res.status).toBe(307);
+    expect(res.headers.get('Location')).toBe(RELEASES_URL);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+
+  it('respects the Sec-CH-UA-Platform header over the UA for non-Mac', async () => {
+    const res = await GET(req({ ua: MAC_UA, platform: 'Windows' }));
+    expect(res.headers.get('Location')).toBe(RELEASES_URL);
+  });
+
+  it('serves the arm64 DMG by default for Mac', async () => {
+    const res = await GET(req({ ua: MAC_UA }));
+    expect(res.status).toBe(307);
+    expect(res.headers.get('Location')).toBe(`${DL_PREFIX}/ShipCode-0.2.0-arm64.dmg`);
+  });
+
+  it('serves the x64 DMG when ?arch=x64', async () => {
+    const res = await GET(req({ ua: MAC_UA, url: 'https://x/download?arch=x64' }));
+    expect(res.headers.get('Location')).toBe(`${DL_PREFIX}/ShipCode-0.2.0-x64.dmg`);
+  });
+
+  it('accepts the intel alias for x64', async () => {
+    const res = await GET(req({ ua: MAC_UA, url: 'https://x/download?arch=intel' }));
+    expect(res.headers.get('Location')).toBe(`${DL_PREFIX}/ShipCode-0.2.0-x64.dmg`);
+  });
+
+  it('treats an unknown platform as Mac (site ships a macOS app)', async () => {
+    const res = await GET(req({ ua: 'curl/8.0' }));
+    expect(res.headers.get('Location')).toBe(`${DL_PREFIX}/ShipCode-0.2.0-arm64.dmg`);
+  });
+
+  it('falls back to releases when the GitHub API errors', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => new Response('nope', { status: 502 })));
+    const res = await GET(req({ ua: MAC_UA }));
+    expect(res.headers.get('Location')).toBe(RELEASES_URL);
+  });
+
+  it('falls back to releases when no matching DMG asset exists', async () => {
+    mockLatestRelease([
+      { name: 'ShipCode-0.2.0-x64.dmg', browser_download_url: `${DL_PREFIX}/ShipCode-0.2.0-x64.dmg` },
+    ]);
+    const res = await GET(req({ ua: MAC_UA })); // wants arm64, only x64 present
+    expect(res.headers.get('Location')).toBe(RELEASES_URL);
+  });
+
+  it('rejects a download URL that is not a github releases asset', async () => {
+    mockLatestRelease([
+      { name: 'ShipCode-0.2.0-arm64.dmg', browser_download_url: 'https://evil.example/x.dmg' },
+    ]);
+    const res = await GET(req({ ua: MAC_UA }));
+    expect(res.headers.get('Location')).toBe(RELEASES_URL);
+  });
+
+  it('falls back to releases when fetch throws', async () => {
+    vi.stubGlobal('fetch', vi.fn(async () => {
+      throw new Error('network down');
+    }));
+    const res = await GET(req({ ua: MAC_UA }));
+    expect(res.headers.get('Location')).toBe(RELEASES_URL);
+  });
+
+  it('marks the redirect uncacheable and varies on platform', async () => {
+    const res = await GET(req({ ua: MAC_UA }));
+    expect(res.headers.get('Cache-Control')).toContain('no-store');
+    expect(res.headers.get('Vary')).toContain('Sec-CH-UA-Platform');
+  });
+});

--- a/apps/web/app/download/route.ts
+++ b/apps/web/app/download/route.ts
@@ -1,0 +1,99 @@
+// Smart download redirect: 307s to the correct macOS DMG of the LATEST GitHub
+// release, so the site's Download button always serves the current version with
+// no hardcoded version and no manual updates. Ported from the landings repo's
+// redirectToLatestRelease, extended for ShipCode's two-arch (arm64 + x64) DMGs.
+//
+// Runs per-request as a serverless function (reads headers, hits the GitHub
+// API), so it must never be statically optimized.
+export const dynamic = 'force-dynamic';
+
+const RELEASE_REPO = 'shipshitdev/shipcode';
+const RELEASES_URL = `https://github.com/${RELEASE_REPO}/releases`;
+
+const NON_MAC_PLATFORM = /Android|CrOS|iPad|iPhone|Linux|Windows/i;
+const MAC_PLATFORM = /Macintosh|Mac OS X/i;
+
+type GitHubRelease = {
+  assets?: Array<{ browser_download_url?: unknown; name?: unknown }>;
+};
+
+function isMacRequest(request: Request): boolean {
+  const clientPlatform = request.headers
+    .get('sec-ch-ua-platform')
+    ?.replaceAll('"', '')
+    .trim();
+
+  if (clientPlatform) {
+    return clientPlatform.toLowerCase() === 'macos';
+  }
+
+  const userAgent = request.headers.get('user-agent') ?? '';
+  if (MAC_PLATFORM.test(userAgent)) return true;
+  if (NON_MAC_PLATFORM.test(userAgent)) return false;
+
+  // Privacy browsers and CLI clients may omit platform data. The site ships a
+  // macOS app, so macOS is the safe default when the platform is unknown.
+  return true;
+}
+
+// Browsers can't reliably report Apple Silicon vs Intel (Safari sends no arch
+// hint; Chrome's Sec-CH-UA-Arch needs an opt-in handshake; Rosetta lies in the
+// UA). So default to arm64 — every Mac sold since 2020 — and let the explicit
+// `?arch=x64` (aliases: intel) link on the site cover Intel holdouts.
+function resolveArch(request: Request): 'arm64' | 'x64' {
+  const arch = new URL(request.url).searchParams.get('arch')?.toLowerCase();
+  if (arch === 'x64' || arch === 'intel' || arch === 'x86_64') return 'x64';
+  return 'arm64';
+}
+
+function redirect(location: string): Response {
+  return new Response(null, {
+    status: 307,
+    headers: {
+      'Cache-Control': 'private, no-store',
+      Location: location,
+      Vary: 'Sec-CH-UA-Platform, User-Agent',
+    },
+  });
+}
+
+export async function GET(request: Request): Promise<Response> {
+  if (!isMacRequest(request)) return redirect(RELEASES_URL);
+
+  const arch = resolveArch(request);
+
+  try {
+    const response = await fetch(
+      `https://api.github.com/repos/${RELEASE_REPO}/releases/latest`,
+      {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+        // Cache the release lookup for 15 min so a burst of downloads doesn't
+        // hammer (or get rate-limited by) the unauthenticated GitHub API.
+        next: { revalidate: 900 },
+      } as RequestInit & { next: { revalidate: number } },
+    );
+
+    if (!response.ok) return redirect(RELEASES_URL);
+
+    const release = (await response.json()) as GitHubRelease;
+    // Asset names look like ShipCode-<version>-<arch>.dmg — match on the arch
+    // suffix so the version is never hardcoded here.
+    const assetPattern = new RegExp(`-${arch}\\.dmg$`, 'i');
+    const asset = release.assets?.find(
+      ({ name }) => typeof name === 'string' && assetPattern.test(name),
+    );
+    const downloadUrl = asset?.browser_download_url;
+    const expectedPrefix = `https://github.com/${RELEASE_REPO}/releases/download/`;
+
+    if (typeof downloadUrl !== 'string' || !downloadUrl.startsWith(expectedPrefix)) {
+      return redirect(RELEASES_URL);
+    }
+
+    return redirect(downloadUrl);
+  } catch {
+    return redirect(RELEASES_URL);
+  }
+}

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,8 +1,10 @@
 import type { NextConfig } from 'next';
 
+// No `output: 'export'`: the site is a Next.js server build so app/download can
+// run as a serverless Function (reads request headers, hits the GitHub API,
+// 307s to the latest release DMG). Every other route stays statically prerendered.
 const config: NextConfig = {
   allowedDevOrigins: ['127.0.0.1'],
-  output: 'export',
 };
 
 export default config;

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -1,9 +1,9 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
+  "framework": "nextjs",
   "buildCommand": "cd ../.. && bun run sync:docs && bun run --filter @shipcode/web build",
   "git": {
     "deploymentEnabled": false
   },
-  "installCommand": "cd ../.. && bun install",
-  "outputDirectory": "out"
+  "installCommand": "cd ../.. && bun install"
 }


### PR DESCRIPTION
## What

The Download buttons pointed at the GitHub **releases page**, where the `.dmg` is buried among `.deb` / `.AppImage` / `.zip` / source. This adds a `/download` route handler that:

- **Platform-sniffs** (Sec-CH-UA-Platform, then UA) — non-Mac → releases page.
- Queries the GitHub API for the **latest** release and **307s straight to the correct macOS DMG**.
- **arm64 by default** (every Mac since 2020); an **"Intel Mac?"** link uses `?arch=x64`.
- **Version is never hardcoded** — the asset is matched by arch suffix, so it self-updates on every release.
- **Falls back to the releases page** on non-Mac, API error, missing asset, or a non-`releases/download/` URL (SSRF guard).

Ported from the landings repo's `redirectToLatestRelease`, extended for ShipCode's two-arch DMGs. `Hero` + `CtaBanner` now link to `/download`.

## Deploy change (validated by web-smoke at PR time)

Removed `output: 'export'` from `apps/web/next.config.ts` so `next build` produces a `.next/` server build and `app/download/route.ts` (`export const dynamic = 'force-dynamic'`) becomes a Vercel Function; **every other page stays statically prerendered**. `apps/web/vercel.json` drops the export-only `outputDirectory: "out"` and adds `"framework": "nextjs"`. `buildCommand`/`installCommand` are unchanged and run `next build` exactly once — `vercel build` treats the custom command as a full substitute, then translates `.next/` into Build Output API artifacts (`static/` + `functions/`). The `vercel pull → vercel build --prebuilt → vercel deploy` pipeline in `publish.yml` needs no changes.

**One optional hygiene step (not required for correctness):** in the Vercel dashboard (Project → Settings → Build & Deployment), clear any lingering "Output Directory: out" override from the export era — `vercel.json` wins regardless.

## Tests

`route.test.ts` covers: non-Mac → releases; header-over-UA; arm64 default; `?arch=x64` + `intel` alias; unknown platform → Mac; API !ok / missing asset / non-github URL / fetch throws → releases; no-store + Vary headers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated download route that detects macOS and directs visitors to the latest compatible Mac build.
  - Added support for Apple Silicon and Intel Mac downloads, including an explicit x64 option.
  - Added a “See the pipeline” link to the hero section.
  - Added fallback handling to the general releases page when a compatible download cannot be found.

- **Bug Fixes**
  - Updated download buttons to use the new in-site download flow instead of linking directly to external releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->