### PR TITLE
test(coverage): restore 95% statement floor after PRs #373-#383

### DIFF
--- a/apps/desktop/src/main/ipc/register-automation-handlers.test.ts
+++ b/apps/desktop/src/main/ipc/register-automation-handlers.test.ts
@@ -323,4 +323,42 @@ describe('registerAutomationHandlers', () => {
     expect(automations.setEnabled).not.toHaveBeenCalled();
     expect(automationScheduler.schedule).not.toHaveBeenCalled();
   });
+
+  it('rejects updates for automations that no longer exist', async () => {
+    automations.getById.mockReturnValue(null);
+
+    await expect(
+      getHandler('automations:update')(null, { id: 'missing', name: 'Renamed' }),
+    ).rejects.toThrow('Automation missing not found');
+    expect(automations.update).not.toHaveBeenCalled();
+    expect(automationScheduler.schedule).not.toHaveBeenCalled();
+  });
+
+  it('rejects enabling automations that no longer exist', async () => {
+    automations.getById.mockReturnValue(null);
+
+    await expect(
+      getHandler('automations:set-enabled')(null, { id: 'missing', enabled: true }),
+    ).rejects.toThrow('Automation missing not found');
+    expect(automations.setEnabled).not.toHaveBeenCalled();
+  });
+
+  it('rejects updates whose targets reference a missing project', async () => {
+    automations.getById.mockReturnValue(makeAutomation({ targets: ['project-gone'] }));
+    projects.getById.mockReturnValue(null);
+
+    await expect(
+      getHandler('automations:update')(null, { id: 'auto-1', name: 'Renamed' }),
+    ).rejects.toThrow('Automation target project project-gone not found');
+    expect(automations.update).not.toHaveBeenCalled();
+  });
+
+  it('rejects updates that select gh or shell as the automation executor', async () => {
+    automations.getById.mockReturnValue(makeAutomation());
+
+    await expect(
+      getHandler('automations:update')(null, { id: 'auto-1', executorProvider: 'gh' }),
+    ).rejects.toThrow('gh cannot be used as an automation executor');
+    expect(automations.update).not.toHaveBeenCalled();
+  });
 });

--- a/packages/agents/src/github/gh-cli.test.ts
+++ b/packages/agents/src/github/gh-cli.test.ts
@@ -175,6 +175,41 @@ describe('GhCli', () => {
         ghExecOptions,
       );
     });
+
+    it('dedupes duplicate/blank labels and skips removals absent from the issue', async () => {
+      // 1) listRepoLabels (filterExistingLabels), 2) getIssue, 3) add edit
+      success(JSON.stringify([{ name: 'agent:claude' }]));
+      success(
+        JSON.stringify({
+          number: 12,
+          title: 'Dedup',
+          labels: [{ name: 'stale' }],
+          assignees: [],
+          state: 'open',
+          url: '',
+        }),
+      );
+      success('');
+
+      const result = await gh.applyIssueLabelActions(12, {
+        // Duplicate + whitespace-only entries collapse to a single unique label.
+        addLabels: ['agent:claude', 'agent:claude', '   '],
+        // 'ghost' is not present on the issue, so the removal is a no-op.
+        removeLabels: ['ghost', 'ghost'],
+      });
+
+      expect(result).toEqual({ added: ['agent:claude'], removed: [], skipped: [] });
+      expect(mockExecFileAsync).toHaveBeenCalledWith(
+        'gh',
+        ['issue', 'edit', '12', '--add-label', 'agent:claude'],
+        ghExecOptions,
+      );
+      expect(mockExecFileAsync).not.toHaveBeenCalledWith(
+        'gh',
+        expect.arrayContaining(['--remove-label']),
+        ghExecOptions,
+      );
+    });
   });
 
   describe('listIssues', () => {

--- a/packages/db/src/queries/review-findings.test.ts
+++ b/packages/db/src/queries/review-findings.test.ts
@@ -6,6 +6,7 @@ import { ProjectQueries } from './projects';
 import { ReviewFindingQueries } from './review-findings';
 import { ReviewQueries } from './reviews';
 import { ThreadQueries } from './threads';
+import { VerificationQueries } from './verifications';
 
 describe('ReviewFindingQueries', () => {
   let db: DatabaseSync;
@@ -92,6 +93,45 @@ describe('ReviewFindingQueries', () => {
     expect(findings.getById(original.id)?.status).toBe('superseded');
     expect(replacement.status).toBe('open');
     expect(replacement.title).toBe('New');
+  });
+
+  it('replaces verification findings by superseding previous open rows for the plan', () => {
+    const original = findings.createOrUpdateOpen({
+      projectId,
+      threadId,
+      planId,
+      phase: 'verify',
+      source: 'verification',
+      severity: 'major',
+      title: 'Old',
+      description: 'Old verification finding',
+      fingerprint: 'same-verify',
+    });
+    const verificationId = new VerificationQueries(db).create(threadId, planId, 'raw', null).id;
+
+    const [replacement] = findings.replaceOpenForVerification({
+      threadId,
+      planId,
+      verificationId,
+      findings: [
+        {
+          projectId,
+          threadId,
+          planId,
+          phase: 'verify',
+          source: 'verification',
+          severity: 'minor',
+          title: 'New',
+          description: 'New verification finding',
+          fingerprint: 'same-verify',
+        },
+      ],
+    });
+
+    expect(findings.getById(original.id)?.status).toBe('superseded');
+    expect(replacement.status).toBe('open');
+    expect(replacement.title).toBe('New');
+    expect(replacement.verificationId).toBe(verificationId);
   });
 
   it('marks open findings fixed for a plan', () => {


### PR DESCRIPTION
## Why

The advisory **Coverage** job on `master` (`.github/workflows/ci.yml`, `COVERAGE_MIN=95`) started failing after ten PRs (#373–#383) merged on 2026-07-13:

- statements **94.99%** < 95.00% ❌ (~3 uncovered statements short)
- lines 95.85%, functions 95.41%, branches 90.70% — all pass ✅

The gap is a handful of newly-merged branches that shipped without tests exercising their error/edge paths.

## What

Test-only change (no source edits). Adds targeted unit tests for the previously-uncovered, newly-merged lines:

| File | Before | After | Covered branch |
|---|---|---|---|
| `packages/agents/src/github/gh-cli.ts` | miss 2 | **100%** | `applyIssueLabelActions`: `uniqueLabels` dedupe of duplicate/blank labels + skipping removals absent from the issue |
| `apps/desktop/src/main/ipc/register-automation-handlers.ts` | miss 4 | **100%** | reject missing automations on `update`/`set-enabled`, missing target project, and `gh`/`shell` executors |
| `packages/db/src/queries/review-findings.ts` | miss 4 | miss 1 | `replaceOpenForVerification` supersede-then-recreate path (mirrors the existing `replaceOpenForReview` test) |

Net **+9 covered statements** against the ~3-statement shortfall — clears the 95% floor with margin. Since no source lines were added, CI's covered count rises by 9 while the denominator is unchanged, so the aggregate lands at ≈95.02%.

Only remaining gap in the touched files is `review-findings.ts` `failLoad()`, a `never`-return guard that fires only on post-insert row-load failure (not cleanly reachable).

## Verification

- `bun run coverage` per affected package — all green:
  - `packages/db`: 533 tests pass; `review-findings.ts` 35→38/39 covered
  - `packages/agents`: 1098 tests pass; `gh-cli.ts` 100%
  - `apps/desktop`: 1537 tests pass; `register-automation-handlers.ts` 100%
- Local aggregate (same methodology): statements 95.02% → **95.04%**
- Biome check: clean

The advisory Coverage job on `master` will confirm the restored floor once this squash-merges.